### PR TITLE
client: fix status patch method

### DIFF
--- a/client/src/test_client.rs
+++ b/client/src/test_client.rs
@@ -193,10 +193,13 @@ impl TestClient {
     where
         S: AsRef<str>,
     {
-        let ps = PatchParams::apply("TestClient").force();
         Ok(self
             .api
-            .patch_status(test_name.as_ref(), &ps, &Patch::Apply(json))
+            .patch_status(
+                test_name.as_ref(),
+                &PatchParams::default(),
+                &Patch::Merge(json),
+            )
             .await
             .context(KubeApiCall {
                 method: "patch",


### PR DESCRIPTION

**Issue number:**

Fixup of #6

**Description of changes:**

Patching status with the Apply did not behave correctly. Patching
status.agent would overwrite status.controller will null. This is the
correct patching method and behaves as desired.

**Testing done:**

Didn't work right before in my controller test work, this fixes it.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
