### PR TITLE
test-agent: implement traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cfg-if"
@@ -653,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dea6388d3d5498ec651701f14edbaf463c924b5d8829fb2848ccf0bcc7b3c69"
+checksum = "039f02eb0f69271f26abe3202189275d7aa2258b903cb0281b5de710a2570ff3"
 dependencies = [
  "num-traits",
 ]

--- a/test-agent/src/k8s_bootstrap.rs
+++ b/test-agent/src/k8s_bootstrap.rs
@@ -1,0 +1,24 @@
+use crate::{Bootstrap, BootstrapData, DefaultBootstrap};
+use async_trait::async_trait;
+use snafu::Snafu;
+use std::fmt::Debug;
+
+/// The public error type for the default [`Bootstrap`].
+#[derive(Debug, Snafu)]
+pub struct BootstrapError(InnerError);
+
+/// The private error type for the default [`Bootstrap`].
+#[derive(Debug, Snafu)]
+pub(crate) enum InnerError {}
+
+#[async_trait]
+impl Bootstrap for DefaultBootstrap {
+    type E = BootstrapError;
+
+    async fn read(&self) -> Result<BootstrapData, Self::E> {
+        Ok(BootstrapData {
+            // TODO - read from the container environment or filesystem
+            test_name: "hello-world".to_string(),
+        })
+    }
+}

--- a/test-agent/src/k8s_client.rs
+++ b/test-agent/src/k8s_client.rs
@@ -1,0 +1,101 @@
+use async_trait::async_trait;
+use client::model::{Configuration, RunState};
+use client::TestClient;
+use serde_json::Value;
+use snafu::{ResultExt, Snafu};
+use std::fmt::{Debug, Display};
+
+use crate::{BootstrapData, Client, DefaultClient, RunnerStatus, TestInfo};
+
+/// The public error type for the default [`Client`].
+#[derive(Debug, Snafu)]
+pub struct ClientError(InnerError);
+
+/// The private error type for the default [`Client`].
+#[derive(Debug, Snafu)]
+pub(crate) enum InnerError {
+    /// Any error when using the k8s client will have a descriptive error message. The user of
+    /// `DefaultClient` is in a better position to provide context than we are, so we forward the
+    /// error message.
+    #[snafu(display("{}", source))]
+    K8s { source: client::Error },
+
+    #[snafu(display("Unable to deserialize test configuration: {}", source))]
+    Deserialization { source: serde_json::Error },
+}
+
+#[async_trait]
+impl Client for DefaultClient {
+    type E = ClientError;
+
+    async fn new(bootstrap_data: BootstrapData) -> Result<Self, Self::E> {
+        Ok(Self {
+            client: TestClient::new().await.context(K8s)?,
+            name: bootstrap_data.test_name,
+        })
+    }
+
+    async fn get_test_info<C>(&self) -> Result<TestInfo<C>, Self::E>
+    where
+        C: Configuration,
+    {
+        let test_data = self.client.get_test(&self.name).await.context(K8s)?;
+
+        let configuration: C = match test_data.spec.configuration {
+            Some(serde_map) => {
+                serde_json::from_value(Value::Object(serde_map)).context(Deserialization)?
+            }
+            None => Default::default(),
+        };
+
+        Ok(TestInfo {
+            name: self.name.clone(),
+            configuration,
+        })
+    }
+
+    async fn send_status(&self, status: RunnerStatus) -> Result<(), Self::E> {
+        let mut agent_status = self
+            .client
+            .get_agent_status(&self.name)
+            .await
+            .context(K8s)?;
+        let (run_state, test_results) = match status {
+            RunnerStatus::Running => (RunState::Running, None),
+            RunnerStatus::Done(test_results) => (RunState::Done, Some(test_results)),
+        };
+        agent_status.run_state = run_state;
+        agent_status.results = test_results;
+        let _ = self
+            .client
+            .set_agent_status(&self.name, agent_status)
+            .await
+            .context(K8s)?;
+        Ok(())
+    }
+
+    async fn is_cancelled(&self) -> Result<bool, Self::E> {
+        let _test_data = self.client.get_test(&self.name).await.context(K8s)?;
+        // TODO - check whether we are cancelled in a field of the test CRD
+        Ok(false)
+    }
+
+    async fn send_error<E>(&self, error: E) -> Result<(), Self::E>
+    where
+        E: Debug + Display + Send + Sync,
+    {
+        let mut agent_status = self
+            .client
+            .get_agent_status(&self.name)
+            .await
+            .context(K8s)?;
+        agent_status.run_state = RunState::Error;
+        agent_status.error_message = Some(error.to_string());
+        let _ = self
+            .client
+            .set_agent_status(&self.name, agent_status)
+            .await
+            .context(K8s)?;
+        Ok(())
+    }
+}

--- a/test-agent/src/lib.rs
+++ b/test-agent/src/lib.rs
@@ -1,10 +1,15 @@
 mod agent;
 pub(crate) mod constants;
 pub mod error;
+mod k8s_bootstrap;
+mod k8s_client;
 
 pub use agent::TestAgent;
 use async_trait::async_trait;
 pub use client::model::{Configuration, TestResults};
+use client::TestClient;
+pub use k8s_bootstrap::BootstrapError;
+pub use k8s_client::ClientError;
 use std::fmt::{Debug, Display};
 
 /// The status of the test `Runner`.
@@ -98,8 +103,11 @@ pub trait Client: Sized {
         E: Debug + Display + Send + Sync;
 }
 
-// TODO - implement the default client
-pub struct DefaultClient;
+/// Provides the default [`Client`] implementation.
+pub struct DefaultClient {
+    client: TestClient,
+    name: String,
+}
 
 /// The `Bootstrap` trait provides the information needed by the test agent before a k8s client can
 /// be instantiated. For example, if some data such as the test name is provided by way of the k8s
@@ -120,5 +128,5 @@ pub struct BootstrapData {
     pub test_name: String,
 }
 
-// TODO - implement the default bootstrap
+/// Provides the default [`Bootstrap`] implementation.
 pub struct DefaultBootstrap;

--- a/test-agent/tests/mock.rs
+++ b/test-agent/tests/mock.rs
@@ -150,7 +150,7 @@ impl Bootstrap for MockBootstrap {
 
     async fn read(&self) -> Result<BootstrapData, Self::E> {
         Ok(BootstrapData {
-            test_name: "mock_test".to_string(),
+            test_name: "hello-world".to_string(),
         })
     }
 }


### PR DESCRIPTION
**Issue number:**

Closes #7

**Description of changes:**

Provides the default implementations of the Client and Bootstrap traits.

**Testing done:**

I manually created an instance of a Test CRD and ran a throw-away integration test. I observed that the status.agent field of the Test CRD instance was being updated.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
