### PR TITLE
client: organize constants

### DIFF
--- a/client/src/model/constants.rs
+++ b/client/src/model/constants.rs
@@ -1,0 +1,23 @@
+/// Helper macro to avoid retyping the base domain-like name of our system when creating further
+/// string constants from it. When given no parameters, this returns the base domain-like name of
+/// the system. When given a string literal parameter it adds `/parameter` to the end.
+macro_rules! testsys {
+    () => {
+        "testsys.bottlerocket.aws"
+    };
+    ($s:literal) => {
+        concat!(testsys!(), "/", $s)
+    };
+}
+
+// System identifiers
+pub const API_VERSION: &str = testsys!("v1");
+pub const NAMESPACE: &str = "testsys-bottlerocket-aws";
+pub const TESTSYS: &str = testsys!();
+
+#[test]
+fn testsys_constants_macro_test() {
+    assert_eq!("testsys.bottlerocket.aws", testsys!());
+    assert_eq!("testsys.bottlerocket.aws/v1", API_VERSION);
+    assert_eq!("testsys.bottlerocket.aws/foo", testsys!("foo"));
+}

--- a/client/src/model/mod.rs
+++ b/client/src/model/mod.rs
@@ -1,6 +1,8 @@
+mod constants;
 mod resource_provider;
 mod test;
 
+pub use constants::{API_VERSION, NAMESPACE, TESTSYS};
 pub use resource_provider::{ResourceProvider, ResourceProviderSpec, ResourceProviderStatus};
 pub use test::{
     AgentStatus, ControllerStatus, Lifecycle, ResourceStatus, RunState, Test, TestResults,
@@ -10,10 +12,6 @@ pub use test::{
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::fmt::Debug;
-
-pub const TESTSYS: &str = "testsys.bottlerocket.aws";
-pub const TESTSYS_API: &str = "testsys.bottlerocket.aws/v1";
-pub const TESTSYS_NAMESPACE: &str = "testsys-bottlerocket-aws";
 
 /// The `Configuration` trait is for structs that can be used for custom data, which is represented
 /// in a CRD model like this:

--- a/client/src/test_client.rs
+++ b/client/src/test_client.rs
@@ -1,4 +1,4 @@
-use crate::model::{AgentStatus, ControllerStatus, Test, TESTSYS, TESTSYS_API, TESTSYS_NAMESPACE};
+use crate::model::{AgentStatus, ControllerStatus, Test, API_VERSION, NAMESPACE, TESTSYS};
 use kube::api::{Patch, PatchParams};
 use kube::{Api, Resource};
 use log::trace;
@@ -54,7 +54,7 @@ impl TestClient {
     /// Create a new [`TestClient`] from an existing k8s client.
     pub fn new_from_k8s_client(k8s_client: kube::Client) -> Self {
         Self {
-            api: Api::<Test>::namespaced(k8s_client, TESTSYS_NAMESPACE),
+            api: Api::<Test>::namespaced(k8s_client, NAMESPACE),
         }
     }
 
@@ -165,7 +165,7 @@ impl TestClient {
         T: Serialize,
     {
         json!({
-            "apiVersion": TESTSYS_API,
+            "apiVersion": API_VERSION,
             "kind": "Test",
             top_key.as_ref(): {
                 sub_key.as_ref(): value


### PR DESCRIPTION

**Issue number:**

Pulling something small from my work on #14 so that won't be a huge code bomb.

**Description of changes:**

Move constants to their own file and use macros to avoid repeating the
string testsys.bottlerocket.aws many times.

Basically we will be making labels that look like `testsys.bottlerocket.aws/labelname` and we will have quite a few other constants.

I also did away with the `TESTSYS_` prefix on a couple of symbols to reduce verbosity.

**Testing done:**

It works I promise.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
