### PR TITLE
test_agent: use env variable in bootstrap

### DIFF
--- a/client/src/model/constants.rs
+++ b/client/src/model/constants.rs
@@ -15,6 +15,9 @@ pub const API_VERSION: &str = testsys!("v1");
 pub const NAMESPACE: &str = "testsys-bottlerocket-aws";
 pub const TESTSYS: &str = testsys!();
 
+// Environment variables
+pub const ENV_TEST_NAME: &str = "TESTSYS_TEST_NAME";
+
 #[test]
 fn testsys_constants_macro_test() {
     assert_eq!("testsys.bottlerocket.aws", testsys!());

--- a/client/src/model/mod.rs
+++ b/client/src/model/mod.rs
@@ -2,7 +2,7 @@ mod constants;
 mod resource_provider;
 mod test;
 
-pub use constants::{API_VERSION, NAMESPACE, TESTSYS};
+pub use constants::{API_VERSION, ENV_TEST_NAME, NAMESPACE, TESTSYS};
 pub use resource_provider::{ResourceProvider, ResourceProviderSpec, ResourceProviderStatus};
 pub use test::{
     AgentStatus, ControllerStatus, Lifecycle, ResourceStatus, RunState, Test, TestResults,


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

This is needed by #75 #14

**Description of changes:**

I believe environment variables will be the simplest way for the controller to pass arguments to the test pod. So...

Instead of hard coding the test name, we take it from an environment
variable. This environment variable key is given by a constant that we
have added to the client library.

**Testing done:**

This is working in my controller integ test described in #75

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
