### PR TITLE
resource-agent: ec2 polling and backup for termination (4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,7 @@ dependencies = [
  "resource-agent",
  "serde",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -2350,6 +2351,16 @@ name = "urlencoding"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a1f0175e03a0973cf4afd476bef05c26e228520400eb1fd473ad417b1c00ffb"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+ "serde",
+]
 
 [[package]]
 name = "vcpkg"

--- a/agent/ec2-resource-agent/Cargo.toml
+++ b/agent/ec2-resource-agent/Cargo.toml
@@ -12,3 +12,4 @@ model = { path = "../../model" }
 resource-agent = { path = "../resource-agent" }
 serde = { version = "1", features = [ "derive" ] }
 tokio = { version = "1", default-features = false, features = [ "macros", "rt-multi-thread" ] }
+uuid = { version = "0.8", default-features=false, features = ["serde", "v4"] }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #148
Closes #147 


**Description of changes:**
Adds a check to make sure the created ec2 instances reach the running state before the resource is considered created. Adds a check to make sure the deleted ec2 instances reach the terminated state before the resource is considered deleted.
Adds a tag containing a uuid that is sent once the agent starts. At any point if the program fails, we can use the uuid to check for instances that need to be terminated.


**Testing done:**
Ran the ec2 resource provider as presented, instances are created and then cleaned up.
Altered the timeout so that the creation could not be completed in time and the pod errored.
Altered the timeout so termination didn't have time to complete and the pod errored.
Created ec2 instances, then used `kubectl edit` to remove all references of instance ids leaving only the uuid to identify the instances, and the instances are successfully deleted.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
