### PR TITLE
Adds `PreserveUnknownFields` to configuration for nested maps.

### DIFF
--- a/agent/test-agent/examples/example_test_agent/main.rs
+++ b/agent/test-agent/examples/example_test_agent/main.rs
@@ -31,6 +31,7 @@ spec:
 use async_trait::async_trait;
 use model::{Outcome, TestResults};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use test_agent::{BootstrapData, Configuration, TestInfo};
 use tokio::time::{sleep, Duration};
 
@@ -45,6 +46,12 @@ struct ExampleConfig {
     person: String,
     hello_count: u32,
     hello_duration_milliseconds: u32,
+    nested: Option<Nested>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct Nested {
+    data: Value,
 }
 
 impl Configuration for ExampleConfig {}
@@ -69,6 +76,9 @@ impl test_agent::Runner for ExampleTestRunner {
                 self.config.hello_duration_milliseconds.into(),
             ))
             .await
+        }
+        if let Some(nested) = &self.config.nested {
+            println!("Nested Data:\n {:?}", nested.data);
         }
         Ok(TestResults {
             outcome: Outcome::Pass,

--- a/model/src/agent.rs
+++ b/model/src/agent.rs
@@ -42,6 +42,7 @@ pub struct Agent {
     pub keep_running: bool,
     /// The configuration to pass to the agent. This is 'open' to allow agents to define their own
     /// schemas.
+    #[schemars(schema_with = "config_schema")]
     pub configuration: Option<Map<String, Value>>,
     /// A map of `SecretType` -> `SecretName` where `SecretType` is defined by the agent that will
     /// use it, and `SecretName` is provided by the user. `SecretName` is constrained to ascii
@@ -56,6 +57,21 @@ impl Agent {
             .map(|secrets_map| secrets_map.values().collect::<BTreeSet<&SecretName>>())
             .unwrap_or_default()
     }
+}
+
+pub fn config_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    let mut extensions = BTreeMap::<String, Value>::new();
+    extensions.insert("nullable".to_string(), Value::Bool(true));
+    extensions.insert(
+        "x-kubernetes-preserve-unknown-fields".to_string(),
+        Value::Bool(true),
+    );
+    let schema = SchemaObject {
+        instance_type: Some(InstanceType::Object.into()),
+        extensions,
+        ..SchemaObject::default()
+    };
+    schema.into()
 }
 
 /// The type of a secret, as defined and required by an agent. Possible examples: `foo-credentials`,

--- a/model/src/resource.rs
+++ b/model/src/resource.rs
@@ -1,4 +1,4 @@
-use crate::{Agent, CrdExt, TaskState};
+use crate::{agent::config_schema, Agent, CrdExt, TaskState};
 use core::option::Option;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::{CustomResource, Resource as Kresource};
@@ -150,9 +150,11 @@ pub struct ResourceStatus {
     pub destruction: ResourceAgentState,
 
     /// Open content to be used by the resource agent to store state.
+    #[schemars(schema_with = "config_schema")]
     pub agent_info: Option<Map<String, Value>>,
 
     /// A description of the resource that has been created by the resource agent.
+    #[schemars(schema_with = "config_schema")]
     pub created_resource: Option<Map<String, Value>>,
 }
 

--- a/testsys/tests/data/template-test.yaml
+++ b/testsys/tests/data/template-test.yaml
@@ -11,6 +11,8 @@ spec:
     configuration:
       mode: Fast
       person: Bones the Cat
-      hello_count: ${dup1.info}
+      hello_count: 3
       hello_duration_milliseconds: 500
+      nested: 
+        data: "Nested String"
   resources: [dup1]

--- a/yamlgen/deploy/testsys-crd.yaml
+++ b/yamlgen/deploy/testsys-crd.yaml
@@ -27,10 +27,10 @@ spec:
                   description: Information about the test agent.
                   properties:
                     configuration:
-                      additionalProperties: true
                       description: "The configuration to pass to the agent. This is 'open' to allow agents to define their own schemas."
                       nullable: true
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
                     image:
                       description: The URI of the agent container image.
                       type: string
@@ -54,6 +54,7 @@ spec:
                       nullable: true
                       type: object
                   required:
+                    - configuration
                     - image
                     - keep_running
                     - name
@@ -168,10 +169,10 @@ spec:
                   description: Information about the resource agent.
                   properties:
                     configuration:
-                      additionalProperties: true
                       description: "The configuration to pass to the agent. This is 'open' to allow agents to define their own schemas."
                       nullable: true
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
                     image:
                       description: The URI of the agent container image.
                       type: string
@@ -195,6 +196,7 @@ spec:
                       nullable: true
                       type: object
                   required:
+                    - configuration
                     - image
                     - keep_running
                     - name
@@ -207,15 +209,15 @@ spec:
               nullable: true
               properties:
                 agent_info:
-                  additionalProperties: true
                   description: Open content to be used by the resource agent to store state.
                   nullable: true
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 created_resource:
-                  additionalProperties: true
                   description: A description of the resource that has been created by the resource agent.
                   nullable: true
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 creation:
                   description: The state or the resource agent when creating resources.
                   properties:
@@ -281,6 +283,8 @@ spec:
                     - task_state
                   type: object
               required:
+                - agent_info
+                - created_resource
                 - creation
                 - destruction
               type: object


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #149 


**Description of changes:**

Fixes a bug where nested maps in configuration we not properly stored in k8s.

**Testing done:**
Updated `duplicator` agent to send the info request to ensure that storing nested data works. Added a nested field in `example-test-agent` to show that tests can now take nested configs.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
