### PR TITLE
controller: mount agent secrets

### DIFF
--- a/model/src/agent.rs
+++ b/model/src/agent.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use snafu::ensure;
 use std::borrow::Borrow;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Deref;
@@ -47,6 +47,15 @@ pub struct Agent {
     /// use it, and `SecretName` is provided by the user. `SecretName` is constrained to ascii
     /// alphanumerics plus underscores and dashes.
     pub secrets: Option<BTreeMap<SecretType, SecretName>>,
+}
+
+impl Agent {
+    pub fn secret_names(&self) -> BTreeSet<&SecretName> {
+        self.secrets
+            .as_ref()
+            .map(|secrets_map| secrets_map.values().collect::<BTreeSet<&SecretName>>())
+            .unwrap_or_default()
+    }
 }
 
 /// The type of a secret, as defined and required by an agent. Possible examples: `foo-credentials`,

--- a/model/src/constants.rs
+++ b/model/src/constants.rs
@@ -38,6 +38,9 @@ pub const ENV_RESOURCE_ACTION: &str = "TESTSYS_RESOURCE_ACTION";
 pub const ENV_RESOURCE_NAME: &str = "TESTSYS_RESOURCE_NAME";
 pub const ENV_TEST_NAME: &str = "TESTSYS_TEST_NAME";
 
+// Paths
+pub const SECRETS_PATH: &str = "/secrets";
+
 // Standard tags https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 pub const APP_NAME: &str = "app.kubernetes.io/name";
 pub const APP_INSTANCE: &str = "app.kubernetes.io/instance";


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #124

**Description of changes:**

```
When running test-agent and resource-agent pods, mount the specified
agent secrets to the container filesystem.
```

**Testing done:**

Switched the example test agent to `ubuntu` instead of `scratch`.

Created secrets like this:

```sh
kubectl create secret generic mysecret1 --from-literal=key1=value1 --from-literal=key2=value2
kubectl create secret generic mysecret2 --from-literal=key1=value1 --from-literal=key2=value2
kubectl create secret generic mysecret3 --from-literal=username=bar --from-literal 'password===='
```

Created a test like this:

```yaml
apiVersion: testsys.bottlerocket.aws/v1
kind: Test
metadata:
  name: robot-hello-test
  namespace: testsys-bottlerocket-aws
  labels:
    testsys.bottlerocket.aws/test-name: robot-hello-test
spec:
  agent:
    name: hello-agent
    image: "example-testsys-agent:bones"
    configuration:
      mode: Fast
      person: Bones the Cat
      hello_count: 1000
      hello_duration_milliseconds: 30000
    secrets:
      serious-secret: mysecret1
      silly-secret: mysecret2
      honest-secret: mysecret3
      repeated-secret: mysecret3
    keep_running: false
  resources:
    - three-robots
```

Attached to the running pod with:

```sh
root@robot-hello-test-cpdkk:/# cd /secrets
```

Inspected the filesystem:

```
root@robot-hello-test-cpdkk:/secrets# ls -al
total 8
drwxr-xr-x 5 root root 4096 Oct 28 18:44 .
drwxr-xr-x 1 root root 4096 Oct 28 18:44 ..
drwxrwxrwt 3 root root  120 Oct 28 18:44 mysecret1
drwxrwxrwt 3 root root  120 Oct 28 18:44 mysecret2
drwxrwxrwt 3 root root  120 Oct 28 18:44 mysecret3
```

```
root@robot-hello-test-cpdkk:/secrets# tree
.
|-- mysecret1
|   |-- key1 -> ..data/key1
|   `-- key2 -> ..data/key2
|-- mysecret2
|   |-- key1 -> ..data/key1
|   `-- key2 -> ..data/key2
`-- mysecret3
    |-- password -> ..data/password
    `-- username -> ..data/username
```

```
root@robot-hello-test-cpdkk:/# cat /secrets/mysecret3/password
===
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
