### PR TITLE
cli: `testsys run file` subcommand

### DIFF
--- a/model/src/clients/test_client.rs
+++ b/model/src/clients/test_client.rs
@@ -4,6 +4,7 @@ use crate::{
     AgentStatus, Configuration, ControllerStatus, ErrorResources, ResourceAgentState,
     ResourceRequest, ResourceStatus, Test,
 };
+use kube::api::PostParams;
 use kube::api::{Patch, PatchParams};
 use kube::{Api, Resource};
 use log::trace;
@@ -55,6 +56,18 @@ impl TestClient {
             .await
             .context(error::KubeApiCall {
                 method: "get",
+                what: "test",
+            })?)
+    }
+
+    /// Create a TestSys [`Test`].
+    pub async fn create_test(&self, test: Test) -> Result<Test> {
+        Ok(self
+            .api
+            .create(&PostParams::default(), &test)
+            .await
+            .context(error::KubeApiCall {
+                method: "create",
                 what: "test",
             })?)
     }

--- a/testsys/src/error.rs
+++ b/testsys/src/error.rs
@@ -1,3 +1,4 @@
+use crate::PathBuf;
 use snafu::Snafu;
 
 /// The crate-wide result type.
@@ -7,14 +8,20 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub(crate)")]
 pub(crate) enum Error {
-    #[snafu(display("Unable to check {}: {}", what, source))]
-    Check { what: String, source: kube::Error },
-
     #[snafu(display("Unable to create client: {}", source))]
     Client { source: kube::Error },
 
-    #[snafu(display("Error Creating {}: {}", what, source))]
+    #[snafu(display("Error creating {}: {}", what, source))]
     Creation { what: String, source: kube::Error },
+
+    #[snafu(display("Error creating test: {}", source))]
+    CreateTest { source: model::clients::Error },
+
+    #[snafu(display("Unable to open file '{}': {}", path.display(), source))]
+    File {
+        path: PathBuf,
+        source: std::io::Error,
+    },
 
     #[snafu(display("Could not serialize object: {}", source))]
     JsonSerialize { source: serde_json::Error },
@@ -24,4 +31,13 @@ pub(crate) enum Error {
 
     #[snafu(display("Error patching {}: {}", what, source))]
     Patch { what: String, source: kube::Error },
+
+    #[snafu(display("Unable to create client: {}", source))]
+    TestClientNew { source: model::clients::Error },
+
+    #[snafu(display("Unable to create Test CRD from '{}': {}", path.display(), source))]
+    TestFileParse {
+        path: PathBuf,
+        source: serde_yaml::Error,
+    },
 }

--- a/testsys/src/k8s.rs
+++ b/testsys/src/k8s.rs
@@ -1,0 +1,70 @@
+use crate::error::{self, Result};
+use kube::api::{Api, Patch, PatchParams, PostParams, ResourceExt};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use snafu::ResultExt;
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+const MAX_RETRIES: i32 = 3;
+const BACKOFF_MS: u64 = 500;
+
+/// Create or update an object in `api` with `data`'s name
+pub(crate) async fn create_or_update<T>(api: &Api<T>, data: T, what: &str) -> Result<()>
+where
+    T: Clone + DeserializeOwned + Debug + kube::Resource + Serialize,
+{
+    let mut error = None;
+
+    for _ in 0..MAX_RETRIES {
+        match create_or_update_internal(api, data.clone(), what).await {
+            Ok(()) => return Ok(()),
+            Err(e) => error = Some(e),
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(BACKOFF_MS)).await;
+    }
+    match error {
+        None => Ok(()),
+        Some(error) => Err(error),
+    }
+}
+
+async fn create_or_update_internal<T>(api: &Api<T>, data: T, what: &str) -> Result<()>
+where
+    T: Clone + DeserializeOwned + Debug + kube::Resource + Serialize,
+{
+    // If the data already exists, update it with the new one using a `Patch`. If not create a new one.
+    match api.get(&data.name()).await {
+        Ok(deployment) => {
+            api.patch(
+                &deployment.name(),
+                &PatchParams::default(),
+                &Patch::Merge(data),
+            )
+            .await
+        }
+        Err(_err) => api.create(&PostParams::default(), &data).await,
+    }
+    .context(error::Creation { what })?;
+
+    Ok(())
+}
+
+#[derive(Serialize)]
+pub(crate) struct DockerConfigJson {
+    auths: HashMap<String, DockerConfigAuth>,
+}
+
+#[derive(Serialize)]
+struct DockerConfigAuth {
+    auth: String,
+}
+
+impl DockerConfigJson {
+    pub(crate) fn new(username: &str, password: &str, registry: &str) -> DockerConfigJson {
+        let mut auths = HashMap::new();
+        let auth = base64::encode(format!("{}:{}", username, password));
+        auths.insert(registry.to_string(), DockerConfigAuth { auth });
+        DockerConfigJson { auths }
+    }
+}

--- a/testsys/src/main.rs
+++ b/testsys/src/main.rs
@@ -6,6 +6,9 @@ This is the command line interface for setting up a TestSys Cluster and running 
 
 pub(crate) mod error;
 pub(crate) mod install;
+mod k8s;
+pub(crate) mod run;
+pub(crate) mod run_file;
 
 use env_logger::Builder;
 use error::Result;
@@ -31,6 +34,8 @@ struct Args {
 enum Command {
     /// Install TestSys components into the cluster.
     Install(install::Install),
+    /// Run a testsys test.
+    Run(run::Run),
 }
 
 #[tokio::main]
@@ -46,6 +51,7 @@ async fn main() {
 async fn run(args: Args) -> Result<()> {
     match args.command {
         Command::Install(install) => install.run().await,
+        Command::Run(run) => run.run().await,
     }
 }
 

--- a/testsys/src/run.rs
+++ b/testsys/src/run.rs
@@ -1,0 +1,24 @@
+use crate::error::Result;
+use crate::run_file;
+use structopt::StructOpt;
+
+/// Run testsys tests.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Run {
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, StructOpt)]
+enum Command {
+    /// Run a test from a YAML file.
+    File(run_file::RunFile),
+}
+
+impl Run {
+    pub(crate) async fn run(&self) -> Result<()> {
+        match &self.command {
+            Command::File(run_file) => run_file.run().await,
+        }
+    }
+}

--- a/testsys/src/run_file.rs
+++ b/testsys/src/run_file.rs
@@ -1,0 +1,29 @@
+use crate::error::{self, Result};
+use model::clients::TestClient;
+use snafu::ResultExt;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+/// Run a test stored in a YAML file at `path`.
+#[derive(Debug, StructOpt)]
+pub(crate) struct RunFile {
+    /// Path to test crd YAML file.
+    #[structopt(parse(from_os_str))]
+    path: PathBuf,
+}
+
+impl RunFile {
+    pub(crate) async fn run(&self) -> Result<()> {
+        // Create the test object from its path.
+        let test_file =
+            std::fs::File::open(&self.path).context(error::File { path: &self.path })?;
+        let test = serde_yaml::from_reader(test_file)
+            .context(error::TestFileParse { path: &self.path })?;
+
+        let tests = TestClient::new().await.context(error::TestClientNew)?;
+
+        tests.create_test(test).await.context(error::CreateTest)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #20 


**Description of changes:**
Adds a new subcommand `testsys run file --path path/to/test/yaml`.
Also moves some of the `Install` logic to a separate file.


**Testing done:**
Using the install command followed by the run file command we achieve the following output:
![image](https://user-images.githubusercontent.com/16852817/133512485-bc20244d-8e49-4807-aaba-75dfdb0c1760.png)



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
