### PR TITLE
sonobuoy-test-agent: add aws-cli to image

### DIFF
--- a/agent/sonobuoy-test-agent/Dockerfile
+++ b/agent/sonobuoy-test-agent/Dockerfile
@@ -15,16 +15,25 @@ RUN --mount=type=cache,mode=0777,target=/src/target \
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
 ARG GOARCH
+ARG UNAME_ARCH
 ARG SONOBUOY_VERSION=0.53.2
 ARG SONOBUOY_URL=https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_${GOARCH}.tar.gz
 ARG AWS_IAM_AUTHENTICATOR_URL=https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/${GOARCH}/aws-iam-authenticator
-RUN yum install -y tar gzip && yum clean all
+ARG AWS_CLI_URL=https://awscli.amazonaws.com/awscli-exe-linux-${UNAME_ARCH}.zip
+RUN yum install -y tar gzip unzip && yum clean all
 
 # Download aws-iam-authenticator
 RUN temp_dir="$(mktemp -d --suffix aws-iam-authenticator)" && \
     curl -fsSL "${AWS_IAM_AUTHENTICATOR_URL}" -o "${temp_dir}/${AWS_IAM_AUTHENTICATOR_URL##*/}" && \
     chmod 0755 "${temp_dir}/${AWS_IAM_AUTHENTICATOR_URL##*/}" && \
     mv "${temp_dir}/${AWS_IAM_AUTHENTICATOR_URL##*/}" /usr/bin/aws-iam-authenticator && \
+    rm -rf ${temp_dir}
+
+# Download aws-cli
+RUN temp_dir="$(mktemp -d --suffix aws-cli)" && \
+    curl -fsSL "${AWS_CLI_URL}" -o "${temp_dir}/awscliv2.zip" && \
+    unzip "${temp_dir}/awscliv2.zip" -d "${temp_dir}" && \
+    ${temp_dir}/aws/install && \
     rm -rf ${temp_dir}
 
 # Download sonobuoy


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Mon Nov 8 16:59:53 2021 -0800

    sonobuoy-test-agent: add aws-cli to image
    
    Adds aws-cli to the image for kubeconfigs that use aws-cli as the cred
    plugin instead of aws-iam-authenticator.

```


**Testing done:**
Image builds successfully.
I was able to invoke `aws` commands from a sonobuoy-test-image container.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
