### PR TITLE
controller: sort error variants

### DIFF
--- a/controller/src/error.rs
+++ b/controller/src/error.rs
@@ -18,18 +18,6 @@ pub(crate) enum Error {
     },
 
     #[snafu(display(
-        "Unable to remove finalizer '{}' for test '{}': {}",
-        finalizer,
-        test_name,
-        source
-    ))]
-    RemoveFinalizer {
-        test_name: String,
-        finalizer: String,
-        source: client::Error,
-    },
-
-    #[snafu(display(
         "Unable to remove all finalizers for test '{}', zombie cannot be deleted.",
         test_name
     ))]
@@ -40,6 +28,18 @@ pub(crate) enum Error {
         test_name
     ))]
     NewTestWithFinalizers { test_name: String },
+
+    #[snafu(display(
+        "Unable to remove finalizer '{}' for test '{}': {}",
+        finalizer,
+        test_name,
+        source
+    ))]
+    RemoveFinalizer {
+        test_name: String,
+        finalizer: String,
+        source: client::Error,
+    },
 
     #[snafu(display("Unable to set controller status for test '{}': {}", test_name, source))]
     SetControllerStatus {


### PR DESCRIPTION


**Description of changes:**

Oops. Let's keep error variants in alphabetical order.

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
