### PR TITLE
build: rename arch variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
 TOP := $(dir $(firstword $(MAKEFILE_LIST)))
 
-.PHONY: build sdk-openssl example-test-agent-image example-resource-agent-image controller-image images sonobuoy-test-agent-image integ-test ec2-resource-agent-image eks-resource-agent-image
+.PHONY: build sdk-openssl example-test-agent-image example-resource-agent-image controller-image images sonobuoy-test-agent-image integ-test ec2-resource-agent-image eks-resource-agent-image show-variables
 
-UNAME_ARCH=$(shell uname -m)
-ARCH ?= $(lastword $(subst :, ,$(filter $(UNAME_ARCH):%,x86_64:amd64 aarch64:arm64)))
+TESTSYS_BUILD_HOST_UNAME_ARCH=$(shell uname -m)
+TESTSYS_BUILD_HOST_GOARCH ?= $(lastword $(subst :, ,$(filter $(TESTSYS_BUILD_HOST_UNAME_ARCH):%,x86_64:amd64 aarch64:arm64)))
 
 export DOCKER_BUILDKIT=1
 export CARGO_HOME = $(TOP)/.cargo
+
+show-variables:
+	$(info TESTSYS_BUILD_HOST_UNAME_ARCH=$(TESTSYS_BUILD_HOST_UNAME_ARCH))
+	$(info TESTSYS_BUILD_HOST_GOARCH=$(TESTSYS_BUILD_HOST_GOARCH))
+	 @echo > /dev/null
 
 # Fetches crates from upstream
 fetch:
@@ -22,54 +27,54 @@ build: fetch
 	cargo test --locked
 
 # Build the container image for the example test-agent program
-example-test-agent-image: fetch
+example-test-agent-image: show-variables fetch
 	docker build $(DOCKER_BUILD_FLAGS) \
-		--build-arg ARCH="$(UNAME_ARCH)" \
+		--build-arg ARCH="$(TESTSYS_BUILD_HOST_UNAME_ARCH)" \
 		--tag "example-testsys-agent" \
 		--network none \
 		-f agent/test-agent/examples/example_test_agent/Dockerfile .
 
 # Build the container image for the example resource-agent program
-example-resource-agent-image: fetch
+example-resource-agent-image: show-variables fetch
 	docker build $(DOCKER_BUILD_FLAGS) \
-		--build-arg ARCH="$(UNAME_ARCH)" \
+		--build-arg ARCH="$(TESTSYS_BUILD_HOST_UNAME_ARCH)" \
 		--tag "example-resource-agent" \
 		--network none \
 		-f agent/resource-agent/examples/example_resource_agent/Dockerfile .
 
-duplicator-resource-agent-image: fetch
+duplicator-resource-agent-image: show-variables fetch
 	docker build $(DOCKER_BUILD_FLAGS) \
-		--build-arg ARCH="$(UNAME_ARCH)" \
+		--build-arg ARCH="$(TESTSYS_BUILD_HOST_UNAME_ARCH)" \
 		--tag "duplicator-resource-agent" \
 		--network none \
 		-f agent/resource-agent/examples/duplicator_resource_agent/Dockerfile .
 
-eks-resource-agent-image: fetch
+eks-resource-agent-image: show-variables fetch
 	docker build $(DOCKER_BUILD_FLAGS) \
-		--build-arg ARCH="$(UNAME_ARCH)" \
+		--build-arg ARCH="$(TESTSYS_BUILD_HOST_UNAME_ARCH)" \
 		--tag "eks-resource-agent" \
 		-f agent/eks-resource-agent/Dockerfile .
 
-controller-image: fetch
+controller-image: show-variables fetch
 	docker build $(DOCKER_BUILD_FLAGS) \
-		--build-arg ARCH="$(UNAME_ARCH)" \
+		--build-arg ARCH="$(TESTSYS_BUILD_HOST_UNAME_ARCH)" \
 		--tag "testsys-controller" \
 		-f controller/Dockerfile .
 
-sonobuoy-test-agent-image: fetch
+sonobuoy-test-agent-image: show-variables fetch
 	docker build $(DOCKER_BUILD_FLAGS) \
-		--build-arg UNAME_ARCH="$(UNAME_ARCH)" \
-		--build-arg ARCH="$(ARCH)" \
+		--build-arg UNAME_ARCH="$(TESTSYS_BUILD_HOST_UNAME_ARCH)" \
+		--build-arg GOARCH="$(TESTSYS_BUILD_HOST_GOARCH)" \
 		--tag "sonobuoy-test-agent" \
 		-f agent/sonobuoy-test-agent/Dockerfile .
 
-ec2-resource-agent-image: fetch
+ec2-resource-agent-image: show-variables fetch
 	docker build $(DOCKER_BUILD_FLAGS) \
-		--build-arg ARCH="$(UNAME_ARCH)" \
+		--build-arg ARCH="$(TESTSYS_BUILD_HOST_UNAME_ARCH)" \
 		--tag "ec2-resource-agent" \
 		-f agent/ec2-resource-agent/Dockerfile .
 
-integ-test: fetch controller-image example-test-agent-image example-resource-agent-image sonobuoy-test-agent-image
+integ-test: controller-image example-test-agent-image example-resource-agent-image sonobuoy-test-agent-image
 	docker tag example-testsys-agent example-testsys-agent:integ
 	docker tag testsys-controller testsys-controller:integ
 	docker tag example-resource-agent example-resource-agent:integ

--- a/agent/sonobuoy-test-agent/Dockerfile
+++ b/agent/sonobuoy-test-agent/Dockerfile
@@ -14,10 +14,10 @@ RUN --mount=type=cache,mode=0777,target=/src/target \
     cargo install --offline --locked --target ${UNAME_ARCH}-bottlerocket-linux-musl --path . --root ./
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
-ARG ARCH
+ARG GOARCH
 ARG SONOBUOY_VERSION=0.53.2
-ARG SONOBUOY_URL=https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_${ARCH}.tar.gz
-ARG AWS_IAM_AUTHENTICATOR_URL=https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/${ARCH}/aws-iam-authenticator
+ARG SONOBUOY_URL=https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_${GOARCH}.tar.gz
+ARG AWS_IAM_AUTHENTICATOR_URL=https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/${GOARCH}/aws-iam-authenticator
 RUN yum install -y tar gzip && yum clean all
 
 # Download aws-iam-authenticator


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

```
    build: rename arch variables

    I spent a bunch of time figuring out why the Sonobuoy build was not
    working and it turned out to be because some other script of mine had
    put the variable ARCH into my environment. Here I rename the Makefile
    variables UNAME_ARCH and ARCH to TESTSYS_BUILD_HOST_UNAME_ARCH and
    TESTSYS_BUILD_HOST_GOARCH respectively.

    GOARCH is used to reflect that the less-common amd64 and arm64
    designations exist in our build because aws-iam-authenticator is a Go
    program (and presumably this is why they use the GOARCH values when
    publishing).

    I also added a printout of these variables to image builds to hopefully
    help future me when our build is broken again for some future reason.
```


**Testing done:**

Ran container builds via the Makefile.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
