### PR TITLE
cli: `status` subcommand

### DIFF
--- a/model/src/clients/test_client.rs
+++ b/model/src/clients/test_client.rs
@@ -4,7 +4,7 @@ use crate::{
     AgentStatus, Configuration, ControllerStatus, ErrorResources, ResourceAgentState,
     ResourceRequest, ResourceStatus, Test,
 };
-use kube::api::{Patch, PatchParams, PostParams};
+use kube::api::{ListParams, Patch, PatchParams, PostParams};
 use kube::{Api, Resource};
 use log::trace;
 use serde::Serialize;
@@ -57,6 +57,19 @@ impl TestClient {
                 method: "get",
                 what: "test",
             })?)
+    }
+
+    /// Get all of the TestSys [`Test`]s.
+    pub async fn get_all_tests(&self) -> Result<Vec<Test>> {
+        Ok(self
+            .api
+            .list(&ListParams::default())
+            .await
+            .context(error::KubeApiCall {
+                method: "get",
+                what: "all test",
+            })?
+            .items)
     }
 
     /// Create a TestSys [`Test`].

--- a/model/src/test.rs
+++ b/model/src/test.rs
@@ -3,7 +3,7 @@ use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt::Display};
 
 /// A TestSys Test. The `CustomResource` derive also produces a struct named `Test` which represents
 /// a test CRD object in the k8s API.
@@ -62,6 +62,12 @@ pub enum RunState {
 impl Default for RunState {
     fn default() -> Self {
         RunState::Unknown
+    }
+}
+
+impl Display for RunState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
@@ -134,5 +140,11 @@ pub enum Lifecycle {
 impl Default for Lifecycle {
     fn default() -> Self {
         Lifecycle::New
+    }
+}
+
+impl Display for Lifecycle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
     }
 }

--- a/testsys/src/error.rs
+++ b/testsys/src/error.rs
@@ -20,11 +20,17 @@ pub(crate) enum Error {
     #[snafu(display("Error creating test: {}", source))]
     CreateTest { source: model::clients::Error },
 
+    #[snafu(display("The following tests failed to run '{:?}'", tests))]
+    FailedTest { tests: Vec<String> },
+
     #[snafu(display("Unable to open file '{}': {}", path.display(), source))]
     File {
         path: PathBuf,
         source: std::io::Error,
     },
+
+    #[snafu(display("Unable to get test: {}", source))]
+    GetTest { source: model::clients::Error },
 
     #[snafu(display("Could not serialize object: {}", source))]
     JsonSerialize { source: serde_json::Error },

--- a/testsys/src/main.rs
+++ b/testsys/src/main.rs
@@ -9,6 +9,7 @@ mod install;
 mod k8s;
 mod run;
 mod run_file;
+mod status;
 
 use crate::k8s::k8s_client;
 use env_logger::Builder;
@@ -35,8 +36,10 @@ struct Args {
 enum Command {
     /// Install TestSys components into the cluster.
     Install(install::Install),
-    /// Run a testsys test.
+    /// Run a TestSys test.
     Run(run::Run),
+    /// Check the status of a TestSys test.
+    Status(status::Status),
 }
 
 #[tokio::main]
@@ -54,6 +57,7 @@ async fn run(args: Args) -> Result<()> {
     match args.command {
         Command::Install(install) => install.run(k8s_client).await,
         Command::Run(run) => run.run(k8s_client).await,
+        Command::Status(status) => status.run(k8s_client).await,
     }
 }
 

--- a/testsys/src/status.rs
+++ b/testsys/src/status.rs
@@ -1,0 +1,196 @@
+use crate::error::{self, Result};
+use kube::Client;
+use model::clients::TestClient;
+use model::{Lifecycle, RunState, Test};
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use std::collections::HashMap;
+use std::fmt::Display;
+use structopt::StructOpt;
+
+/// Check the status of a TestSys test.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Status {
+    /// Check the status of `Test` named `test_name`. Omit to check the status of all tests.
+    #[structopt(long = "test-name", short = "t")]
+    test_name: Option<String>,
+
+    /// Continue checking the status of the test(s) until all have completed.
+    #[structopt(long = "wait")]
+    wait: bool,
+
+    /// Output the results in JSON format.
+    #[structopt(long = "json")]
+    json: bool,
+}
+
+impl Status {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        let tests_api = TestClient::new_from_k8s_client(k8s_client);
+        let mut failures;
+        let mut status_results;
+        loop {
+            failures = Vec::new();
+            status_results = StatusResults::new();
+            let tests = match self.test_name.as_ref() {
+                Some(test_name) => vec![tests_api
+                    .get_test(test_name)
+                    .await
+                    .context(error::GetTest)?],
+                None => tests_api.get_all_tests().await.context(error::GetTest)?,
+            };
+            let mut all_finished = true;
+            for test in tests {
+                let test_result = TestResult::from_test(&test);
+                if !test_result.is_finished() {
+                    all_finished = false;
+                }
+                if test_result.failed() {
+                    failures.push(test_result.name.clone())
+                }
+                status_results.add_test_result(test_result)
+            }
+            if !self.json {
+                println!("{}", status_results);
+            }
+            if !self.wait || all_finished {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
+        }
+        if self.json {
+            println!(
+                "{}",
+                serde_json::to_string(&status_results).context(error::JsonSerialize)?
+            )
+        }
+        if !failures.is_empty() {
+            Err(error::Error::FailedTest { tests: failures })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct StatusResults {
+    tests: HashMap<String, TestResult>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TestResult {
+    name: String,
+    lifecycle: Option<Lifecycle>,
+    run_state: Option<RunState>,
+    passed: Option<u64>,
+    failed: Option<u64>,
+    skipped: Option<u64>,
+}
+
+impl StatusResults {
+    fn new() -> Self {
+        Self {
+            tests: HashMap::new(),
+        }
+    }
+
+    fn add_test_result(&mut self, test_result: TestResult) {
+        self.tests.insert(test_result.name.clone(), test_result);
+    }
+}
+
+impl Display for StatusResults {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (_name, result) in &self.tests {
+            write!(f, "{}\n\n", result)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl TestResult {
+    fn from_test(test: &Test) -> Self {
+        let name = test.metadata.name.clone().unwrap_or("".to_string());
+        let mut passed = None;
+        let mut failed = None;
+        let mut skipped = None;
+        let mut lifecycle = None;
+        let mut run_state = None;
+        if let Some(status) = &test.status {
+            if let Some(controller) = &status.controller {
+                lifecycle = Some(controller.lifecycle);
+            }
+            if let Some(agent) = &status.agent {
+                if let Some(results) = &agent.results {
+                    passed = Some(results.num_passed);
+                    failed = Some(results.num_failed);
+                    skipped = Some(results.num_skipped);
+                }
+                run_state = Some(agent.run_state);
+            }
+        }
+
+        Self {
+            name,
+            lifecycle,
+            run_state,
+            passed,
+            failed,
+            skipped,
+        }
+    }
+
+    fn is_finished(&self) -> bool {
+        // TODO update the finished condition.
+        if let Some(lifecycle) = self.lifecycle {
+            lifecycle == Lifecycle::TestPodExited
+                || lifecycle == Lifecycle::TestPodError
+                || lifecycle == Lifecycle::TestPodDone
+                || lifecycle == Lifecycle::TestPodFailed
+        } else {
+            false
+        }
+    }
+
+    fn failed(&self) -> bool {
+        if let Some(run_state) = self.run_state {
+            run_state == RunState::Error
+        } else {
+            false
+        }
+    }
+}
+
+impl Display for TestResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Test Name: {}\n", self.name)?;
+        write!(
+            f,
+            "Controller State: {}\n",
+            self.lifecycle.map_or("".to_string(), |l| l.to_string())
+        )?;
+        write!(
+            f,
+            "Agent State: {}\n",
+            self.run_state.map_or("".to_string(), |r| r.to_string())
+        )?;
+        write!(
+            f,
+            "Passed: {}\n",
+            self.passed.map_or("".to_string(), |x| x.to_string())
+        )?;
+        write!(
+            f,
+            "Failed: {}\n",
+            self.failed.map_or("".to_string(), |x| x.to_string())
+        )?;
+        write!(
+            f,
+            "Skipped: {}\n",
+            self.skipped.map_or("".to_string(), |x| x.to_string())
+        )?;
+
+        Ok(())
+    }
+}

--- a/testsys/tests/cli_test.rs
+++ b/testsys/tests/cli_test.rs
@@ -82,3 +82,59 @@ async fn test_run_file() {
         )
     }
 }
+
+#[tokio::test]
+async fn test_status() {
+    let cluster_name = "status-test";
+    let max_wait_iter = 25;
+    let wait_time = 1000;
+    let cluster = Cluster::new(cluster_name).unwrap();
+    cluster
+        .load_image_to_cluster("testsys-controller:integ")
+        .unwrap();
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "install",
+        "--controller-uri",
+        "testsys-controller:integ",
+    ]);
+    cmd.assert().success();
+    cluster
+        .load_image_to_cluster("example-testsys-agent:integ")
+        .unwrap();
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "run",
+        "file",
+        data::hello_example_path().to_str().unwrap(),
+    ]);
+    cmd.assert().success();
+
+    let mut iter_count = 0;
+    while !cluster.is_controller_running().await.unwrap() && iter_count < max_wait_iter {
+        iter_count += 1;
+        tokio::time::sleep(Duration::from_millis(wait_time)).await;
+    }
+    while !cluster.is_test_running("hello-bones").await.unwrap() && iter_count < max_wait_iter {
+        iter_count += 1;
+        tokio::time::sleep(Duration::from_millis(wait_time)).await;
+    }
+    if iter_count == max_wait_iter {
+        panic!(
+            "Controller or test did not reach `running` after {} ms",
+            wait_time * max_wait_iter
+        )
+    }
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "status",
+        "--wait",
+    ]);
+    cmd.assert().success();
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to #43 

**Description of changes:**

Adds a subcommand `testsys status` which can be configured to report the status of a specific testsys test, or check all tests. There is also a flag `--wait` to continue updating the status. 

**Testing done:**

Output on example test pod looks correct.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
