### PR TITLE
controller: run a test pod

### DIFF
--- a/agent/test-agent/src/k8s_client.rs
+++ b/agent/test-agent/src/k8s_client.rs
@@ -41,7 +41,7 @@ impl Client for DefaultClient {
     {
         let test_data = self.client.get_test(&self.name).await.context(K8s)?;
 
-        let configuration: C = match test_data.spec.configuration {
+        let configuration: C = match test_data.spec.agent.configuration {
             Some(serde_map) => {
                 serde_json::from_value(Value::Object(serde_map)).context(Deserialization)?
             }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -7,5 +7,4 @@ This library provides the Kubernetes custom resource definitions and their API c
 pub mod model;
 mod test_client;
 
-pub use test_client::Error;
-pub use test_client::TestClient;
+pub use test_client::{Error, TestClient};

--- a/client/src/model/constants.rs
+++ b/client/src/model/constants.rs
@@ -15,6 +15,15 @@ pub const API_VERSION: &str = testsys!("v1");
 pub const NAMESPACE: &str = "testsys-bottlerocket-aws";
 pub const TESTSYS: &str = testsys!();
 
+// Component names
+pub const CONTROLLER: &str = "testsys-controller";
+pub const TEST_AGENT: &str = "testsys-test-agent";
+pub const TEST_AGENT_SERVICE_ACCOUNT: &str = "testsys-test-agent-account";
+
+// Label keys
+pub const LABEL_TEST_NAME: &str = testsys!("test-name");
+pub const LABEL_TEST_UID: &str = testsys!("test-uid");
+
 // Environment variables
 pub const ENV_TEST_NAME: &str = "TESTSYS_TEST_NAME";
 

--- a/client/src/model/mod.rs
+++ b/client/src/model/mod.rs
@@ -2,10 +2,13 @@ mod constants;
 mod resource_provider;
 mod test;
 
-pub use constants::{API_VERSION, ENV_TEST_NAME, NAMESPACE, TESTSYS};
+pub use constants::{
+    API_VERSION, CONTROLLER, ENV_TEST_NAME, LABEL_TEST_NAME, LABEL_TEST_UID, NAMESPACE, TESTSYS,
+    TEST_AGENT, TEST_AGENT_SERVICE_ACCOUNT,
+};
 pub use resource_provider::{ResourceProvider, ResourceProviderSpec, ResourceProviderStatus};
 pub use test::{
-    AgentStatus, ControllerStatus, Lifecycle, ResourceStatus, RunState, Test, TestResults,
+    Agent, AgentStatus, ControllerStatus, Lifecycle, ResourceStatus, RunState, Test, TestResults,
     TestSpec, TestStatus,
 };
 

--- a/controller/src/action.rs
+++ b/controller/src/action.rs
@@ -13,6 +13,12 @@ pub(crate) enum Action {
     CreateTestPod,
     /// If a `Test` pod has been started, we need to check its status.
     CheckTestPod,
+    /// The test pod needs to be deleted.
+    DeleteTestPod,
+    /// The test pod is in the process of deletion, check if it has finished deleting.
+    CheckTestPodDeletion,
+    /// The test pod has been deleted, remove the pod finalizer.
+    RemovePodFinalizer,
     /// When a `Test` has been marked for deletion, we need to clean up and remove finalizers.
     Delete,
     /// There is nothing to do.
@@ -22,7 +28,7 @@ pub(crate) enum Action {
 /// Inspect the `test` to determine which `Action` the controller should take.
 pub(crate) fn determine_action(test: &TestInterface) -> Result<Action> {
     if test.is_delete_requested() {
-        return Ok(Action::Delete);
+        return Ok(determine_delete_action(test));
     }
     let lifecycle = test.controller_status().lifecycle;
     match lifecycle {
@@ -34,9 +40,40 @@ pub(crate) fn determine_action(test: &TestInterface) -> Result<Action> {
                 Ok(Action::AddMainFinalizer)
             }
         }
-        Lifecycle::TestPodCreated | Lifecycle::TestPodHealthy => Ok(Action::CheckTestPod),
+        Lifecycle::TestPodCreated | Lifecycle::TestPodStarting | Lifecycle::TestPodHealthy => {
+            Ok(Action::CheckTestPod)
+        }
+        Lifecycle::TestPodDeleting => Ok(Action::CheckTestPodDeletion),
+        Lifecycle::TestPodDeleted => Ok(Action::RemovePodFinalizer),
         // TODO - these are placeholders. see issues #14, #44, #47, etc
-        Lifecycle::TestPodDone => Ok(Action::NoOp),
-        Lifecycle::TestPodExited => Ok(Action::NoOp),
+        Lifecycle::TestPodDone
+        | Lifecycle::TestPodExited
+        | Lifecycle::TestPodFailed
+        | Lifecycle::TestPodError => Ok(Action::NoOp),
     }
+}
+
+/// Determines what we should do next if the TestSys `Test` CRD has been marked for deletion.
+/// If we were already deleting the test pod then we need to wait for that complete. Otherwise,
+/// we need to initiate the deletion of the test pod.
+///
+/// # Preconditions
+///
+/// This function assumes that the test has been marked for deletion. This is checked in debug
+/// builds but not in release builds.
+///
+pub(crate) fn determine_delete_action(test: &TestInterface) -> Action {
+    debug_assert!(test.is_delete_requested());
+    if test.has_pod_finalizer() {
+        match &test.controller_status().lifecycle {
+            // If we are already deleting the test pod, then continue through that deletion process.
+            Lifecycle::TestPodDeleting => return Action::CheckTestPodDeletion,
+            Lifecycle::TestPodDeleted => return Action::RemovePodFinalizer,
+            // If we have a pod finalizer and deletion is not already underway, we need to delete
+            // the test pod.
+            _ => return Action::DeleteTestPod,
+        };
+    }
+    // There is no pod finalizer so we are ready to delete the TestSys `Test` CRD.
+    Action::Delete
 }

--- a/controller/src/error.rs
+++ b/controller/src/error.rs
@@ -24,6 +24,18 @@ pub(crate) enum Error {
     DanglingFinalizers { test_name: String },
 
     #[snafu(display(
+        "Kubernetes client error trying to {} for test '{}': {}",
+        action,
+        test_name,
+        source
+    ))]
+    KubeClient {
+        test_name: String,
+        action: String,
+        source: kube::Error,
+    },
+
+    #[snafu(display(
         "Test '{}' is in a bad state, it should not be created with finalizers.",
         test_name
     ))]
@@ -46,4 +58,24 @@ pub(crate) enum Error {
         test_name: String,
         source: client::Error,
     },
+
+    #[snafu(display(
+        "There should be only one k8s job but found {} running, {} succeeded, and {} failed for test '{}'",
+        running,
+        succeeded,
+        failed,
+        test_name
+    ))]
+    TooManyJobContainers {
+        test_name: String,
+        running: i32,
+        succeeded: i32,
+        failed: i32,
+    },
+
+    #[snafu(display(
+        "The controller tried to delete test '{}' before cleaning up finalizers.",
+        test_name
+    ))]
+    UnsafeDelete { test_name: String },
 }

--- a/controller/src/test_pod.rs
+++ b/controller/src/test_pod.rs
@@ -1,38 +1,327 @@
 use crate::context::TestInterface;
-use crate::error::Result;
+use crate::error::{self, Result};
 use crate::reconcile::REQUEUE;
-use client::model::Lifecycle;
+use client::model::{
+    Lifecycle, RunState, CONTROLLER, ENV_TEST_NAME, LABEL_TEST_NAME, LABEL_TEST_UID, NAMESPACE,
+    TESTSYS, TEST_AGENT, TEST_AGENT_SERVICE_ACCOUNT,
+};
+use k8s_openapi::api::batch::v1::{Job, JobSpec};
+use k8s_openapi::api::core::v1::{
+    Container, EnvVar, LocalObjectReference, PodSpec, PodTemplateSpec,
+};
+use kube::api::{DeleteParams, ListParams, ObjectMeta, PostParams, PropagationPolicy};
 use kube_runtime::controller::ReconcilerAction;
-use log::{debug, trace};
+use log::{debug, error, trace};
+use snafu::{ensure, ResultExt};
+use std::collections::BTreeMap;
 
+/// Runs a k8s `Job` to run our test pod. Adds the pod finalizer to ensure we don't forget to clean
+/// up the `Job` later.
+///
+/// # Preconditions
+///
+/// Assumes that the pod finalizer is not present. If it is, A duplicate finalizer error will occur.
+///
 pub(crate) async fn create_test_pod(test: &mut TestInterface) -> Result<ReconcilerAction> {
     debug!("Creating test pod for '{}'", test.name());
-    // TODO - create pod https://github.com/bottlerocket-os/bottlerocket-test-system/issues/14
     test.add_pod_finalizer().await?;
+    if let Err(create_job_error) = create_job(test).await {
+        if let Err(remove_finalizer_error) = test.remove_pod_finalizer().await {
+            error!(
+                "Unable to remove pod finalizer after inability to create test pod for test '{}': {}",
+                test.name(),
+                remove_finalizer_error
+            );
+        }
+        return Err(create_job_error);
+    }
     let mut status = test.controller_status().into_owned();
     status.lifecycle = Lifecycle::TestPodCreated;
     test.set_controller_status(status).await?;
     Ok(REQUEUE)
 }
 
-pub(crate) async fn delete_test_pod(test: &mut TestInterface) -> Result<()> {
+/// Deletes the k8s `Job` if the pod finalizer is present. See `delete_job` for more.
+pub(crate) async fn delete_test_pod(test: &mut TestInterface) -> Result<ReconcilerAction> {
     if !test.has_pod_finalizer() {
-        return Ok(());
+        return Ok(REQUEUE);
     }
     debug!("Deleting test pod for '{}'", test.name());
-    // TODO - delete pod https://github.com/bottlerocket-os/bottlerocket-test-system/issues/14
-    test.remove_pod_finalizer().await?;
-    Ok(())
+    delete_job(test).await?;
+    Ok(REQUEUE)
 }
 
+/// Checks the status of the test pod's `Job`. Updates the TestSys `Test`'s `Lifecycle` state
+/// accordingly.
+///
+/// # Preconditions
+///
+/// Assumes the k8s `Job` is present. Will error otherwise due to k8s returning 'not found'.
+///
 pub(crate) async fn check_test_pod(test: &mut TestInterface) -> Result<ReconcilerAction> {
     trace!("Checking test pod for '{}'", test.name());
-    let status = test.controller_status();
-    if matches!(status.lifecycle, Lifecycle::TestPodCreated) {
-        // TODO - actually check the status of the test pod
-        let mut status = status.into_owned();
-        status.lifecycle = Lifecycle::TestPodHealthy;
+    let mut status = test.controller_status().into_owned();
+    // TODO - enforce a timeout/deadline for pods that never start
+    // https://github.com/bottlerocket-os/bottlerocket-test-system/issues/76
+    let job_api = test.job_api();
+    let job = job_api.get(test.name()).await.context(error::KubeClient {
+        action: "get job",
+        test_name: test.name(),
+    })?;
+
+    let job_state = JobState::from_job(&job)?;
+
+    match job_state {
+        JobState::Unknown => {
+            trace!(
+                "Job for test '{}' is created but pod not found yet.",
+                test.name()
+            );
+            status.lifecycle = Lifecycle::TestPodStarting;
+        }
+        JobState::Running => {
+            trace!(
+                "Pod for test '{}' is created and has not completed.",
+                test.name()
+            );
+            match test.agent_status().run_state {
+                RunState::Running => status.lifecycle = Lifecycle::TestPodHealthy,
+                RunState::Done => status.lifecycle = Lifecycle::TestPodDone,
+                RunState::Error => status.lifecycle = Lifecycle::TestPodError,
+                RunState::Unknown => { /* Waiting for agent to start. No status change. */ }
+            }
+        }
+        JobState::Failed => {
+            trace!("Pod for test '{}' failed.", test.name());
+            status.lifecycle = Lifecycle::TestPodFailed;
+            // TODO - find out why and add an error message to the test
+        }
+        JobState::Succeeded => {
+            trace!("Pod for test '{}' exited zero.", test.name());
+            status.lifecycle = Lifecycle::TestPodExited;
+        }
+    }
+    test.set_controller_status(status).await?;
+    Ok(REQUEUE)
+}
+
+/// Get the TestSys `Test`'s k8s `Job` if present. Returns `None` if the `Job` does not exist.
+pub(crate) async fn get_job(test: &mut TestInterface) -> Result<Option<Job>> {
+    let job_api = test.job_api();
+    let jobs = job_api
+        .list(&ListParams::default().fields(&format!("metadata.name={}", test.name())))
+        .await
+        .context(error::KubeClient {
+            action: "list jobs",
+            test_name: test.name(),
+        })?;
+    Ok(jobs.items.into_iter().next())
+}
+
+/// Checks whether the TestSys `Test`'s k8s `Job` exists. If not, the test's `Lifecycle` state is
+/// set to 'deleted'.
+///
+/// # Preconditions
+///
+/// Assumes that deletion of the `Job` has been started but not finished. In other words, assumes
+/// that the pod finalizer is present and that it is appropriate to update the `Lifecycle` to
+/// `TestPodDeleted`.
+///
+pub(crate) async fn check_test_pod_deletion(test: &mut TestInterface) -> Result<ReconcilerAction> {
+    if get_job(test).await?.is_some() {
+        // The job is not deleted yet, no status change.
+        trace!("Test pod is being deleted for test '{}'.", test.name());
+    } else {
+        // The job does not exist, it must be deleted.
+        trace!("Test pod deleted for test '{}'.", test.name());
+        let mut status = test.controller_status().into_owned();
+        status.lifecycle = Lifecycle::TestPodDeleted;
         test.set_controller_status(status).await?;
     }
     Ok(REQUEUE)
+}
+
+// =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
+// private
+
+/// We run the test pod using a k8s `Job`. Jobs can run many containers and provide counts of how
+/// many containers are running or have completed (succeeded or failed). We are only running one
+/// container, so it is helpful to transform those counts into a simple enumeration of our job's
+/// state.
+enum JobState {
+    Unknown,
+    Running,
+    Failed,
+    Succeeded,
+}
+
+impl JobState {
+    /// Transform the container counts in `job.status` to a `JobState`
+    fn from_job(job: &Job) -> Result<Self> {
+        // Return early if `job.status` is somehow `None`.
+        let status = match &job.status {
+            None => {
+                return Ok(Self::Unknown);
+            }
+            Some(some) => some,
+        };
+
+        // Unwrap the container counts defaulting to zero if they are missing.
+        let running = status.active.unwrap_or(0);
+        let succeeded = status.succeeded.unwrap_or(0);
+        let failed = status.failed.unwrap_or(0);
+
+        // Return early if there are no containers counted. It probably means the container hasn't
+        // started yet.
+        if running + succeeded + failed == 0 {
+            return Ok(Self::Unknown);
+        }
+
+        // There should be exactly one container.
+        ensure!(
+            running + succeeded + failed == 1,
+            error::TooManyJobContainers {
+                test_name: job
+                    .metadata
+                    .name
+                    .as_ref()
+                    .map_or("name unknown", |name| name.as_str()),
+                running,
+                succeeded,
+                failed
+            }
+        );
+
+        if running == 1 {
+            Ok(Self::Running)
+        } else if succeeded == 1 {
+            Ok(Self::Succeeded)
+        } else {
+            Ok(Self::Failed)
+        }
+    }
+}
+
+/// Creates a k8s job to run the test pod.
+async fn create_job(test: &TestInterface) -> Result<Job> {
+    let labels = create_labels(test);
+
+    // Definition of the test pod's job.
+    let job = Job {
+        metadata: ObjectMeta {
+            name: Some(test.name().to_owned()),
+            namespace: Some(NAMESPACE.to_owned()),
+            labels: Some(labels.clone()),
+            ..ObjectMeta::default()
+        },
+        spec: Some(JobSpec {
+            backoff_limit: Some(0),
+            template: PodTemplateSpec {
+                spec: Some(PodSpec {
+                    containers: vec![Container {
+                        name: test.name().to_owned(),
+                        image: Some(test.agent().image.to_owned()),
+                        env: Some(vec![EnvVar {
+                            name: ENV_TEST_NAME.to_string(),
+                            value: Some(test.name().to_owned()),
+                            ..EnvVar::default()
+                        }]),
+                        ..Container::default()
+                    }],
+                    restart_policy: Some(String::from("Never")),
+                    image_pull_secrets: Some(vec![LocalObjectReference {
+                        name: test.agent().pull_secret.to_owned(),
+                    }]),
+                    service_account: Some(TEST_AGENT_SERVICE_ACCOUNT.to_owned()),
+                    ..PodSpec::default()
+                }),
+                metadata: Some(ObjectMeta {
+                    labels: Some(labels),
+                    ..ObjectMeta::default()
+                }),
+                ..PodTemplateSpec::default()
+            },
+            ..JobSpec::default()
+        }),
+        ..Job::default()
+    };
+
+    // Deploy the test pod in a job.
+    Ok(test
+        .job_api()
+        .create(&PostParams::default(), &job)
+        .await
+        .context(error::KubeClient {
+            test_name: test.name(),
+            action: "create job",
+        })?)
+}
+
+/// Deletes a k8s `Job`. Updates the TestSys `Test`'s `Lifecycle` state to either 'deleting' or
+/// 'deleted' depending on what k8s returns.
+///
+/// # Preconditions
+///
+/// The `Job` should exist otherwise k8s will return a 'not found' error.
+///
+async fn delete_job(test: &mut TestInterface) -> Result<()> {
+    let api = test.job_api();
+    let delete_return = api
+        .delete(
+            test.name(),
+            &DeleteParams {
+                propagation_policy: Some(PropagationPolicy::Foreground),
+                ..DeleteParams::default()
+            },
+        )
+        .await
+        .context(error::KubeClient {
+            test_name: test.name(),
+            action: "delete job",
+        })?;
+
+    let mut status = test.controller_status().into_owned();
+
+    // The delete function returns an `Either` enum where `Left` means deleting has started and
+    // `Right` means the item has been fully deleted. Also, I can't seem to import the `Either` enum
+    // getting "expected enum `either::Either`, found enum `Either`" which means I cannot write a
+    // match statement.
+    status.lifecycle = if delete_return.is_left() {
+        Lifecycle::TestPodDeleting
+    } else {
+        trace!("Test pod deleted for test '{}'", test.name());
+        Lifecycle::TestPodDeleted
+    };
+    test.set_controller_status(status).await
+}
+
+// Standard tags https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+const APP_NAME: &str = "app.kubernetes.io/name";
+const APP_INSTANCE: &str = "app.kubernetes.io/instance";
+const APP_COMPONENT: &str = "app.kubernetes.io/component";
+const APP_PART_OF: &str = "app.kubernetes.io/part-of";
+const APP_MANAGED_BY: &str = "app.kubernetes.io/managed-by";
+const APP_CREATED_BY: &str = "app.kubernetes.io/created-by";
+
+/// Creates the labels that we will add to the test pod deployment.
+fn create_labels(test: &TestInterface) -> BTreeMap<String, String> {
+    let mut labels = BTreeMap::new();
+    insert(&mut labels, APP_NAME, test.agent().name.to_owned());
+    insert(&mut labels, APP_INSTANCE, test.name());
+    insert(&mut labels, APP_COMPONENT, TEST_AGENT);
+    insert(&mut labels, APP_PART_OF, TESTSYS);
+    insert(&mut labels, APP_MANAGED_BY, CONTROLLER);
+    insert(&mut labels, APP_CREATED_BY, CONTROLLER);
+    insert(&mut labels, LABEL_TEST_NAME, test.name());
+    insert(&mut labels, LABEL_TEST_UID, test.id());
+    labels
+}
+
+/// Convenience function so we don't have to call `to_owned` all over the place.
+fn insert<S1, S2>(map: &mut BTreeMap<String, String>, k: S1, v: S2) -> Option<String>
+where
+    S1: Into<String>,
+    S2: Into<String>,
+{
+    map.insert(k.into(), v.into())
 }

--- a/yamlgen/deploy/testsys.yaml
+++ b/yamlgen/deploy/testsys.yaml
@@ -23,16 +23,30 @@ spec:
             spec:
               description: "A TestSys Test. The `CustomResource` derive also produces a struct named `Test` which represents a test CRD object in the k8s API."
               properties:
-                configuration:
-                  additionalProperties: true
-                  description: "The configuration to pass to the test pod. This is 'open' to allow tests to define their own schemas."
-                  nullable: true
+                agent:
+                  description: Information about the test agent.
+                  properties:
+                    configuration:
+                      additionalProperties: true
+                      description: "The configuration to pass to the test pod. This is 'open' to allow tests to define their own schemas."
+                      nullable: true
+                      type: object
+                    image:
+                      description: The URI of the test agent container image.
+                      type: string
+                    name:
+                      description: The name of the test agent.
+                      type: string
+                    pull_secret:
+                      description: The name of an image registry pull secret if one is needed to pull the test agent image.
+                      nullable: true
+                      type: string
+                  required:
+                    - image
+                    - name
                   type: object
-                image:
-                  description: The URI of the test agent container image.
-                  type: string
               required:
-                - image
+                - agent
               type: object
             status:
               description: The status field of the TestSys Test CRD. This is where the controller and agents will write information about the status of the test run.
@@ -69,13 +83,19 @@ spec:
                   nullable: true
                   properties:
                     lifecycle:
+                      description: "What phase of the TestSys `Test` lifecycle are we in."
                       enum:
                         - New
                         - Acknowledged
                         - TestPodCreated
+                        - TestPodStarting
                         - TestPodHealthy
                         - TestPodDone
+                        - TestPodError
+                        - TestPodFailed
                         - TestPodExited
+                        - TestPodDeleting
+                        - TestPodDeleted
                       type: string
                   required:
                     - lifecycle


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #14

**Description of changes:**

This PR adds the 'happy path' whereby the controller runs a test pod.

I've noticed that there are an infinite number of ways that things can go wrong and have added a tracking issue error handling issues here #78.

**Testing done:**

I created a kind cluster and added testsys.yaml to it and created a test object like this:

```yaml
apiVersion: testsys.bottlerocket.aws/v1
kind: Test
metadata:
  name: hello-bones
  namespace: testsys-bottlerocket-aws
spec:
  agent:
    name: hello-agent
    image: "554409873180.dkr.ecr.us-west-2.amazonaws.com/hello-agent:9"
    pull_secret: regcred
    configuration:
      mode: Fast
      person: Bones the Cat
      hello_count: 10
      hello_duration_seconds: 3
```

I published the example_test_agent to ECR and added creds to be able to pull it in the cluster.

I added this RBAC stuff to the cluster, but this isn't part of the PR because there is more work to be done around controller deployment:

```yaml
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: testsys-test-agent-account
  namespace: testsys-bottlerocket-aws
  annotations:
    kubernetes.io/service-account.name: testsys-test-agent-account
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: testsys-agent-role
rules:
  - apiGroups: ["testsys.bottlerocket.aws"]
    resources: ["tests", "tests/status"]
    verbs:
      - get
      - list
      - patch
      - update
      - watch
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: testsys-agent-role-binding
subjects:
  - kind: ServiceAccount
    name: testsys-test-agent-account
    namespace: testsys-bottlerocket-aws
roleRef:
  kind: ClusterRole
  name: testsys-agent-role
  apiGroup: rbac.authorization.k8s.io
```

- I ran the controller locally with a kubeconfig.
- I observed that the test pod ran and successfully printed `Hello Bones the Cat`. This indicates that the `Bootstrap` change worked and the test pod was able to get info from k8s.
- When the test pod finished, I ran `kubectl delete test hello-bones`
- I observed traces in the controller logs and everything seems to work correctly for the happy path case.

Controller trace logs:

```text
[2021-08-17T22:15:37Z INFO  controller] Starting
[2021-08-17T22:15:37Z TRACE controller::context] Adding main finalizer for test 'hello-bones'
[2021-08-17T22:15:38Z TRACE controller::context] Added finalizer 'owned' to test 'hello-bones': owned.finalizers.testsys.bottlerocket.aws
[2021-08-17T22:15:38Z DEBUG controller::test_pod] Creating test pod for 'hello-bones'
[2021-08-17T22:15:38Z TRACE controller::context] Adding pod finalizer for test 'hello-bones'
[2021-08-17T22:15:38Z TRACE controller::context] Added finalizer 'test-pod' to test 'hello-bones': owned.finalizers.testsys.bottlerocket.aws, test-pod.finalizers.testsys.bottlerocket.aws
[2021-08-17T22:15:38Z TRACE controller::test_pod] Checking test pod for 'hello-bones'
[2021-08-17T22:15:38Z TRACE controller::test_pod] Job for test 'hello-bones' is created but pod not found yet.

[ ... repeats ... ]

[2021-08-17T22:15:43Z TRACE controller::test_pod] Checking test pod for 'hello-bones'
[2021-08-17T22:15:43Z TRACE controller::test_pod] Pod for test 'hello-bones' is created and has not completed.

[ ... repeats ... ]

[2021-08-17T22:17:38Z TRACE controller::reconcile] Reconciling test: hello-bones
[2021-08-17T22:17:43Z TRACE controller::reconcile] Reconciling test: hello-bones

[ ... repeats (test is done, these are no-ops) ... ]

[2021-08-17T22:17:49Z TRACE controller::reconcile] Reconciling test: hello-bones
[2021-08-17T22:17:54Z TRACE controller::reconcile] Reconciling test: hello-bones
[2021-08-17T22:17:59Z TRACE controller::reconcile] Reconciling test: hello-bones
[2021-08-17T22:18:01Z TRACE controller::reconcile] Reconciling test: hello-bones

[... ran kubectl delete test command ...]

[2021-08-17T22:18:01Z DEBUG controller::test_pod] Deleting test pod for 'hello-bones'
[2021-08-17T22:18:01Z TRACE controller::test_pod] Job 'hello-bones' is still deleting.
[2021-08-17T22:18:06Z TRACE controller::test_pod] Job 'hello-bones' has been deleted.
[2021-08-17T22:18:06Z TRACE controller::context] Removing pod finalizer for test 'hello-bones'
[2021-08-17T22:18:06Z TRACE controller::context] Removed finalizer 'test-pod' from test 'hello-bones': owned.finalizers.testsys.bottlerocket.aws
[2021-08-17T22:18:06Z TRACE controller::context] Removing main finalizer for test 'hello-bones'
[2021-08-17T22:18:06Z TRACE controller::context] Removed finalizer 'owned' from test 'hello-bones': 
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
