### PR TITLE
agent: pass information from resource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,6 +1236,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "derive_more",
+ "futures",
  "json-patch",
  "k8s-openapi",
  "kube",

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,13 @@ example-resource-agent-image: fetch
 		--network none \
 		-f agent/resource-agent/examples/example_resource_agent/Dockerfile .
 
+duplicator-resource-agent-image: fetch
+	docker build $(DOCKER_BUILD_FLAGS) \
+		--build-arg ARCH="$(UNAME_ARCH)" \
+		--tag "duplicator-resource-agent" \
+		--network none \
+		-f agent/resource-agent/examples/duplicator_resource_agent/Dockerfile .
+
 eks-resource-agent-image: fetch
 	docker build $(DOCKER_BUILD_FLAGS) \
 		--build-arg ARCH="$(UNAME_ARCH)" \

--- a/agent/resource-agent/examples/duplicator_resource_agent/Dockerfile
+++ b/agent/resource-agent/examples/duplicator_resource_agent/Dockerfile
@@ -1,0 +1,23 @@
+ARG ARCH
+FROM public.ecr.aws/bottlerocket/bottlerocket-sdk-${ARCH}:v0.23.0 as build
+
+ARG ARCH
+USER root
+# We need these environment variables set for building the `openssl-sys` crate
+ENV PKG_CONFIG_PATH=/${ARCH}-bottlerocket-linux-musl/sys-root/usr/lib/pkgconfig
+ENV PKG_CONFIG_ALLOW_CROSS=1
+ENV CARGO_HOME=/src/.cargo
+ENV OPENSSL_STATIC=true
+ADD ./ /src/
+WORKDIR /src/agent/resource-agent
+RUN --mount=type=cache,mode=0777,target=/src/target \
+    cargo install --offline --locked --target ${ARCH}-bottlerocket-linux-musl --path . --example duplicator_resource_agent --root ./
+
+FROM scratch
+# Copy CA certificates store
+COPY --from=build /etc/ssl /etc/ssl
+COPY --from=build /etc/pki /etc/pki
+# Copy binary
+COPY --from=build /src/agent/resource-agent/bin/duplicator_resource_agent ./
+
+ENTRYPOINT ["./duplicator_resource_agent"]

--- a/agent/resource-agent/examples/duplicator_resource_agent/main.rs
+++ b/agent/resource-agent/examples/duplicator_resource_agent/main.rs
@@ -1,0 +1,67 @@
+/*!
+
+This program takes its input (the "spec") and writes it to its output (the "created resource"). The
+purpose of this program is to test the resources that depend on other resources for their inputs,
+and tests that depend on resources for their inputs.
+
+!*/
+
+mod provider;
+
+use crate::provider::{DuplicationCreator, DuplicationDestroyer};
+use env_logger::Builder;
+use log::LevelFilter;
+use resource_agent::clients::{DefaultAgentClient, DefaultInfoClient};
+use resource_agent::error::AgentResult;
+use resource_agent::{Agent, BootstrapData, Types};
+use std::marker::PhantomData;
+
+#[tokio::main]
+async fn main() {
+    init_logger();
+    // This will get information that is provided to the container by the TestSys controller.
+    let data = match BootstrapData::from_env() {
+        Ok(ok) => ok,
+        Err(e) => {
+            eprintln!("Unable to get bootstrap data: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    // Pass the bootstrap data to a run function.
+    if let Err(e) = run(data).await {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    };
+}
+
+async fn run(data: BootstrapData) -> AgentResult<()> {
+    // We specify all of our custom types with this PhantomData struct.
+    let types = Types {
+        info_client: PhantomData::<DefaultInfoClient>::default(),
+        agent_client: PhantomData::<DefaultAgentClient>::default(),
+    };
+
+    // We build the agent component and use it to either create or destroy resources.
+    let agent = Agent::new(types, data, DuplicationCreator {}, DuplicationDestroyer {}).await?;
+    agent.run().await
+}
+
+/// Extract the value of `RUST_LOG` if it exists, otherwise log this crate at
+/// `DEFAULT_LEVEL_FILTER`.
+fn init_logger() {
+    match std::env::var(env_logger::DEFAULT_FILTER_ENV).ok() {
+        Some(_) => {
+            // RUST_LOG exists; env_logger will use it.
+            Builder::from_default_env().init();
+        }
+        None => {
+            // RUST_LOG does not exist; use default log level for this crate only.
+            Builder::new()
+                .filter(Some(env!("CARGO_CRATE_NAME")), LevelFilter::Trace)
+                .filter(Some("resource_agent"), LevelFilter::Trace)
+                .filter(Some("model"), LevelFilter::Trace)
+                .init();
+        }
+    }
+}

--- a/agent/resource-agent/examples/duplicator_resource_agent/provider.rs
+++ b/agent/resource-agent/examples/duplicator_resource_agent/provider.rs
@@ -1,0 +1,77 @@
+/*!
+ *
+This program takes its input (the "spec") and writes it to its output (the "created resource"). The
+purpose of this program is to test the resources that depend on other resources for their inputs,
+and tests that depend on resources for their inputs.
+
+!*/
+
+use model::Configuration;
+use resource_agent::clients::InfoClient;
+use resource_agent::provider::{Create, Destroy, ProviderResult, Spec};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Memo {}
+
+impl Configuration for Memo {}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct DuplicationRequest {
+    /// The info that will be copied to `DuplicatedData`.
+    pub info: Value,
+}
+
+impl Configuration for DuplicationRequest {}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct DuplicatedData {
+    /// The info we have duplicated.
+    info: Value,
+}
+
+impl Configuration for DuplicatedData {}
+
+pub struct DuplicationCreator {}
+
+#[async_trait::async_trait]
+impl Create for DuplicationCreator {
+    type Info = Memo;
+    type Request = DuplicationRequest;
+    type Resource = DuplicatedData;
+
+    async fn create<I>(
+        &self,
+        request: Spec<Self::Request>,
+        _client: &I,
+    ) -> ProviderResult<Self::Resource>
+    where
+        I: InfoClient,
+    {
+        Ok(DuplicatedData {
+            info: request.configuration.info.clone(),
+        })
+    }
+}
+
+pub struct DuplicationDestroyer {}
+#[async_trait::async_trait]
+impl Destroy for DuplicationDestroyer {
+    type Request = DuplicationRequest;
+    type Info = Memo;
+    type Resource = DuplicatedData;
+
+    async fn destroy<I>(
+        &self,
+        _request: Option<Spec<Self::Request>>,
+        _resource: Option<Self::Resource>,
+        _client: &I,
+    ) -> ProviderResult<()>
+    where
+        I: InfoClient,
+    {
+        // Nothing to destroy.
+        Ok(())
+    }
+}

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 async-trait = "0.1"
 derive_more = { version = "0", default-features = false, features = [ "error" ] }
+futures = "0.3"
 json-patch = "0.2"
 # k8s-openapi must match the version required by kube and enable a k8s version feature
 k8s-openapi = { version = "0.13.0", default-features = false, features = ["v1_20"] }

--- a/model/src/clients/error.rs
+++ b/model/src/clients/error.rs
@@ -15,6 +15,9 @@ pub(crate) enum InnerError {
     #[snafu(display("{}", source))]
     ConfigSerde { source: ModelError },
 
+    #[snafu(display("An error occured while resolving the config: {}", what))]
+    ConfigResolution { what: String },
+
     #[snafu(display("Error serializing object '{}': {}", what, source))]
     Serde {
         what: String,

--- a/model/src/resource.rs
+++ b/model/src/resource.rs
@@ -28,6 +28,13 @@ pub struct ResourceSpec {
 }
 
 impl Resource {
+    /// Gets the information for the resource created.
+    pub fn created_resource(&self) -> Option<&Map<String, Value>> {
+        self.status
+            .as_ref()
+            .and_then(|s| s.created_resource.as_ref())
+    }
+
     /// Gets the error that occurred during resource creation (if any).
     pub fn creation_error(&self) -> Option<&ResourceError> {
         self.status.as_ref().and_then(|s| s.creation.error.as_ref())

--- a/model/src/system/agent.rs
+++ b/model/src/system/agent.rs
@@ -97,7 +97,7 @@ impl AgentType {
         let managed_status = format!("{}/status", managed_resource);
 
         // TODO - make two policy rules, remove patch/update for `managed_resource` (i.e. status only)
-        vec![PolicyRule {
+        let mut policy_rules = vec![PolicyRule {
             api_groups: Some(vec![TESTSYS.to_string()]),
             resources: Some(vec![managed_resource, managed_status]),
             verbs: vec!["get", "list", "patch", "update", "watch"]
@@ -105,6 +105,20 @@ impl AgentType {
                 .map(|s| s.to_string())
                 .collect(),
             ..Default::default()
-        }]
+        }];
+
+        // We need to give the test agent the ability to get a resource's result.
+        if matches!(self, &AgentType::Test) {
+            policy_rules.push(PolicyRule {
+                api_groups: Some(vec![TESTSYS.to_string()]),
+                resources: Some(vec![AgentType::Resource
+                    .managed_resource_plural_name()
+                    .to_string()]),
+                verbs: vec!["get".to_string()],
+                ..Default::default()
+            })
+        }
+
+        policy_rules
     }
 }

--- a/testsys/tests/data/template-test.yaml
+++ b/testsys/tests/data/template-test.yaml
@@ -1,0 +1,16 @@
+apiVersion: testsys.bottlerocket.aws/v1
+kind: Test
+metadata:
+  name: hello-bones
+  namespace: testsys-bottlerocket-aws
+spec:
+  agent:
+    name: hello-agent
+    image: "example-testsys-agent:integ"
+    keep_running: false
+    configuration:
+      mode: Fast
+      person: Bones the Cat
+      hello_count: ${dup1.info}
+      hello_duration_milliseconds: 500
+  resources: [dup1]

--- a/yamlgen/deploy/testsys-agent.yaml
+++ b/yamlgen/deploy/testsys-agent.yaml
@@ -31,6 +31,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - testsys.bottlerocket.aws
+    resources:
+      - resources
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #36


**Description of changes:**
Allows templating to pass information from a resource's results to a test's config. In the example below, the value from the resource `dup1`'s info field is used as `hello_count` in this test.
```
apiVersion: testsys.bottlerocket.aws/v1
kind: Test
metadata:
  name: hello-bones
  namespace: testsys-bottlerocket-aws
spec:
  agent:
    name: hello-agent
    image: "example-testsys-agent:integ"
    keep_running: false
    configuration:
      mode: Fast
      person: Bones the Cat
      hello_count: ${dup1.info}
      hello_duration_milliseconds: 500
  resources: [dup1]
```

**Testing done:**
Created a duplication agent that duplicates any `json::Value` to its result field and ran with the above agent. In the end both tests successfully completed.
```
pullenep@88665a468558 bottlerocket-test-system % kubectl -n testsys-bottlerocket-aws get pods
NAME                                  READY   STATUS      RESTARTS   AGE
dup1-creation-p4dm2                   0/1     Completed   0          13s
hello-bones-jxqrv                     0/1     Completed   0          8s
testsys-controller-56dcddd4c6-7jqlq   1/1     Running     0          23s
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
