### PR TITLE
`testsys add secret map`

### DIFF
--- a/testsys/src/add.rs
+++ b/testsys/src/add.rs
@@ -1,5 +1,5 @@
-use crate::add_file;
 use crate::error::Result;
+use crate::{add_file, add_secret};
 use kube::Client;
 use structopt::StructOpt;
 
@@ -14,12 +14,16 @@ pub(crate) struct Add {
 enum Command {
     /// Add a resource provider from a YAML file.
     File(add_file::AddFile),
+
+    /// Add a secret to the cluster.
+    Secret(add_secret::AddSecret),
 }
 
 impl Add {
     pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
         match &self.command {
             Command::File(add_file) => add_file.run(k8s_client).await,
+            Command::Secret(add_secret) => add_secret.run(k8s_client).await,
         }
     }
 }

--- a/testsys/src/add_secret.rs
+++ b/testsys/src/add_secret.rs
@@ -1,0 +1,25 @@
+use crate::add_secret_map;
+use crate::error::Result;
+use kube::Client;
+use structopt::StructOpt;
+
+/// Add a `Secret` to a testsys cluster.
+#[derive(Debug, StructOpt)]
+pub(crate) struct AddSecret {
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, StructOpt)]
+enum Command {
+    /// Add a `Secret` to the cluster using key value pairs.
+    Map(add_secret_map::AddSecretMap),
+}
+
+impl AddSecret {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        match &self.command {
+            Command::Map(add_secret_map) => add_secret_map.run(k8s_client).await,
+        }
+    }
+}

--- a/testsys/src/add_secret_map.rs
+++ b/testsys/src/add_secret_map.rs
@@ -1,0 +1,58 @@
+use crate::error::{self, Result};
+use crate::k8s::create_or_update;
+use k8s_openapi::api::core::v1::Secret;
+use kube::{Api, Client};
+use model::constants::NAMESPACE;
+use model::SecretName;
+use snafu::OptionExt;
+use std::collections::BTreeMap;
+use structopt::StructOpt;
+
+/// Add a `Secret` with key value pairs.
+#[derive(Debug, StructOpt)]
+pub(crate) struct AddSecretMap {
+    /// Name of the secret
+    #[structopt(short, long)]
+    name: SecretName,
+
+    /// Key value pairs for secrets. (Key=value)
+    #[structopt(parse(try_from_str = parse_key_val))]
+    args: Vec<(String, String)>,
+}
+
+impl AddSecretMap {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        let args: BTreeMap<String, String> = self.args.clone().into_iter().collect();
+
+        let secrets: Api<k8s_openapi::api::core::v1::Secret> =
+            Api::namespaced(k8s_client.clone(), NAMESPACE);
+
+        let object_meta = kube::api::ObjectMeta {
+            name: Some(self.name.as_str().to_owned()),
+            ..Default::default()
+        };
+
+        // Create the secret we are going to add.
+        let secret = Secret {
+            data: None,
+            immutable: None,
+            metadata: object_meta,
+            string_data: Some(args),
+            type_: None,
+        };
+
+        create_or_update(&secrets, secret, "Secret").await?;
+        Ok(())
+    }
+}
+
+fn parse_key_val(s: &str) -> Result<(String, String)> {
+    let mut iter = s.splitn(2, '=');
+    let key = iter
+        .next()
+        .context(error::ArgumentMissing { arg: s.to_string() })?;
+    let value = iter
+        .next()
+        .context(error::ArgumentMissing { arg: s.to_string() })?;
+    Ok((key.to_string(), value.to_string()))
+}

--- a/testsys/src/error.rs
+++ b/testsys/src/error.rs
@@ -8,6 +8,12 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub(crate)")]
 pub(crate) enum Error {
+    #[snafu(display(
+        "Unable to parse argument '{}' as key value pair, expected key=value syntax",
+        arg
+    ))]
+    ArgumentMissing { arg: String },
+
     #[snafu(display("Unable to create client: {}", source))]
     ClientCreate { source: kube::Error },
 

--- a/testsys/src/main.rs
+++ b/testsys/src/main.rs
@@ -6,6 +6,8 @@ This is the command line interface for setting up a TestSys Cluster and running 
 
 mod add;
 mod add_file;
+mod add_secret;
+mod add_secret_map;
 mod error;
 mod install;
 mod k8s;


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #26 


**Description of changes:**
Implements `testsys add secret map --name <Secret Name> Key1=Value1 Key2=Value2 ...` command to add secrets to a testsys cluster.
Note: The keys are not allowed to have `=` in them, but the values are ok.


**Testing done:**
Installed testsys and ran `testsys add secret map --name my-secret hello=world` and kubectl shows that the secret was properly created.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
