### PR TITLE
test-agent: Adds secrets to sonobuoy test agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,6 +1918,7 @@ dependencies = [
 name = "sonobuoy-test-agent"
 version = "0.1.0"
 dependencies = [
+ "agent-common",
  "async-trait",
  "base64",
  "log",

--- a/agent/sonobuoy-test-agent/Cargo.toml
+++ b/agent/sonobuoy-test-agent/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+agent-common = { path = "../agent-common" }
 async-trait = "0.1"
 base64 = "0.13.0"
 log = "0.4"

--- a/agent/sonobuoy-test-agent/src/lib.rs
+++ b/agent/sonobuoy-test-agent/src/lib.rs
@@ -1,6 +1,8 @@
 use model::Configuration;
 use serde::{Deserialize, Serialize};
 
+pub const SONOBUOY_AWS_SECRET_NAME: &str = "aws_credentials";
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SonobuoyConfig {
     // FIXME: need a better way of passing test cluster information


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Sonobuoy test agent can now use secrets for aws authentication. `testsys run sonobuoy` now has the option for the aws-credentials secret name.


**Testing done:**
Ran sonobuoy test using testsys cli on an existing eks cluster.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
