### PR TITLE
resource-agent: eks provider

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -14,6 +14,7 @@ jobs:
         make_target:
          - "controller-image"
          - "ec2-resource-agent-image"
+         - "eks-resource-agent-image"
          - "example-resource-agent-image"
          - "example-test-agent-image"
          - "sonobuoy-test-agent-image"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "eks-resource-agent"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "model",
+ "resource-agent",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "agent/agent-common",
     "agent/ec2-resource-agent",
+    "agent/eks-resource-agent",
     "agent/resource-agent",
     "agent/test-agent",
     "agent/sonobuoy-test-agent",

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TOP := $(dir $(firstword $(MAKEFILE_LIST)))
 
-.PHONY: build sdk-openssl example-test-agent-image example-resource-agent-image controller-image images sonobuoy-test-agent-image integ-test ec2-resource-agent-image
+.PHONY: build sdk-openssl example-test-agent-image example-resource-agent-image controller-image images sonobuoy-test-agent-image integ-test ec2-resource-agent-image eks-resource-agent-image
 
 UNAME_ARCH=$(shell uname -m)
 ARCH ?= $(lastword $(subst :, ,$(filter $(UNAME_ARCH):%,x86_64:amd64 aarch64:arm64)))
@@ -36,6 +36,12 @@ example-resource-agent-image: fetch
 		--tag "example-resource-agent" \
 		--network none \
 		-f agent/resource-agent/examples/example_resource_agent/Dockerfile .
+
+eks-resource-agent-image: fetch
+	docker build $(DOCKER_BUILD_FLAGS) \
+		--build-arg ARCH="$(UNAME_ARCH)" \
+		--tag "eks-resource-agent" \
+		-f agent/eks-resource-agent/Dockerfile .
 
 controller-image: fetch
 	docker build $(DOCKER_BUILD_FLAGS) \

--- a/agent/eks-resource-agent/Cargo.toml
+++ b/agent/eks-resource-agent/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+ name = "eks-resource-agent"
+ version = "0.1.0"
+ edition = "2018"
+
+ [dependencies]
+ async-trait = "0.1"
+ model = { path = "../../model" }
+ resource-agent = { path = "../resource-agent" }
+ serde = { version = "1", features = [ "derive" ] }
+ tokio = { version = "1", default-features = false, features = [ "time", "macros", "rt-multi-thread" ] }

--- a/agent/eks-resource-agent/Dockerfile
+++ b/agent/eks-resource-agent/Dockerfile
@@ -1,0 +1,27 @@
+ARG ARCH
+FROM public.ecr.aws/bottlerocket/bottlerocket-sdk-${ARCH}:v0.23.0 as build
+
+ARG ARCH
+USER root
+# We need these environment variables set for building the `openssl-sys` crate
+ENV PKG_CONFIG_PATH=/${ARCH}-bottlerocket-linux-musl/sys-root/usr/lib/pkgconfig
+ENV PKG_CONFIG_ALLOW_CROSS=1
+ENV CARGO_HOME=/src/.cargo
+ENV OPENSSL_STATIC=true
+ADD ./ /src/
+WORKDIR /src/agent/eks-resource-agent
+RUN --mount=type=cache,mode=0777,target=/src/target \
+    cargo install --offline --locked --target ${ARCH}-bottlerocket-linux-musl --path . --root ./
+
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+
+RUN yum install -y tar gzip && yum clean all
+# Download eksctl
+RUN temp_dir="$(mktemp -d --suffix eksctl-setup)" && \
+    curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz" | tar xz -C /tmp && \
+    mv /tmp/eksctl /usr/bin/eksctl
+
+# Copy binary
+COPY --from=build /src/agent/eks-resource-agent/bin/eks-resource-agent ./
+
+ENTRYPOINT ["./eks-resource-agent"]

--- a/agent/eks-resource-agent/src/main.rs
+++ b/agent/eks-resource-agent/src/main.rs
@@ -1,0 +1,33 @@
+mod provider;
+
+use crate::provider::{EksCreator, EksDestroyer};
+use resource_agent::clients::{DefaultAgentClient, DefaultInfoClient};
+use resource_agent::error::AgentResult;
+use resource_agent::{Agent, BootstrapData, Types};
+use std::marker::PhantomData;
+
+#[tokio::main]
+async fn main() {
+    let data = match BootstrapData::from_env() {
+        Ok(ok) => ok,
+        Err(e) => {
+            eprintln!("Unable to get bootstrap data: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    if let Err(e) = run(data).await {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    };
+}
+
+async fn run(data: BootstrapData) -> AgentResult<()> {
+    let types = Types {
+        info_client: PhantomData::<DefaultInfoClient>::default(),
+        agent_client: PhantomData::<DefaultAgentClient>::default(),
+    };
+
+    let agent = Agent::new(types, data, EksCreator {}, EksDestroyer {}).await?;
+    agent.run().await
+}

--- a/agent/eks-resource-agent/src/provider.rs
+++ b/agent/eks-resource-agent/src/provider.rs
@@ -1,0 +1,238 @@
+use model::{Configuration, SecretName};
+use resource_agent::clients::InfoClient;
+use resource_agent::provider::{
+    Create, Destroy, IntoProviderError, ProviderError, ProviderResult, Resources, Spec,
+};
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::process::Command;
+
+/// The default region for the cluster.
+const DEFAULT_REGION: &str = "us-west-2";
+
+/// The configuration information for a eks instance provider.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct ClusterConfig {
+    /// The name of the eks cluster to create.
+    cluster_name: String,
+
+    /// The AWS region to create the cluster. If no value is provided `us-west-2` will be used.
+    region: Option<String>,
+
+    /// The availablility zones. (e.g. us-west-2a,us-west-2b)
+    zones: Option<Vec<String>>,
+}
+
+impl Configuration for ClusterConfig {}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProductionMemo {
+    pub current_status: String,
+
+    /// The name of the secret containing aws credentials.
+    pub aws_secret_name: Option<SecretName>,
+
+    /// The name of the cluster we created.
+    pub cluster_name: Option<String>,
+
+    // The region the cluster is in.
+    pub region: Option<String>,
+}
+
+impl Configuration for ProductionMemo {}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct CreatedCluster {
+    /// The name of the cluster we created.
+    pub cluster_name: String,
+
+    /// The region the cluster is in.
+    pub region: String,
+}
+
+impl Configuration for CreatedCluster {}
+
+pub struct EksCreator {}
+
+#[async_trait::async_trait]
+impl Create for EksCreator {
+    type Info = ProductionMemo;
+    type Request = ClusterConfig;
+    type Resource = CreatedCluster;
+
+    async fn create<I>(
+        &self,
+        request: Spec<Self::Request>,
+        client: &I,
+    ) -> ProviderResult<Self::Resource>
+    where
+        I: InfoClient,
+    {
+        let mut memo: ProductionMemo = client
+            .get_info()
+            .await
+            .context(Resources::Clear, "Unable to get info from client")?;
+
+        let region = request
+            .configuration
+            .region
+            .as_ref()
+            .unwrap_or(&DEFAULT_REGION.to_string())
+            .to_string();
+
+        let cluster_name = request.configuration.cluster_name;
+
+        // Write aws credentials if we need them so we can run eksctl
+        if let Some(aws_secret_name) = request.secrets.get("aws-credentials") {
+            setup_env(client, aws_secret_name, Resources::Clear).await?;
+            memo.aws_secret_name = Some(aws_secret_name.clone());
+        }
+
+        memo.current_status = "Creating Cluster".into();
+        client
+            .send_info(memo.clone())
+            .await
+            .context(Resources::Clear, "Error sending cluster creation message")?;
+
+        let status = Command::new("eksctl")
+            .args([
+                "create",
+                "cluster",
+                "-r",
+                &region,
+                "--zones",
+                &request.configuration.zones.unwrap_or_default().join(","),
+                "--set-kubeconfig-context=false",
+                "-n",
+                &cluster_name,
+                "--nodes",
+                "0",
+                "--managed=false",
+            ])
+            .status()
+            .context(Resources::Clear, "Failed create cluster")?;
+
+        if !status.success() {
+            return Err(ProviderError::new_with_context(
+                Resources::Clear,
+                format!("Failed create cluster with status code {}", status),
+            ));
+        }
+
+        let created_lot = CreatedCluster {
+            cluster_name: cluster_name.clone(),
+            region: region.clone(),
+        };
+
+        memo.current_status = "Cluster Created".into();
+        memo.cluster_name = Some(cluster_name);
+        memo.region = Some(region);
+        client.send_info(memo.clone()).await.context(
+            Resources::Remaining,
+            "Error sending cluster created message",
+        )?;
+
+        Ok(created_lot)
+    }
+}
+
+async fn setup_env<I>(
+    client: &I,
+    aws_secret_name: &SecretName,
+    failure_resources: Resources,
+) -> ProviderResult<()>
+where
+    I: InfoClient,
+{
+    let aws_secret = client.get_secret(aws_secret_name).await.context(
+        failure_resources,
+        format!("Error getting secret '{}'", aws_secret_name),
+    )?;
+
+    let access_key_id = String::from_utf8(
+        aws_secret
+            .get("access-key-id")
+            .context(
+                failure_resources,
+                format!("access-key-id missing from secret '{}'", aws_secret_name),
+            )?
+            .to_owned(),
+    )
+    .context(
+        failure_resources,
+        "Could not convert access-key-id to String",
+    )?;
+    let secret_access_key = String::from_utf8(
+        aws_secret
+            .get("secret-access-key")
+            .context(
+                failure_resources,
+                format!(
+                    "secret-access-key missing from secret '{}'",
+                    aws_secret_name
+                ),
+            )?
+            .to_owned(),
+    )
+    .context(
+        Resources::Clear,
+        "Could not convert secret-access-key to String",
+    )?;
+
+    env::set_var("AWS_ACCESS_KEY_ID", access_key_id);
+    env::set_var("AWS_SECRET_ACCESS_KEY", secret_access_key);
+
+    Ok(())
+}
+
+pub struct EksDestroyer {}
+
+#[async_trait::async_trait]
+impl Destroy for EksDestroyer {
+    type Request = ClusterConfig;
+    type Info = ProductionMemo;
+    type Resource = CreatedCluster;
+
+    async fn destroy<I>(
+        &self,
+        _request: Option<Spec<Self::Request>>,
+        _resource: Option<Self::Resource>,
+        client: &I,
+    ) -> ProviderResult<()>
+    where
+        I: InfoClient,
+    {
+        let mut memo: ProductionMemo = client
+            .get_info()
+            .await
+            .context(Resources::Remaining, "Unable to get info from client")?;
+
+        if let Some(cluster_name) = &memo.cluster_name {
+            // Write aws credentials if we need them so we can run eksctl
+            if let Some(aws_secret_name) = &memo.aws_secret_name {
+                setup_env(client, aws_secret_name, Resources::Remaining).await?;
+            }
+            let region = memo.clone().region.unwrap_or(DEFAULT_REGION.to_string());
+            let status = Command::new("eksctl")
+                .args(["delete", "cluster", "--name", &cluster_name, "-r", &region])
+                .status()
+                .context(Resources::Remaining, "Failed to run eksctl delete command")?;
+            if !status.success() {
+                return Err(ProviderError::new_with_context(
+                    Resources::Orphaned,
+                    format!("Failed to delete cluster with status code {}", status),
+                ));
+            }
+        }
+
+        memo.current_status = "Cluster deleted".into();
+        if let Err(e) = client.send_info(memo.clone()).await {
+            eprintln!(
+                "Cluster deleted but failed to send info message to k8s: {}",
+                e
+            )
+        }
+
+        Ok(())
+    }
+}

--- a/model/src/clients/resource_client.rs
+++ b/model/src/clients/resource_client.rs
@@ -58,6 +58,7 @@ impl ResourceClient {
             None => return Ok(R::default()),
             Some(some) => some,
         };
+        // Add test results here.
         Ok(R::from_map(map).context(error::ConfigSerde)?)
     }
 

--- a/testsys/tests/data/resource-test.yaml
+++ b/testsys/tests/data/resource-test.yaml
@@ -13,4 +13,4 @@ spec:
       person: Bones the Cat
       hello_count: 3
       hello_duration_milliseconds: 500
-  resources: [ec2]
+  resources: [eks]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #41 


**Description of changes:**
Adds a resource provider for spinning up an eks cluster using eksctl.


**Testing done:**
Tested the resource as a test dependency and can see the created cluster on aws console.

```
pullenep@88665a468558 bottlerocket-test-system % kubectl get pods -n testsys-bottlerocket-aws
NAME                                  READY   STATUS      RESTARTS   AGE
eks-creation-skgg6                    0/1     Completed   0          22m
hello-bones-r7xtm                     1/1     Running     0          3m38s
testsys-controller-56dcddd4c6-fdgdv   1/1     Running     0          22m
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
