### PR TITLE
test-agent: create traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "async-trait"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +145,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dtoa"
@@ -960,6 +977,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
+name = "snafu"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1039,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-agent"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "client",
+ "log",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,11 +1089,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
+ "bytes",
  "libc",
  "mio",
  "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
+ "tokio-macros",
  "winapi",
 ]
 
@@ -1054,6 +1107,17 @@ checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
 dependencies = [
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
     "client",
+    "test-agent",
     "yamlgen",
 ]

--- a/client/src/model/mod.rs
+++ b/client/src/model/mod.rs
@@ -7,5 +7,28 @@ pub use test::{
     TestStatus,
 };
 
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::fmt::Debug;
+
 pub const TESTSYS_NAMESPACE: &str = "testsys-bottlerocket-aws";
 pub const TESTSYS_API: &str = "testsys.bottlerocket.aws/v1";
+
+/// The `Configuration` trait is for structs that can be used for custom data, which is represented
+/// in a CRD model like this:
+///
+/// ```yaml
+/// configuration:
+///   additionalProperties: true
+///   nullable: true
+///   type: object
+/// ```
+///
+/// The traits aggregated by the `Configuration` trait are typical of "plain old data" types and
+/// provide a way for clients to strongly type this data which is otherwise unconstrained by the
+/// API.
+///
+pub trait Configuration:
+    Serialize + DeserializeOwned + Clone + Debug + Default + Send + Sync + Sized + 'static
+{
+}

--- a/test-agent/Cargo.toml
+++ b/test-agent/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "test-agent"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+async-trait = "0.1"
+client = { path = "../client" }
+log = "0.4"
+serde = { version = "1", features = [ "derive" ] }
+serde_json = "1"
+snafu = "0.6"
+tokio = { version = "1", default-features = false, features = [ "time" ] }
+
+[dev-dependencies]
+tokio = { version = "1", default-features = false, features = [ "macros", "process" ] }

--- a/test-agent/src/agent.rs
+++ b/test-agent/src/agent.rs
@@ -1,0 +1,165 @@
+use crate::constants::{SPAWN_TIMEOUT, STATUS_CHECK_WAIT, STATUS_TIMEOUT, TERMINATE_TIMEOUT};
+use crate::error::{self, Error, InnerError, Result};
+use crate::{Bootstrap, Client, Runner, RunnerStatus};
+use log::{debug, error};
+use snafu::ResultExt;
+use std::future::Future;
+use std::time::Duration;
+use tokio::time::sleep;
+use tokio::time::timeout as tokio_timeout;
+
+/// The `TestAgent` is the main entrypoint for the program running in a TestPod. It starts a test
+/// run, regularly checks the health of the test run, observes cancellation of a test run, and sends
+/// the results of a test run.
+///
+/// To create a test, implement the [`Runner`] trait on an object and inject it into the
+/// `TestAgent`.
+///
+/// Two additional dependencies are injected for the sake of testability. You can mock these traits
+/// in order to test your [`Runner`] in the absence of k8s.
+/// - [`Bootstrap`] collects information from the container environment.
+/// - [`Client`] communicates with the k8s server.
+///
+// TODO - link to example https://github.com/bottlerocket-os/bottlerocket-test-system/issues/8
+// TODO - for now see mock https://github.com/bottlerocket-os/bottlerocket-test-system/pull/63
+pub struct TestAgent<C, R>
+where
+    C: Client + 'static,
+    R: Runner + 'static,
+{
+    client: C,
+    runner: R,
+}
+
+impl<C, R> TestAgent<C, R>
+where
+    C: Client + 'static,
+    R: Runner + 'static,
+{
+    /// Create a new `TestAgent`. Since the [`Client`] and [`Runner`] are constructed internally
+    /// based on information from the [`Bootstrap`], you will need to specify the types using the
+    /// type parameters. `TestAgent::<DefaultClient, MyRunner>::new(DefaultBootstrap::new())`. Any
+    /// errors that occur during this function are fatal since we are not able to fully construct
+    /// the `Runner`.
+    pub async fn new<B>(bootstrap: B) -> Result<Self, C::E, R::E>
+    where
+        B: Bootstrap,
+    {
+        let bootstrap_data = bootstrap.read().await.map_err(|e| InnerError::Bootstrap {
+            error: e.to_string(),
+        })?;
+        let client = C::new(bootstrap_data).await.map_err(|e| Error::Client(e))?;
+        let test_info = client.get_test_info().await.map_err(|e| Error::Client(e))?;
+        let runner = R::new(test_info).await.map_err(|e| Error::Runner(e))?;
+        Ok(Self { runner, client })
+    }
+
+    /// Run the `TestAgent`. This function returns once the test has completed or been cancelled.
+    pub async fn run(&mut self) -> Result<(), C::E, R::E> {
+        // Run the spawn function. If an error occurs, attempt to allow the runner to terminate and
+        // attempt to send the error to k8s. Return the original spawn error.
+        debug!("spawning test");
+        let spawn_fut = self.runner.spawn();
+        let spawn_result = Self::wait(SPAWN_TIMEOUT, spawn_fut, "spawn").await;
+        if let Err(spawn_err) = spawn_result {
+            self.send_error_best_effort(&spawn_err).await;
+            self.terminate_best_effort().await;
+            return Err(spawn_err);
+        }
+
+        // Loop until the test is done or an error occurs.
+        if let Err(e) = self.run_status_loop().await {
+            error!("error during test run: {}", e);
+            self.send_error_best_effort(&e).await;
+            self.terminate_best_effort().await;
+            return Err(e);
+        }
+
+        // Test finished successfully. Try to terminate. If termination fails, we try to send the
+        // error to k8s, and return the error so that the process will exit with error.
+        let terminate_fut = Self::wait(TERMINATE_TIMEOUT, self.runner.terminate(), "terminate");
+        if let Err(e) = terminate_fut.await {
+            error!("unable to terminate test runner: {}", e);
+            self.send_error_best_effort(&e).await;
+            return Err(e);
+        }
+
+        Ok(())
+    }
+
+    /// Loops checking status and returning when the status is either `Done` or an error occurs.
+    /// This function updates k8s with the runner's status and test results.
+    async fn run_status_loop(&mut self) -> Result<(), C::E, R::E> {
+        loop {
+            // Pause before the first, and each subsequent status check.
+            sleep(STATUS_CHECK_WAIT).await;
+
+            // A failed status check is fatal to the test run.
+            // TODO - consider allowing multiple status check failures before returning an error
+            let status = self.check_status().await?;
+
+            // If sending status or test results to k8s fails it is fatal to the test.
+            self.client
+                .send_status(status.clone())
+                .await
+                .map_err(|e| Error::Client(e))?;
+
+            // If status is Done, or if we have been canceled, we can stop looping and return.
+            if matches!(status, RunnerStatus::Done(_)) {
+                break;
+            } else {
+                // Failure to check our cancellation status is not fatal, so we log any error.
+                match self.client.is_cancelled().await {
+                    Err(e) => {
+                        error!("unable to check cancellation status: {}", e);
+                        // We do not know if we are cancelled, continue looping.
+                    }
+                    Ok(cancelled) if cancelled => {
+                        // The test run has been cancelled, stop looping.
+                        break;
+                    }
+                    _ => { /* continue looping */ }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Checks the status with a timeout.
+    async fn check_status(&mut self) -> Result<RunnerStatus, C::E, R::E> {
+        let status_fut = self.runner.status();
+        Self::wait(STATUS_TIMEOUT, status_fut, "status").await
+    }
+
+    async fn wait<F, T>(timeout: Duration, future: F, op: &str) -> Result<T, C::E, R::E>
+    where
+        F: Future<Output = std::result::Result<T, R::E>>,
+    {
+        tokio_timeout(timeout, future)
+            .await
+            .context(error::Timeout {
+                duration: timeout,
+                op,
+            })?
+            .map_err(|e| Error::Runner(e))
+    }
+
+    /// Returns `true` if the error was successfully sent, `false` if the error could not be sent.
+    async fn send_error_best_effort(&mut self, e: &Error<C::E, R::E>) {
+        if let Err(send_error) = self.client.send_error(e).await {
+            error!(
+                "unable to send error message '{}' to k8s: {}",
+                e, send_error
+            );
+        }
+    }
+
+    /// Tells the `Runner` to terminate. If an error occurs, tries to send it to k8s, but logs it
+    /// if it cannot be sent to k8s.
+    async fn terminate_best_effort(&mut self) {
+        let terminate_fut = Self::wait(TERMINATE_TIMEOUT, self.runner.terminate(), "terminate");
+        if let Err(e) = terminate_fut.await {
+            self.send_error_best_effort(&e).await;
+        }
+    }
+}

--- a/test-agent/src/constants.rs
+++ b/test-agent/src/constants.rs
@@ -1,0 +1,6 @@
+use std::time::Duration;
+
+pub(crate) const SPAWN_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const STATUS_CHECK_WAIT: Duration = Duration::from_secs(2);
+pub(crate) const STATUS_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const TERMINATE_TIMEOUT: Duration = Duration::from_secs(30);

--- a/test-agent/src/error.rs
+++ b/test-agent/src/error.rs
@@ -1,0 +1,73 @@
+use snafu::Snafu;
+use std::fmt::{Debug, Display, Formatter};
+use std::time::Duration;
+
+/// The `Error` type for the `TestAgent`. Errors originating from the `Client` or the `Runner` are
+/// passed through, preserving their type. Errors originating with the `Agent` are of the
+/// [`AgentError`] type.
+#[derive(Debug)]
+pub enum Error<C, R>
+where
+    C: Debug + Display + Send + Sync + 'static,
+    R: Debug + Display + Send + Sync + 'static,
+{
+    /// An error originating from the [`Agent`].
+    Agent(AgentError),
+    /// An error originating from the [`Client`].
+    Client(C),
+    /// An error originating from the [`Runner`].
+    Runner(R),
+}
+
+/// The `Result` type for the `TestAgent`.
+pub type Result<T, C, R> = std::result::Result<T, Error<C, R>>;
+
+impl<C, R> std::error::Error for Error<C, R>
+where
+    C: Debug + Display + Send + Sync + 'static,
+    R: Debug + Display + Send + Sync + 'static,
+{
+}
+
+impl<C, R> Display for Error<C, R>
+where
+    C: Debug + Display + Send + Sync + 'static,
+    R: Debug + Display + Send + Sync + 'static,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Agent(e) => write!(f, "agent error: {}", e),
+            Error::Client(e) => write!(f, "client error: {}", e),
+            Error::Runner(e) => write!(f, "agent error: {}", e),
+        }
+    }
+}
+
+/// An error that has originated with the [`Agent`].
+#[derive(Debug, Snafu)]
+pub struct AgentError(InnerError);
+
+/// The private error type, [`AgentError'] is opaque. `InnerError` is the underlying error type.
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub(crate)")]
+pub(crate) enum InnerError {
+    #[snafu(display("Bootstrap error: {}", error))]
+    Bootstrap { error: String },
+
+    #[snafu(display("Timeout waiting more than {:?} for {}: {}", duration, op, source))]
+    Timeout {
+        duration: Duration,
+        op: String,
+        source: tokio::time::error::Elapsed,
+    },
+}
+
+impl<C, R> From<InnerError> for Error<C, R>
+where
+    C: Debug + Display + Send + Sync + 'static,
+    R: Debug + Display + Send + Sync + 'static,
+{
+    fn from(e: InnerError) -> Self {
+        Error::Agent(e.into())
+    }
+}

--- a/test-agent/src/lib.rs
+++ b/test-agent/src/lib.rs
@@ -1,0 +1,124 @@
+mod agent;
+pub(crate) mod constants;
+pub mod error;
+
+pub use agent::TestAgent;
+use async_trait::async_trait;
+pub use client::model::{Configuration, TestResults};
+use std::fmt::{Debug, Display};
+
+/// The status of the test `Runner`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RunnerStatus {
+    /// The test process has not encountered any fatal errors and is proceeding.
+    Running,
+    /// The test process has concluded (irrespective of tests passing or failing).
+    Done(TestResults),
+}
+
+/// Information that a test [`Runner`] needs before it can begin a test.
+#[derive(Debug, Clone)]
+pub struct TestInfo<C: Configuration> {
+    pub name: String,
+    pub configuration: C,
+}
+
+/// The `Runner` trait provides a wrapper for any testing modality. You must implement this trait
+/// for your unique testing situation.
+///
+/// The [`TestAgent`] will call your implementation of the `Runner` trait as follows:
+/// - `new` will be called to instantiate the object.
+/// - `spawn` will be called to begin the test process. You will run your test process in a separate
+///   thread/process and return from `spawn` once the test has been kicked off.
+/// - `status` will be repeatedly called after spawn until either an `Error` or `Done` is received.
+/// - `terminate` will be called before the program exits.
+///
+/// You will also define a [`Configuration`] type to define data that your test needs when it
+/// starts. This requires serialization and other common traits, but otherwise can be whatever
+/// you want it to be. The serialized form of this struct is provided to k8s when an instance of the
+/// TestSys Test CRD is created.
+///
+#[async_trait]
+pub trait Runner: Sized {
+    /// Input that you need to initialize your test run.
+    type C: Configuration;
+
+    /// The error type returned by this trait's functions.
+    type E: Debug + Display + Send + Sync + 'static;
+
+    /// Creates a new instance of the `Runner`.
+    async fn new(test_info: TestInfo<Self::C>) -> Result<Self, Self::E>;
+
+    /// Starts the testing process. The testing process should run in a separate thread or child
+    /// process and `spawn` should return as soon as that process is running successfully. `spawn`
+    /// has a timeout (see [`SPAWN_TIMEOUT`]).
+    async fn spawn(&mut self) -> Result<(), Self::E>;
+
+    /// Checks and returns the status of the test. If possible, `status` should check that the
+    /// testing process has not failed and is still on track to finish successfully, in which case
+    /// `status` should return [`Status::Running`]. If the testing process has completed (regardless
+    /// of whether tests have passed or failed), `status` should return [`Status::Done`]. If the
+    /// test process has encountered an error and cannot continue, `status` should return an error.
+    /// `status` has a timeout (see [`STATUS_TIMEOUT`].
+    async fn status(&mut self) -> Result<RunnerStatus, Self::E>;
+
+    /// Cleans up prior to program exit. `terminate` can be called either because the testing has
+    /// completed successfully, or because the test run has been cancelled. `terminate` has a
+    /// timeout (see [`TERMINATE_TIMEOUT`]).
+    async fn terminate(&mut self) -> Result<(), Self::E>;
+}
+
+/// The `Client` is an interface to the k8s TestSys Test CRD API. The purpose of the interface is to
+/// allow injection of a mock for development and testing of test agents without the presence of a
+/// k8s cluster. In practice you will use the provided implementation by calling
+/// `DefaultClient::new()`.
+#[async_trait]
+pub trait Client: Sized {
+    /// The error type returned by this trait's functions.
+    type E: Debug + Display + Send + Sync + 'static;
+
+    /// Create a new instance of the `Client`. The [`TestAgent`] will instantiate the `Client` with
+    /// this function after it obtains `BootstrapData`.
+    async fn new(bootstrap_data: BootstrapData) -> Result<Self, Self::E>;
+
+    /// Get the information needed by a test [`Runner`] from the k8s API.
+    async fn get_test_info<C>(&self) -> Result<TestInfo<C>, Self::E>
+    where
+        C: Configuration;
+
+    /// Send the test [`Runner`]'s status to the k8s API.
+    async fn send_status(&self, status: RunnerStatus) -> Result<(), Self::E>;
+
+    /// Check the k8s API to find out if this test run is cancelled.
+    async fn is_cancelled(&self) -> Result<bool, Self::E>;
+
+    /// Send an error to the k8s API.
+    async fn send_error<E>(&self, error: E) -> Result<(), Self::E>
+    where
+        E: Debug + Display + Send + Sync;
+}
+
+// TODO - implement the default client
+pub struct DefaultClient;
+
+/// The `Bootstrap` trait provides the information needed by the test agent before a k8s client can
+/// be instantiated. For example, if some data such as the test name is provided by way of the k8s
+/// downward API or ConfigMaps, the `Bootstrap` trait will provide that  information. It is offered
+/// as a trait to enable testing of a [`Runner`] outside of a k8s pod. In practice you will use the
+/// provided implementation by calling `DefaultBootstrap::new()`.
+#[async_trait]
+pub trait Bootstrap: Sized {
+    type E: Debug + Display + Send + Sync + 'static;
+
+    /// Reads data from the container's environment, filesystem, etc. and provides that information.
+    async fn read(&self) -> Result<BootstrapData, Self::E>;
+}
+
+/// Data that is read from the TestPod's container environment and filesystem.
+pub struct BootstrapData {
+    /// The name of the TestSys Test.
+    pub test_name: String,
+}
+
+// TODO - implement the default bootstrap
+pub struct DefaultBootstrap;


### PR DESCRIPTION
Create traits for the test_agent library.

**Issue number:**

#7

**Description of changes:**

Defines the traits that will be used when building a test agent.
- Runner: this is the core trait that needs to be implemented in order to run a test.
- Client: Abstracts over k8s communication so that implementers can mock out k8s.
- Bootstrap: Abstracts over the details of the container environment so that implementers can run their code outside of the k8s pod.

The most vexing aspect of Rust interface design seems to be error types. I believe the solution I have here is viable. It allows the implementor to use their own error type for the Runner and a mock error type with mocking the Bootstrap or the Client.

**Testing done:**

I have implemented the traits and used them in a basic proof-of-concept mock.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
