### PR TITLE
Cli Install Command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f002ce7d0c5e809ebb02be78fd503aeed4a511fd0fcaff6e6914cbdabbfa33"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +73,17 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bstr"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
 
 [[package]]
 name = "bytes"
@@ -211,6 +236,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dirs-next"
@@ -525,6 +556,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +574,15 @@ checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -571,9 +622,12 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
+ "http",
+ "percent-encoding",
  "serde",
  "serde-value",
  "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -916,6 +970,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "predicates"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c143348f141cc87aab5b950021bac6145d0e5ae754b0591de23244cee42c9308"
+dependencies = [
+ "difflib",
+ "itertools",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dd0fd014130206c9352efbdc92be592751b2b9274dff685348341082c6ea3d"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
@@ -1138,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1323,9 +1410,17 @@ dependencies = [
 name = "testsys"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
+ "base64",
  "client",
  "env_logger",
+ "k8s-openapi",
+ "kube",
+ "kube-runtime",
  "log",
+ "serde",
+ "serde_json",
+ "serde_yaml",
  "snafu",
  "structopt",
  "tokio",
@@ -1371,6 +1466,21 @@ dependencies = [
  "wasi",
  "winapi",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
@@ -1525,10 +1635,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1549,6 +1680,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,6 +1708,15 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/testsys/Cargo.toml
+++ b/testsys/Cargo.toml
@@ -5,8 +5,15 @@ edition = "2018"
 publish = false
 
 [dependencies]
+base64 = "0.13.0"
 env_logger = "0.9"
+kube = { version = "0.59.0", default-features = true, features = [ "derive"] }
+kube-runtime = "0.59.0"
+k8s-openapi = { version = "0.13.0", features = ["v1_20", "api"], default-features = false }
 log = "0.4"
+serde = "1.0.130"
+serde_json = "1.0.61"
+serde_yaml = "0.8"
 snafu = "0.6"
 structopt = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
@@ -15,3 +22,6 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 client = { path = "../client" }
 # regenerate testsys.yaml if the model has changed
 yamlgen = { path = "../yamlgen" }
+
+[dev-dependencies]
+assert_cmd = "2.0"

--- a/testsys/src/error.rs
+++ b/testsys/src/error.rs
@@ -7,6 +7,21 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub(crate)")]
 pub(crate) enum Error {
-    #[snafu(display("TODO: create proper error variants and delete this one."))]
-    Placeholder {},
+    #[snafu(display("Unable to check {}: {}", what, source))]
+    Check { what: String, source: kube::Error },
+
+    #[snafu(display("Unable to create client: {}", source))]
+    Client { source: kube::Error },
+
+    #[snafu(display("Error Creating {}: {}", what, source))]
+    Creation { what: String, source: kube::Error },
+
+    #[snafu(display("Could not serialize object: {}", source))]
+    JsonSerialize { source: serde_json::Error },
+
+    #[snafu(display("Could not extract registry url from '{}'", uri))]
+    MissingRegistry { uri: String },
+
+    #[snafu(display("Error patching {}: {}", what, source))]
+    Patch { what: String, source: kube::Error },
 }

--- a/testsys/src/install.rs
+++ b/testsys/src/install.rs
@@ -1,12 +1,268 @@
 use crate::error::{self, Result};
+use apiexts::CustomResourceDefinition;
+use client::model::{Test, NAMESPACE};
+use client::system::{
+    agent_cluster_role, agent_cluster_role_binding, agent_service_account, controller_cluster_role,
+    controller_cluster_role_binding, controller_deployment, controller_service_account,
+};
+use k8s_openapi::api::core::v1::Secret;
+use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1 as apiexts;
+use kube::{
+    api::{Api, Patch, PatchParams, PostParams, ResourceExt},
+    Client, CustomResourceExt,
+};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use snafu::ResultExt;
+use std::collections::{BTreeMap, HashMap};
+use std::fmt::Debug;
 use structopt::StructOpt;
 
-/// TODO - This is a placeholder.
+const CONTROLLER_SECRET: &str = "testsys-controller-pull-cred";
+
+const DEFAULT_TESTSYS_CONTROLLER_IMAGE: &str =
+    "334716814390.dkr.ecr.us-west-2.amazonaws.com/controller:2";
+
+/// The install subcommand is responsible for putting all of the necessary components for testsys in
+/// a k8s cluster.
 #[derive(Debug, StructOpt)]
-pub(crate) struct Install {}
+pub(crate) struct Install {
+    /// Controller image pull username
+    #[structopt(
+        long = "controller-pull-username",
+        short = "u",
+        requires("pull-password")
+    )]
+    pull_username: Option<String>,
+
+    /// Controller image pull password
+    #[structopt(
+        long = "controller-pull-password",
+        short = "p",
+        requires("pull-username")
+    )]
+    pull_password: Option<String>,
+
+    /// Controller image uri
+    #[structopt(long = "controller-uri", default_value = DEFAULT_TESTSYS_CONTROLLER_IMAGE)]
+    controller_uri: String,
+}
 
 impl Install {
     pub(crate) async fn run(&self) -> Result<()> {
-        error::Placeholder {}.fail()
+        // Initialize the k8s client from in-cluster variables or KUBECONFIG.
+        let client = Client::try_default().await.context(error::Client)?;
+
+        create_namespace(&client).await?;
+        create_crd(&client).await?;
+        create_roles(&client).await?;
+        create_service_accts(&client).await?;
+
+        let mut controller_image_pull_secret = None;
+
+        // Create the secret.
+        if let (Some(username), Some(password)) =
+            (self.pull_username.as_ref(), self.pull_password.as_ref())
+        {
+            create_secret(
+                &client,
+                username,
+                password,
+                self.controller_uri
+                    .split('/')
+                    .next()
+                    .ok_or(error::Error::MissingRegistry {
+                        uri: self.controller_uri.clone(),
+                    })?,
+            )
+            .await?;
+            // Use the secret we just created.
+            controller_image_pull_secret = Some(CONTROLLER_SECRET.to_string());
+        }
+
+        create_deployment(
+            &client,
+            self.controller_uri.clone(),
+            controller_image_pull_secret,
+        )
+        .await?;
+
+        Ok(())
+    }
+}
+
+async fn create_namespace(client: &Client) -> Result<()> {
+    // Add the namespace to the cluster.
+    let api: Api<k8s_openapi::api::core::v1::Namespace> = Api::all(client.clone());
+    let ns = client::system::testsys_namespace();
+
+    create_or_update(&api, ns, "namespace").await?;
+
+    // Give the object enough time to settle.
+    let mut sleep_count = 0;
+    while api.get(NAMESPACE).await.is_err() && sleep_count < 20 {
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        sleep_count += 1;
+    }
+
+    api.get(NAMESPACE)
+        .await
+        .context(error::Creation { what: "namespace" })?;
+
+    Ok(())
+}
+
+async fn create_crd(client: &Client) -> Result<()> {
+    // Manage the cluster CRDs.
+    let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+    // Create the CRD.
+    let testcrd = Test::crd();
+
+    create_or_update(&crds, testcrd, "Test CRD").await
+}
+
+async fn create_roles(client: &Client) -> Result<()> {
+    let roles: Api<k8s_openapi::api::rbac::v1::ClusterRole> = Api::all(client.clone());
+
+    // If the role exists merge the new role, if not create the role.
+    let agent_cluster_role = agent_cluster_role();
+    create_or_update(&roles, agent_cluster_role, "Agent Cluster Role").await?;
+
+    // If the role already exists, update it with the new one using Patch. If not create a new role.
+    let controller_cluster_role = controller_cluster_role();
+    create_or_update(&roles, controller_cluster_role, "Controller Cluster Role").await?;
+
+    let rolesbinding: Api<k8s_openapi::api::rbac::v1::ClusterRoleBinding> =
+        Api::all(client.clone());
+
+    // If the cluster role binding already exists, update it with the new one using Patch. If not
+    // create a new cluster role binding.
+    let agent_cluster_role_binding = agent_cluster_role_binding();
+    create_or_update(
+        &rolesbinding,
+        agent_cluster_role_binding,
+        "Agent Cluster Role Binding",
+    )
+    .await?;
+
+    // If the cluster role binding already exists, update it with the new one using Patch. If not
+    // create a new cluster role binding.
+    let controller_cluster_role_binding = controller_cluster_role_binding();
+    create_or_update(
+        &rolesbinding,
+        controller_cluster_role_binding,
+        "Controller Cluster Role Binding",
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn create_service_accts(client: &Client) -> Result<()> {
+    let service_accts: Api<k8s_openapi::api::core::v1::ServiceAccount> =
+        Api::namespaced(client.clone(), NAMESPACE);
+
+    // If the service accounts already exist, update them with the new ones using Patch.
+    // If not create new service accounts.
+    let agent_service_account = agent_service_account();
+    create_or_update(
+        &service_accts,
+        agent_service_account,
+        "Agent Service Account",
+    )
+    .await?;
+
+    let controller_service_account = controller_service_account();
+    create_or_update(
+        &service_accts,
+        controller_service_account,
+        "Controller Service Accout",
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn create_secret(
+    client: &Client,
+    username: &str,
+    password: &str,
+    registry_url: &str,
+) -> Result<()> {
+    // Create secret for controller image pull.
+    let sec_str =
+        serde_json::to_string_pretty(&DockerConfigJson::new(username, password, registry_url))
+            .context(error::JsonSerialize)?;
+    let mut secret_tree = BTreeMap::new();
+    secret_tree.insert(".dockerconfigjson".to_string(), sec_str);
+
+    let secrets: Api<k8s_openapi::api::core::v1::Secret> =
+        Api::namespaced(client.clone(), NAMESPACE);
+
+    let object_meta = kube::api::ObjectMeta {
+        name: Some(CONTROLLER_SECRET.to_string()),
+        ..Default::default()
+    };
+
+    // Create the secret we are going to add.
+    let secret = Secret {
+        data: None,
+        immutable: None,
+        metadata: object_meta,
+        string_data: Some(secret_tree),
+        type_: Some("kubernetes.io/dockerconfigjson".to_string()),
+    };
+
+    create_or_update(&secrets, secret, "Secret").await
+}
+
+async fn create_deployment(client: &Client, uri: String, secret: Option<String>) -> Result<()> {
+    let deps: Api<k8s_openapi::api::apps::v1::Deployment> =
+        Api::namespaced(client.clone(), NAMESPACE);
+
+    let controller_deployment = controller_deployment(uri, secret);
+
+    // If the controller deployment already exists, update it with the new one using Patch.
+    // If not create a new controller deployment.
+    create_or_update(&deps, controller_deployment, "namespace").await
+}
+
+async fn create_or_update<T>(api: &Api<T>, data: T, what: &str) -> Result<()>
+where
+    T: Clone + DeserializeOwned + Debug + kube::Resource + Serialize,
+{
+    // If the data already exists, update it with the new one using Patch. If not create a new one.
+    match api.get(&data.name()).await {
+        Ok(deployment) => {
+            api.patch(
+                &deployment.name(),
+                &PatchParams::default(),
+                &Patch::Merge(data),
+            )
+            .await
+        }
+        Err(_err) => api.create(&PostParams::default(), &data).await,
+    }
+    .context(error::Creation { what })?;
+
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct DockerConfigJson {
+    auths: HashMap<String, DockerConfigAuth>,
+}
+
+#[derive(Serialize)]
+struct DockerConfigAuth {
+    auth: String,
+}
+
+impl DockerConfigJson {
+    fn new(username: &str, password: &str, registry: &str) -> DockerConfigJson {
+        let mut auths = HashMap::new();
+        let auth = base64::encode(format!("{}:{}", username, password));
+        auths.insert(registry.to_string(), DockerConfigAuth { auth });
+        DockerConfigJson { auths }
     }
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #18


**Description of changes:**
Implements Install command of `testsys` cli. If the object already exists in a cluster then the object is patched with the new `testsys` object.

Cli contains flags for
- Username
- Password
- Docker-Registry Url
- Container URI


**Testing done:**
`install_test.rs` tests that the CLI sets up a cluster 

<img width="501" alt="image" src="https://user-images.githubusercontent.com/16852817/133124728-d902dfe1-615d-4db1-8949-0c45917609e4.png">

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
