### PR TITLE
model: fix testsys namespace

### DIFF
--- a/client/src/model/mod.rs
+++ b/client/src/model/mod.rs
@@ -7,5 +7,5 @@ pub use test::{
     TestStatus,
 };
 
-pub const TESTSYS_NAMESPACE: &str = "testsys.bottlerocket.aws";
+pub const TESTSYS_NAMESPACE: &str = "testsys-bottlerocket-aws";
 pub const TESTSYS_API: &str = "testsys.bottlerocket.aws/v1";


### PR DESCRIPTION

**Issue number:**

N/A

**Description of changes:**

The namespace did not match the validity regex for namespaces. Oops. Now
it does.

**Testing done:**

The namespace could not be applied when it used dots as separators, but using dashes k8s accepted it.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
