### PR TITLE
creation results contains encoded kubeconfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,6 +658,7 @@ name = "eks-resource-agent"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64",
  "model",
  "resource-agent",
  "serde",

--- a/agent/eks-resource-agent/Cargo.toml
+++ b/agent/eks-resource-agent/Cargo.toml
@@ -5,6 +5,7 @@
 
  [dependencies]
  async-trait = "0.1"
+ base64 = "0.13.0"
  model = { path = "../../model" }
  resource-agent = { path = "../resource-agent" }
  serde = { version = "1", features = [ "derive" ] }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #153 


**Description of changes:**
The eks provider now reports the clusters encoded Kubeconfig.


**Testing done:**
Tested the eks provider and ensured the encoded kubeconfig was present upon completion.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
