### PR TITLE
model: fix validity issues

### DIFF
--- a/client/src/model/test.rs
+++ b/client/src/model/test.rs
@@ -32,11 +32,11 @@ pub struct TestSpec {
 #[derive(Serialize, Deserialize, Debug, Default, Eq, PartialEq, Clone, JsonSchema)]
 pub struct TestStatus {
     /// Information written by the controller.
-    pub controller: ControllerStatus,
+    pub controller: Option<ControllerStatus>,
     /// Information written by the test agent.
-    pub agent: AgentStatus,
+    pub agent: Option<AgentStatus>,
     /// Information written by the resource agents.
-    pub resources: HashMap<String, ResourceStatus>,
+    pub resources: Option<HashMap<String, ResourceStatus>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, JsonSchema)]
@@ -44,7 +44,7 @@ pub enum RunState {
     Unknown,
     Running,
     Done,
-    Error(String),
+    Error,
 }
 
 impl Default for RunState {
@@ -62,6 +62,11 @@ pub struct TestResults {
 #[derive(Serialize, Deserialize, Debug, Default, Eq, PartialEq, Clone, JsonSchema)]
 pub struct AgentStatus {
     pub run_state: RunState,
+    /// Due to structural OpenAPI constraints, the error message must be provided separately instead
+    /// of as a value within the `RunState::Error` variant. If the `run_state` is `Error` then there
+    /// *may* be an error message here. If there is an error message here and the `run_state` is
+    /// *not* `Error`, the this is a bad state and the `error_message` should be ignored.
+    pub error_message: Option<String>,
     pub results: Option<TestResults>,
 }
 

--- a/yamlgen/deploy/testsys.yaml
+++ b/yamlgen/deploy/testsys.yaml
@@ -37,7 +37,12 @@ spec:
               properties:
                 agent:
                   description: Information written by the test agent.
+                  nullable: true
                   properties:
+                    error_message:
+                      description: "Due to structural OpenAPI constraints, the error message must be provided separately instead of as a value within the `RunState::Error` variant. If the `run_state` is `Error` then there *may* be an error message here. If there is an error message here and the `run_state` is *not* `Error`, the this is a bad state and the `error_message` should be ignored."
+                      nullable: true
+                      type: string
                     results:
                       nullable: true
                       properties:
@@ -47,24 +52,18 @@ spec:
                         - whatever
                       type: object
                     run_state:
-                      anyOf:
-                        - enum:
-                            - Unknown
-                            - Running
-                            - Done
-                          type: string
-                        - additionalProperties: false
-                          properties:
-                            Error:
-                              type: string
-                          required:
-                            - Error
-                          type: object
+                      enum:
+                        - Unknown
+                        - Running
+                        - Done
+                        - Error
+                      type: string
                   required:
                     - run_state
                   type: object
                 controller:
                   description: Information written by the controller.
+                  nullable: true
                   properties:
                     whatever:
                       type: string
@@ -80,11 +79,8 @@ spec:
                       - whatever
                     type: object
                   description: Information written by the resource agents.
+                  nullable: true
                   type: object
-              required:
-                - agent
-                - controller
-                - resources
               type: object
           required:
             - spec


### PR DESCRIPTION

**Issue number:**

Correction to #4

**Description of changes:**

Constraints on the way that OpenAPI is used with Kubernetes CRD objects
prohibits algebraic enum variants. To fix this and make the CRD valid
we needed to move the error message to its own field.

Additionally, when a CRD object has no status, and we attempt to patch
just one field in the status, then it is necessary for the other fields
in the status to be optional.

**Testing done:**

Applied the model to Kubernetes and it was valid. Previously it was not.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
