### PR TITLE
cli: setup crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +93,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "client"
 version = "0.1.0"
 dependencies = [
@@ -151,7 +175,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn",
 ]
 
@@ -386,6 +410,15 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -875,6 +908,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,9 +1230,39 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "structopt"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -1222,6 +1309,28 @@ dependencies = [
  "serde_json",
  "snafu",
  "tokio",
+]
+
+[[package]]
+name = "testsys"
+version = "0.1.0"
+dependencies = [
+ "client",
+ "env_logger",
+ "log",
+ "snafu",
+ "structopt",
+ "tokio",
+ "yamlgen",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1414,6 +1523,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,6 +1545,18 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@ members = [
     "client",
     "controller",
     "test-agent",
+    "testsys",
     "yamlgen",
 ]

--- a/testsys/Cargo.toml
+++ b/testsys/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "testsys"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+env_logger = "0.9"
+log = "0.4"
+snafu = "0.6"
+structopt = "0.3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+# local dependencies
+client = { path = "../client" }
+# regenerate testsys.yaml if the model has changed
+yamlgen = { path = "../yamlgen" }

--- a/testsys/src/error.rs
+++ b/testsys/src/error.rs
@@ -1,0 +1,12 @@
+use snafu::Snafu;
+
+/// The crate-wide result type.
+pub(crate) type Result<T> = std::result::Result<T, Error>;
+
+/// The crate-wide error type.
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub(crate)")]
+pub(crate) enum Error {
+    #[snafu(display("TODO: create proper error variants and delete this one."))]
+    Placeholder {},
+}

--- a/testsys/src/install.rs
+++ b/testsys/src/install.rs
@@ -1,0 +1,12 @@
+use crate::error::{self, Result};
+use structopt::StructOpt;
+
+/// TODO - This is a placeholder.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Install {}
+
+impl Install {
+    pub(crate) async fn run(&self) -> Result<()> {
+        error::Placeholder {}.fail()
+    }
+}

--- a/testsys/src/main.rs
+++ b/testsys/src/main.rs
@@ -1,0 +1,68 @@
+/*!
+
+This is the command line interface for setting up a TestSys Cluster and running tests in it.
+
+!*/
+
+pub(crate) mod error;
+pub(crate) mod install;
+
+use env_logger::Builder;
+use error::Result;
+use log::LevelFilter;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+/// The command line interface for setting up a Bottlerocket TestSys cluster and running tests.
+#[derive(Debug, StructOpt)]
+struct Args {
+    /// Set logging verbosity [trace|debug|info|warn|error]. If the environment variable `RUST_LOG`
+    /// is present, it overrides the default logging behavior. See https://docs.rs/env_logger/latest
+    #[structopt(long = "log-level", default_value = "info")]
+    log_level: LevelFilter,
+    /// Path to the kubeconfig file.
+    #[structopt(long = "kubeconfig", env = "KUBECONFIG")]
+    kubeconfig: Option<PathBuf>,
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, StructOpt)]
+enum Command {
+    /// Install TestSys components into the cluster.
+    Install(install::Install),
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::from_args();
+    init_logger(args.log_level);
+    if let Err(e) = run(args).await {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    }
+}
+
+async fn run(args: Args) -> Result<()> {
+    match args.command {
+        Command::Install(install) => install.run().await,
+    }
+}
+
+/// Initialize the logger with the value passed by `--log-level` (or its default) when the
+/// `RUST_LOG` environment variable is not present. If present, the `RUST_LOG` environment variable
+/// overrides `--log-level`/`level`.
+fn init_logger(level: LevelFilter) {
+    match std::env::var(env_logger::DEFAULT_FILTER_ENV).ok() {
+        Some(_) => {
+            // RUST_LOG exists; env_logger will use it.
+            Builder::from_default_env().init();
+        }
+        None => {
+            // RUST_LOG does not exist; use default log level for this crate only.
+            Builder::new()
+                .filter(Some(env!("CARGO_CRATE_NAME")), level)
+                .init();
+        }
+    }
+}


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #3

**Description of changes:**

Adds a crate for the testsys command-line program.

**Testing done:**

`testsys --help`

```text
The command line interface for setting up a Bottlerocket TestSys cluster and running tests

USAGE:
    testsys [OPTIONS] <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --kubeconfig <kubeconfig>    Path to the kubeconfig file [env:
                                     KUBECONFIG=/Users/mjb/repos/mybr/testsys/kubeconfig-issue-14.yaml]
        --log-level <log-level>      Set logging verbosity [trace|debug|info|warn|error]. If the environment variable
                                     `RUST_LOG` is present, it overrides the default logging behavior. See
                                     https://docs.rs/env_logger/latest [default: info]

SUBCOMMANDS:
    help       Prints this message or the help of the given subcommand(s)
    install    Install TestSys components into the cluster
```

`testsys install --help`

```text
Install TestSys components into the cluster

USAGE:
    testsys install

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
