### PR TITLE
test-agent: set agent state to done after test has completed

### DIFF
--- a/agent/test-agent/src/k8s_client.rs
+++ b/agent/test-agent/src/k8s_client.rs
@@ -79,7 +79,7 @@ impl Client for DefaultClient {
             .get_agent_status(&self.name)
             .await
             .context(K8s)?;
-        agent_status.run_state = RunState::Running;
+        agent_status.run_state = RunState::Done;
         agent_status.results = Some(results);
         let _ = self
             .client

--- a/testsys/src/status.rs
+++ b/testsys/src/status.rs
@@ -142,15 +142,16 @@ impl TestResult {
     }
 
     fn is_finished(&self) -> bool {
-        // TODO update the finished condition.
-        if let Some(lifecycle) = self.lifecycle {
-            lifecycle == Lifecycle::TestPodExited
-                || lifecycle == Lifecycle::TestPodError
-                || lifecycle == Lifecycle::TestPodDone
-                || lifecycle == Lifecycle::TestPodFailed
-        } else {
-            false
+        if let Some(run_state) = self.run_state {
+            if run_state == RunState::Done || run_state == RunState::Error {
+                return true;
+            }
+        } else if let Some(lifecycle) = self.lifecycle {
+            if lifecycle == Lifecycle::TestPodDone || lifecycle == Lifecycle::TestPodError {
+                return true;
+            }
         }
+        return false;
     }
 
     fn failed(&self) -> bool {

--- a/testsys/tests/data/hello-example.yaml
+++ b/testsys/tests/data/hello-example.yaml
@@ -7,7 +7,7 @@ spec:
   agent:
     name: hello-agent
     image: "example-testsys-agent:integ"
-    keep_running: false
+    keep_running: true
     configuration:
       mode: Fast
       person: Bones the Cat


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #113 


**Description of changes:**
Changes the `RunState` to done when a test is finished. `testsys status` uses this to return once the test has completed.


**Testing done:**
`test_status` runs a test with `keep_running: true` and then calls `testsys status`. This command exits without issue even though the test pod is still running.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
