### PR TITLE
cli: set --keep_running

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,7 @@ dependencies = [
 name = "model"
 version = "0.1.0"
 dependencies = [
+ "json-patch",
  "k8s-openapi",
  "kube",
  "log",

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -5,9 +5,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
+json-patch = "0.2.6"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_20"] }
-kube = { version = "0.59.0", default-features = true, features = [ "derive"] }
+kube = { version = "0.59.0", default-features = true, features = [ "derive", "jsonpatch"] }
 log = "0.4"
 maplit = "1.0.2"
 schemars = "0.8"

--- a/testsys/src/error.rs
+++ b/testsys/src/error.rs
@@ -47,6 +47,13 @@ pub(crate) enum Error {
         source: serde_yaml::Error,
     },
 
+    #[snafu(display("Unable to set {} field of '{}': {}", what, name, source))]
+    Set {
+        name: String,
+        what: String,
+        source: model::clients::Error,
+    },
+
     #[snafu(display("Unable to create client: {}", source))]
     TestClientNew { source: model::clients::Error },
 

--- a/testsys/src/main.rs
+++ b/testsys/src/main.rs
@@ -11,6 +11,7 @@ mod install;
 mod k8s;
 mod run;
 mod run_file;
+mod set;
 mod status;
 
 use crate::k8s::k8s_client;
@@ -44,6 +45,8 @@ enum Command {
     Status(status::Status),
     /// Add various components to the cluster.
     Add(add::Add),
+    /// Set a field of a TestSys test.
+    Set(set::Set),
 }
 
 #[tokio::main]
@@ -63,6 +66,7 @@ async fn run(args: Args) -> Result<()> {
         Command::Run(run) => run.run(k8s_client).await,
         Command::Status(status) => status.run(k8s_client).await,
         Command::Add(add) => add.run(k8s_client).await,
+        Command::Set(set) => set.run(k8s_client).await,
     }
 }
 

--- a/testsys/src/set.rs
+++ b/testsys/src/set.rs
@@ -1,0 +1,34 @@
+use crate::error::{self, Result};
+use kube::Client;
+use model::clients::TestClient;
+use snafu::ResultExt;
+use structopt::StructOpt;
+
+/// Set the field of a testsys test.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Set {
+    /// The name of the test to change.
+    name: String,
+
+    /// Set the value of the `keep_running` field of a testsys test.
+    #[structopt(long)]
+    keep_running: Option<bool>,
+}
+
+impl Set {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        let tests = TestClient::new_from_k8s_client(k8s_client);
+
+        if let Some(keep_running) = &self.keep_running {
+            tests
+                .set_keep_running(&self.name, *keep_running)
+                .await
+                .context(error::Set {
+                    name: self.name.clone(),
+                    what: "keep_running",
+                })?;
+        }
+
+        Ok(())
+    }
+}

--- a/testsys/tests/cli_test.rs
+++ b/testsys/tests/cli_test.rs
@@ -189,3 +189,69 @@ async fn test_status() {
     ]);
     cmd.assert().success();
 }
+
+#[tokio::test]
+async fn test_set() {
+    let cluster_name = "set-test";
+    let max_wait_iter = 25;
+    let wait_time = 1000;
+    let cluster = Cluster::new(cluster_name).unwrap();
+    cluster
+        .load_image_to_cluster("testsys-controller:integ")
+        .unwrap();
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "install",
+        "--controller-uri",
+        "testsys-controller:integ",
+    ]);
+    cmd.assert().success();
+    cluster
+        .load_image_to_cluster("example-testsys-agent:integ")
+        .unwrap();
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "run",
+        "file",
+        data::hello_example_path().to_str().unwrap(),
+    ]);
+    cmd.assert().success();
+
+    let mut iter_count = 0;
+    while !cluster.is_controller_running().await.unwrap() && iter_count < max_wait_iter {
+        iter_count += 1;
+        tokio::time::sleep(Duration::from_millis(wait_time)).await;
+    }
+    while !cluster.is_test_running("hello-bones").await.unwrap() && iter_count < max_wait_iter {
+        iter_count += 1;
+        tokio::time::sleep(Duration::from_millis(wait_time)).await;
+    }
+    if iter_count == max_wait_iter {
+        panic!(
+            "Controller or test did not reach `running` after {} ms",
+            wait_time * max_wait_iter
+        )
+    }
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "set",
+        "hello-bones",
+        "--keep-running",
+        "false",
+    ]);
+    cmd.assert().success();
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "status",
+        "--wait",
+    ]);
+    cmd.assert().success();
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Related to #44 


**Description of changes:**
`testsys terminate` sets the test's `keep_running` field to false allowing the `Runner` to finish.


**Testing done:**
`test_terminate` creates a test with `keep_running : true`. After the test is applied, `terminate` is called, followed by `status` to ensure the test completes successfully.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
