### PR TITLE
build: generate k8s yaml files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,3 +1223,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yamlgen"
+version = "0.1.0"
+dependencies = [
+ "client",
+ "kube",
+ "serde_yaml",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
     "client",
+    "yamlgen",
 ]

--- a/yamlgen/Cargo.toml
+++ b/yamlgen/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "yamlgen"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[build-dependencies]
+client = { path = "../client" }
+kube = "0.58"
+serde_yaml = "0.8"

--- a/yamlgen/build.rs
+++ b/yamlgen/build.rs
@@ -1,0 +1,37 @@
+/*!
+
+The custom resource definitions are modeled as Rust structs in the client crate. Here we generate
+the corresponding k8s yaml files. These are needed when setting up a TestSys cluster. Crates that
+depend on these files can add yamlgen as a build dependency to ensure the files are current. Scripts
+can call `cargo build --package yamlgen`.
+
+!*/
+
+use client::model::{ResourceProvider, Test};
+use kube::CustomResourceExt;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+const YAMLGEN_DIR: &str = env!("CARGO_MANIFEST_DIR");
+const HEADER: &str = "# This file is generated. Do not edit.\n";
+
+fn main() {
+    // Re-run this build script if the model changes.
+    println!("cargo:rerun-if-changed=../model/src");
+
+    let path = PathBuf::from(YAMLGEN_DIR)
+        .join("deploy")
+        .join("testsys.yaml");
+
+    let mut f = File::create(&path).expect(&format!(
+        "unable to open file '{}' for writing",
+        path.display()
+    ));
+
+    f.write(HEADER.as_bytes())
+        .expect("unable to write file header");
+    serde_yaml::to_writer(&f, &Test::crd()).expect("unable to write Test CRD");
+    serde_yaml::to_writer(&f, &ResourceProvider::crd())
+        .expect("unable to write ResourceProvider CRD");
+}

--- a/yamlgen/deploy/testsys.yaml
+++ b/yamlgen/deploy/testsys.yaml
@@ -1,0 +1,142 @@
+# This file is generated. Do not edit.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: tests.testsys.bottlerocket.aws
+spec:
+  group: testsys.bottlerocket.aws
+  names:
+    kind: Test
+    plural: tests
+    singular: test
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Auto-generated derived type for TestSpec via `CustomResource`"
+          properties:
+            spec:
+              description: "A TestSys Test. The `CustomResource` derive also produces a struct named `Test` which represents a test CRD object in the k8s API."
+              properties:
+                configuration:
+                  additionalProperties: true
+                  description: "The configuration to pass to the test pod. This is 'open' to allow tests to define their own schemas."
+                  nullable: true
+                  type: object
+                image:
+                  description: The URI of the test agent container image.
+                  type: string
+              required:
+                - image
+              type: object
+            status:
+              description: The status field of the TestSys Test CRD. This is where the controller and agents will write information about the status of the test run.
+              nullable: true
+              properties:
+                agent:
+                  description: Information written by the test agent.
+                  properties:
+                    results:
+                      nullable: true
+                      properties:
+                        whatever:
+                          type: string
+                      required:
+                        - whatever
+                      type: object
+                    run_state:
+                      anyOf:
+                        - enum:
+                            - Unknown
+                            - Running
+                            - Done
+                          type: string
+                        - additionalProperties: false
+                          properties:
+                            Error:
+                              type: string
+                          required:
+                            - Error
+                          type: object
+                  required:
+                    - run_state
+                  type: object
+                controller:
+                  description: Information written by the controller.
+                  properties:
+                    whatever:
+                      type: string
+                  required:
+                    - whatever
+                  type: object
+                resources:
+                  additionalProperties:
+                    properties:
+                      whatever:
+                        type: string
+                    required:
+                      - whatever
+                    type: object
+                  description: Information written by the resource agents.
+                  type: object
+              required:
+                - agent
+                - controller
+                - resources
+              type: object
+          required:
+            - spec
+          title: Test
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: resource-providers.testsys.bottlerocket.aws
+spec:
+  group: testsys.bottlerocket.aws
+  names:
+    kind: ResourceProvider
+    plural: resource-providers
+    shortNames:
+      - rp
+    singular: resource-provider
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Auto-generated derived type for ResourceProviderSpec via `CustomResource`"
+          properties:
+            spec:
+              description: "An object representing a container that can be run to create and destroy resources. The `CustomResource` derive also produces a struct named `ResourceProvider` which represents a resource provider object in the k8s API."
+              properties:
+                configuration:
+                  additionalProperties: true
+                  description: "The configuration to send to the resource pod. This is 'open' to allow resource providers to define their own schemas."
+                  nullable: true
+                  type: object
+                image:
+                  description: The URI of the resource agent container image.
+                  type: string
+              required:
+                - image
+              type: object
+            status:
+              description: The status field of the ResourceProvider CRD.
+              nullable: true
+              type: object
+          required:
+            - spec
+          title: ResourceProvider
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/yamlgen/src/lib.rs
+++ b/yamlgen/src/lib.rs
@@ -1,0 +1,5 @@
+/*!
+
+Intentionally empty. See build.rs.
+
+!*/


### PR DESCRIPTION

**Issue number:**

Closes #5

**Description of changes:**

The yamlgen crate produces an empty library, but its build.rs script generates the Kubernetes YAML files for the Test and ResourceProvider CRDs.

**Testing done:**

`kubectl apply -f testsys.yaml`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
