### PR TITLE
build: use buildkit cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ TOP := $(dir $(firstword $(MAKEFILE_LIST)))
 UNAME_ARCH=$(shell uname -m)
 ARCH ?= $(lastword $(subst :, ,$(filter $(UNAME_ARCH):%,x86_64:amd64 aarch64:arm64)))
 
+export DOCKER_BUILDKIT=1
 export CARGO_HOME = $(TOP)/.cargo
 
 # Fetches crates from upstream

--- a/agent/resource-agent/examples/example_resource_agent/Dockerfile
+++ b/agent/resource-agent/examples/example_resource_agent/Dockerfile
@@ -10,7 +10,8 @@ ENV CARGO_HOME=/src/.cargo
 ENV OPENSSL_STATIC=true
 ADD ./ /src/
 WORKDIR /src/agent/resource-agent
-RUN cargo install --offline --locked --target ${ARCH}-bottlerocket-linux-musl --path . --example example_resource_agent --root ./
+RUN --mount=type=cache,mode=0777,target=/src/target \
+    cargo install --offline --locked --target ${ARCH}-bottlerocket-linux-musl --path . --example example_resource_agent --root ./
 
 FROM scratch
 # Copy CA certificates store

--- a/agent/sonobuoy-test-agent/Dockerfile
+++ b/agent/sonobuoy-test-agent/Dockerfile
@@ -10,7 +10,8 @@ ENV CARGO_HOME=/src/.cargo
 ENV OPENSSL_STATIC=true
 ADD ./ /src/
 WORKDIR /src/agent/sonobuoy-test-agent
-RUN cargo install --offline --locked --target ${UNAME_ARCH}-bottlerocket-linux-musl --path . --root ./
+RUN --mount=type=cache,mode=0777,target=/src/target \
+    cargo install --offline --locked --target ${UNAME_ARCH}-bottlerocket-linux-musl --path . --root ./
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
 ARG ARCH

--- a/agent/test-agent/examples/example_test_agent/Dockerfile
+++ b/agent/test-agent/examples/example_test_agent/Dockerfile
@@ -10,7 +10,8 @@ ENV CARGO_HOME=/src/.cargo
 ENV OPENSSL_STATIC=true
 ADD ./ /src/
 WORKDIR /src/agent/test-agent
-RUN cargo install --offline --locked --target ${ARCH}-bottlerocket-linux-musl --path . --example example_test_agent --root ./
+RUN --mount=type=cache,mode=0777,target=/src/target \
+    cargo install --offline --locked --target ${ARCH}-bottlerocket-linux-musl --path . --example example_test_agent --root ./
 
 FROM scratch
 # Copy CA certificates store

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -10,7 +10,8 @@ ENV CARGO_HOME=/src/.cargo
 ENV OPENSSL_STATIC=true
 ADD ./ /src/
 WORKDIR /src/controller
-RUN cargo install --offline --locked --target ${ARCH}-bottlerocket-linux-musl --path . --root ./
+RUN --mount=type=cache,mode=0777,target=/src/target \
+    cargo install --offline --locked --target ${ARCH}-bottlerocket-linux-musl --path . --root ./
 
 FROM scratch
 # Copy CA certificates store


### PR DESCRIPTION

**Issue number:**

Closes #126

**Description of changes:**

```
Speed up container image builds with a buildkit cache. This allows
subsequent builds of a container image to use the /target directory
from a previous build of the same image. Thus the build becomes
incremental instead of rebuilding all dependencies.
```

**Testing done:**

Without these changes, making any code edit results in the recompilation of all dependencies/modules, etc. With these changes, a subsequent build becomes incremental.

Controller build without cache:

- First build: `[+] Building 160.0s (15/15) FINISHED`
- Add a `println` somewhere
- Second build: `[+] Building 147.0s (14/14) FINISHED`

Controller build with cache:
- First build: `[+] Building 160.0s (15/15) FINISHED`
- Add a `println` somewhere
- Second build: `[+] Building 27.8s (13/13) FINISHED`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
