### PR TITLE
controller: timeout to tests and resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "lazy_static",
  "log",
  "model",
+ "parse_duration",
  "schemars",
  "serde",
  "serde_json",
@@ -1253,6 +1254,7 @@ dependencies = [
  "lazy_static",
  "log",
  "maplit",
+ "parse_duration",
  "regex",
  "schemars",
  "selftest",
@@ -1297,12 +1299,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1371,6 +1431,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97c9d06878b3a851e8026ef94bf7fef9ba93062cd412601da4d9cf369b1cc62d"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "parse_duration"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7037e5e93e0172a5a96874380bf73bc6ecef022e26fa25f2be26864d6b3ba95d"
+dependencies = [
+ "lazy_static",
+ "num",
+ "regex",
 ]
 
 [[package]]

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -16,6 +16,7 @@ kube-runtime = "0.59.0"
 lazy_static = "1"
 log = "0.4"
 model = { path = "../model" }
+parse_duration = "2.1"
 schemars = "0.8"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"

--- a/controller/src/resource_controller/mod.rs
+++ b/controller/src/resource_controller/mod.rs
@@ -164,6 +164,7 @@ async fn handle_error_state(r: &ResourceInterface, a: ResourceAction, e: ErrorSt
             ErrorState::JobFailed => "Container exited with an error",
             ErrorState::JobRemoved => "Container was killed before it was done",
             ErrorState::TaskFailed => "Task failed",
+            ErrorState::JobTimeout => "Job did not complete within time limit",
             ErrorState::Zombie => {
                 warn!("Resource still exists after main finalizer was removed");
                 return Ok(());

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -16,6 +16,7 @@ kube = { version = "0.59.0", default-features = false, features = [ "derive", "j
 lazy_static = "1"
 log = "0.4"
 maplit = "1.0.2"
+parse_duration = "2.1"
 regex = "1"
 schemars = "0.8"
 serde = { version = "1", features = [ "derive" ] }

--- a/model/src/agent.rs
+++ b/model/src/agent.rs
@@ -40,6 +40,9 @@ pub struct Agent {
     pub pull_secret: Option<String>,
     /// Determine if the pod should keep running after it has finished or encountered and error.
     pub keep_running: bool,
+    /// The maximum amount of time an agent should be left to run.
+    #[schemars(schema_with = "timeout_schema")]
+    pub timeout: Option<String>,
     /// The configuration to pass to the agent. This is 'open' to allow agents to define their own
     /// schemas.
     #[schemars(schema_with = "config_schema")]
@@ -68,6 +71,24 @@ pub fn config_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema
     );
     let schema = SchemaObject {
         instance_type: Some(InstanceType::Object.into()),
+        extensions,
+        ..SchemaObject::default()
+    };
+    schema.into()
+}
+
+pub fn timeout_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    let mut extensions = BTreeMap::<String, Value>::new();
+    extensions.insert("nullable".to_string(), Value::Bool(true));
+    let schema = SchemaObject {
+        string: Some(Box::new(StringValidation {
+            max_length: Some(253),
+            min_length: Some(1),
+            pattern: Some(
+                r#"^((([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?|\d+)$"#.to_string(),
+            ),
+        })),
+        instance_type: Some(InstanceType::String.into()),
         extensions,
         ..SchemaObject::default()
     };

--- a/testsys/src/run_sonobuoy.rs
+++ b/testsys/src/run_sonobuoy.rs
@@ -97,6 +97,7 @@ impl RunSonobuoy {
                     image: self.image.clone(),
                     pull_secret: self.pull_secret.clone(),
                     keep_running: self.keep_running,
+                    timeout: None,
                     configuration: Some(
                         SonobuoyConfig {
                             kubeconfig_base64: kubeconfig_string,

--- a/yamlgen/deploy/testsys-crd.yaml
+++ b/yamlgen/deploy/testsys-crd.yaml
@@ -53,11 +53,19 @@ spec:
                       description: "A map of `SecretType` -> `SecretName` where `SecretType` is defined by the agent that will use it, and `SecretName` is provided by the user. `SecretName` is constrained to ascii alphanumerics plus underscores and dashes."
                       nullable: true
                       type: object
+                    timeout:
+                      description: The maximum amount of time an agent should be left to run.
+                      maxLength: 253
+                      minLength: 1
+                      nullable: true
+                      pattern: "^((([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?|\\d+)$"
+                      type: string
                   required:
                     - configuration
                     - image
                     - keep_running
                     - name
+                    - timeout
                   type: object
                 resources:
                   description: The list of resources required by this test. The test controller will wait for these resources to become ready before running the test agent.
@@ -195,11 +203,19 @@ spec:
                       description: "A map of `SecretType` -> `SecretName` where `SecretType` is defined by the agent that will use it, and `SecretName` is provided by the user. `SecretName` is constrained to ascii alphanumerics plus underscores and dashes."
                       nullable: true
                       type: object
+                    timeout:
+                      description: The maximum amount of time an agent should be left to run.
+                      maxLength: 253
+                      minLength: 1
+                      nullable: true
+                      pattern: "^((([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?|\\d+)$"
+                      type: string
                   required:
                     - configuration
                     - image
                     - keep_running
                     - name
+                    - timeout
                   type: object
                 depends_on:
                   description: Other resources that must to be created before this one can be created.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #130 


**Description of changes:**
Adds a field to agent for the timeout of the agent. If a job runs longer than the time limit the controller sets the action to Error.


**Testing done:**
Ran the example test agent with a timeout of 5 seconds and saw the error in the controller.
```
[2021-11-09T21:29:40Z TRACE controller::test_controller::reconcile] action Error(JobTimeout)
[2021-11-09T21:29:40Z ERROR controller::test_controller::reconcile] Error state for test 'hello-bones': The test agent did not finish within the specified time
```
Did the same thing with the duplicator agent and saw:
```
[2021-11-09T21:48:58Z TRACE controller::resource_controller] Reconciling resource: dup1
[2021-11-09T21:48:58Z TRACE controller::resource_controller] Action: Creation(Error(JobTimeout))
[2021-11-09T21:48:58Z ERROR controller::resource_controller] Creation error state for resource 'dup1': Job did not complete within time limit
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
