### PR TITLE
build: avoid pulling extra images

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -9,8 +9,9 @@ RUN cargo install --locked --target ${ARCH}-bottlerocket-linux-musl --path . --r
 
 FROM scratch
 # Copy CA certificates store
-COPY --from=public.ecr.aws/amazonlinux/amazonlinux:2 /etc/ssl /etc/ssl
-COPY --from=public.ecr.aws/amazonlinux/amazonlinux:2 /etc/pki /etc/pki
+COPY --from=build /etc/ssl /etc/ssl
+COPY --from=build /etc/pki /etc/pki
+# Copy binary
 COPY --from=build /src/controller/bin/controller ./
 
 ENTRYPOINT ["./controller"]


### PR DESCRIPTION
If we use the CA certs from the Bottlerocket SDK (Fedora) instead of
amazonlinux:2, then we can avoid an extra image pull. This is especially
important during GitHub actions runs where we are being rate-limited
when pulling amazonlinux:2.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Fixes #102

**Description of changes:**

Container registry rate limiting will likely continue to be a challenge, but at least for now we can fix our GitHub actions problem by avoiding an extra pull of `amazonlinux:2`.

**Testing done:**

Tested the build.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
