### PR TITLE
controller: timeout for image pull error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "kube-runtime",
+ "lazy_static",
  "log",
  "model",
  "schemars",

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -13,6 +13,7 @@ http = "0"
 k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_20"] }
 kube = { version = "0.59.0", default-features = true, features = [ "derive"] }
 kube-runtime = "0.59.0"
+lazy_static = "1"
 log = "0.4"
 model = { path = "../model" }
 schemars = "0.8"

--- a/controller/src/resource_controller/mod.rs
+++ b/controller/src/resource_controller/mod.rs
@@ -152,6 +152,7 @@ async fn handle_error_state(r: &ResourceInterface, a: ResourceAction, e: ErrorSt
         },
         r.name(),
         match e {
+            ErrorState::JobStart => "Timeout before resource started",
             ErrorState::JobExited => "Container exited before it was done",
             ErrorState::JobFailed => "Container exited with an error",
             ErrorState::JobRemoved => "Container was killed before it was done",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #76 
Closes #77 


**Description of changes:**
Adds a check in action.rs to determine the time since a job was created. If the test has not reached a running state after `MAX_TEST_START_TIME` the controller considers the test a failed test.


**Testing done:**
Tested on a testsys test with a non-existing image and logs show that the test failed.
```
[2021-10-29T17:04:25Z TRACE controller::test_controller::action] Test 'hello-bones' is running
[2021-10-29T17:04:25Z TRACE controller::test_controller::reconcile] action WaitForTest
[2021-10-29T17:04:30Z TRACE controller::test_controller::action] Test 'hello-bones' is running
[2021-10-29T17:04:30Z TRACE controller::test_controller::reconcile] action WaitForTest
[2021-10-29T17:04:35Z TRACE controller::test_controller::action] Test 'hello-bones' failed to reach running state within time limit
[2021-10-29T17:04:35Z TRACE controller::test_controller::reconcile] action Error(JobFailure)
[2021-10-29T17:04:35Z ERROR controller::test_controller::reconcile] Error state for test 'hello-bones': The job failed
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
