### PR TITLE
controller: wait for resource dependencies

### DIFF
--- a/controller/src/resource_controller/mod.rs
+++ b/controller/src/resource_controller/mod.rs
@@ -81,8 +81,15 @@ async fn do_creation_action(r: ResourceInterface, action: CreationAction) -> Res
                 .with_context(|| format!("Unable to creation job finalizer to '{}'", r.name()))?;
         }
         CreationAction::StartJob => r.start_job(ResourceAction::Create).await?,
-        CreationAction::Wait => {
-            trace!("waiting for resource creation")
+        CreationAction::WaitForCreation => {
+            debug!("waiting for creation of resource '{}'", r.name())
+        }
+        CreationAction::WaitForDependency(dependency) => {
+            debug!(
+                "'{}' is waiting for dependency '{}' to be created",
+                r.name(),
+                dependency
+            );
         }
         CreationAction::AddResourceFinalizer => {
             let _ = r

--- a/model/src/resource.rs
+++ b/model/src/resource.rs
@@ -23,6 +23,8 @@ use std::fmt::{Display, Formatter};
     version = "v1"
 )]
 pub struct ResourceSpec {
+    /// Other resources that must to be created before this one can be created.
+    pub depends_on: Option<Vec<String>>,
     /// Information about the resource agent.
     pub agent: Agent,
 }

--- a/yamlgen/deploy/testsys-crd.yaml
+++ b/yamlgen/deploy/testsys-crd.yaml
@@ -201,6 +201,12 @@ spec:
                     - keep_running
                     - name
                   type: object
+                depends_on:
+                  description: Other resources that must to be created before this one can be created.
+                  items:
+                    type: string
+                  nullable: true
+                  type: array
               required:
                 - agent
               type: object


### PR DESCRIPTION
**Issue number:**

Closes #122

**Description of changes:**

```
Adds a field named depends_on to the Resource CRD. The controller will
wait for resources named in this field to be created before proceeding
to create the current resource.
```

**Testing done:**

I ran the controller with these objects:

Resource A

```yaml
apiVersion: testsys.bottlerocket.aws/v1
kind: Resource
metadata:
  name: resource-a
  namespace: testsys-bottlerocket-aws
  labels:
    testsys.bottlerocket.aws/test-name: dependencies-test
spec:
  agent:
    name: duplicator
    image: "duplicator-resource-agent:bones"
    keep_running: false
    configuration:
      info:
        delay_milliseconds: 10000
        foo: bar
```

Resource B

```yaml
apiVersion: testsys.bottlerocket.aws/v1
kind: Resource
metadata:
  name: resource-b
  namespace: testsys-bottlerocket-aws
  labels:
    testsys.bottlerocket.aws/test-name: dependencies-test
spec:
  depends_on:
    - resource-a
  agent:
    name: duplicator
    image: "duplicator-resource-agent:bones"
    keep_running: false
    configuration:
      info:
        delay_milliseconds: 20000
        bar: baz
```

Resource C

```yaml
apiVersion: testsys.bottlerocket.aws/v1
kind: Resource
metadata:
  name: resource-c
  namespace: testsys-bottlerocket-aws
  labels:
    testsys.bottlerocket.aws/test-name: dependencies-test
spec:
  depends_on:
    - resource-b
  agent:
    name: duplicator
    image: "duplicator-resource-agent:bones"
    keep_running: false
    configuration:
      info:
        delay_milliseconds: 20000
        baz: bones
```

Test

```yaml
apiVersion: testsys.bottlerocket.aws/v1
kind: Test
metadata:
  name: simple-test
  namespace: testsys-bottlerocket-aws
  labels:
    testsys.bottlerocket.aws/test-name: simple-test
spec:
  agent:
    name: hello-agent
    image: "example-testsys-agent:bones"
    configuration:
      mode: Fast
      person: Bones the Cat
      hello_count: 1000
      hello_duration_milliseconds: 30000
    keep_running: false
  resources:
    - resource-a
    - resource-c

```

The controller created resources in the correct order, waiting for each to be created before the next. The test ran after all of it's stated resource dependencies were met. Here are some relevant traces:

```text
[2021-11-07T23:04:25Z DEBUG controller::resource_controller] 'resource-b' is waiting for dependency 'resource-a' to be created
[2021-11-07T23:04:25Z DEBUG controller::resource_controller] 'resource-c' is waiting for dependency 'resource-b' to be created
... later
[2021-11-07T23:04:50Z TRACE controller::resource_controller] Reconciling resource: resource-c
[2021-11-07T23:04:50Z TRACE controller::resource_controller] Action: Creation(Done)
... later
[2021-11-07T23:04:55Z TRACE controller::test_controller::reconcile] action StartTest
[2021-11-07T23:04:55Z DEBUG controller::test_controller::reconcile] Creating test job 'simple-test'
[2021-11-07T23:04:55Z TRACE controller::test_controller::action] Test 'simple-test' is running

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
