### PR TITLE
Disable out-of-line atomics in aarch64 musl build

### DIFF
--- a/Dockerfile.sdk_openssl
+++ b/Dockerfile.sdk_openssl
@@ -17,7 +17,8 @@ RUN curl -O -sSL https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.g
     echo "${OPENSSL_SHA256SUM} openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum --check && \
     tar -xzf openssl-${OPENSSL_VERSION}.tar.gz && \
     cd openssl-${OPENSSL_VERSION} && \
-    ./Configure no-shared no-async -fPIC --prefix=/musl --openssldir=/musl/ssl linux-${ARCH} && \
+    if [ ${ARCH} = "aarch64" ]; then CONFIGURE_ARGS="-mno-outline-atomics"; else CONFIGURE_ARGS=""; fi && \
+    ./Configure no-shared no-async ${CONFIGURE_ARGS} -fPIC --prefix=/musl --openssldir=/musl/ssl linux-${ARCH} && \
     env C_INCLUDE_PATH=/musl/include/ make depend 2> /dev/null && \
     make -j && \
     make install && \


### PR DESCRIPTION
These otherwise cause linker errors on aarch64 platforms.

**Issue number:** N/A



**Description of changes:**
This disabled [out of line atomics](https://lists.linaro.org/pipermail/cross-distro/2020-June/000937.html) during the musl build, which were causing issues when compiling on aarch64 platforms (similar to [this](https://github.com/rust-lang/rust/issues/81808) and [this](https://www.mail-archive.com/gcc-bugs@gcc.gnu.org/msg661738.html))


**Testing done:**
`make` now results in a successful build on aarch64 platforms, whereas before it resulted in linker errors like so:

```
          /usr/bin/ld: /src/target/aarch64-bottlerocket-linux-musl/release/deps/libopenssl_sys-5efd7839d47f512d.rlib(eng_list.o):eng_list.c:(.text+0x7b4): more undefined references to `__aarch64_ldadd4_acq_rel' follow
          /usr/bin/ld: /src/target/aarch64-bottlerocket-linux-musl/release/deps/libopenssl_sys-5efd7839d47f512d.rlib(eng_list.o): in function `ENGINE_up_ref':
          eng_list.c:(.text+0x864): undefined reference to `__aarch64_ldadd4_relax'
          collect2: error: ld returned 1 exit status
          

error: aborting due to previous error

error: failed to compile `controller v0.1.0 (/src/controller)`, intermediate artifacts can be found at `/src/target`
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
