### PR TITLE
test-agent: Keep running

### DIFF
--- a/agent/test-agent/src/k8s_client.rs
+++ b/agent/test-agent/src/k8s_client.rs
@@ -34,6 +34,11 @@ impl Client for DefaultClient {
         })
     }
 
+    async fn keep_running(&self) -> Result<bool, Self::E> {
+        let test_data = self.client.get_test(&self.name).await.context(K8s)?;
+        Ok(test_data.spec.agent.keep_running)
+    }
+
     async fn get_test_info<C>(&self) -> Result<TestInfo<C>, Self::E>
     where
         C: Configuration,

--- a/agent/test-agent/src/lib.rs
+++ b/agent/test-agent/src/lib.rs
@@ -68,6 +68,9 @@ pub trait Client: Sized {
     where
         C: Configuration;
 
+    /// Determine if the pod should keep running after it has finished or encountered and error.
+    async fn keep_running(&self) -> Result<bool, Self::E>;
+
     /// Set the appropriate status field to represent that the test has started.
     async fn send_test_starting(&self) -> Result<(), Self::E>;
 

--- a/agent/test-agent/tests/mock.rs
+++ b/agent/test-agent/tests/mock.rs
@@ -100,6 +100,10 @@ impl Client for MockClient {
         println!("MockClient::send_error {}", error);
         Ok(())
     }
+
+    async fn keep_running(&self) -> Result<bool, Self::E> {
+        Ok(false)
+    }
 }
 
 /// This test runs [`MyRunner`] inside a [`TestAgent`] with k8s and the container environment mocked

--- a/model/src/test.rs
+++ b/model/src/test.rs
@@ -34,6 +34,8 @@ pub struct Agent {
     pub image: String,
     /// The name of an image registry pull secret if one is needed to pull the test agent image.
     pub pull_secret: Option<String>,
+    /// Determine if the pod should keep running after it has finished or encountered and error.
+    pub keep_running: bool,
     /// The configuration to pass to the test pod. This is 'open' to allow tests to define their own
     /// schemas.
     pub configuration: Option<Map<String, Value>>,

--- a/testsys/tests/data/hello-example.yaml
+++ b/testsys/tests/data/hello-example.yaml
@@ -9,9 +9,10 @@ spec:
   agent:
     name: hello-agent
     image: "example-testsys-agent:integ"
+    keep_running: false
     configuration:
       mode: Fast
       person: Bones the Cat
-      hello_count: 10
+      hello_count: 5
       hello_duration_seconds: 3
   resources: {}

--- a/yamlgen/deploy/testsys-crd.yaml
+++ b/yamlgen/deploy/testsys-crd.yaml
@@ -34,6 +34,9 @@ spec:
                     image:
                       description: The URI of the test agent container image.
                       type: string
+                    keep_running:
+                      description: Determine if the pod should keep running after it has finished or encountered and error.
+                      type: boolean
                     name:
                       description: The name of the test agent.
                       type: string
@@ -43,6 +46,7 @@ spec:
                       type: string
                   required:
                     - image
+                    - keep_running
                     - name
                   type: object
                 resources:


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #79 


**Description of changes:**
Adds `keep_running` to the test agent. When running, the test agent will stay in the run function until the `test`'s `keep_running` is set to false.


**Testing done:**
Output from `testsys status` shows the test staying in `TestPodHealthy` state instead of `TestPodExited` state.

We will need some way to flip `keep_running` in the future.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
