### PR TITLE
Ec2 eks config (2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,8 +650,6 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-ec2",
- "aws-sdk-eks",
- "aws-sdk-iam",
  "base64",
  "model",
  "resource-agent",
@@ -670,10 +668,16 @@ name = "eks-resource-agent"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "aws-config",
+ "aws-sdk-ec2",
+ "aws-sdk-eks",
+ "aws-sdk-iam",
  "base64",
+ "ec2-resource-agent",
  "model",
  "resource-agent",
  "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/agent/ec2-resource-agent/Cargo.toml
+++ b/agent/ec2-resource-agent/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2018"
 [dependencies]
 aws-config = "0.0.22-alpha"
 aws-sdk-ec2 = "0.0.22-alpha"
-aws-sdk-eks = "0.0.22-alpha"
-aws-sdk-iam = "0.0.22-alpha"
 async-trait = "0.1"
 base64 = "0.13.0"
 model = { path = "../../model" }

--- a/agent/ec2-resource-agent/src/lib.rs
+++ b/agent/ec2-resource-agent/src/lib.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+pub struct ClusterInfo {
+    pub name: String,
+    pub region: String,
+    pub endpoint: String,
+    pub certificate: String,
+    pub public_subnet_ids: Vec<String>,
+    pub private_subnet_ids: Vec<String>,
+    pub nodegroup_sg: Vec<String>,
+    pub controlplane_sg: Vec<String>,
+    pub clustershared_sg: Vec<String>,
+    pub iam_instance_profile_arn: String,
+}

--- a/agent/ec2-resource-agent/src/provider.rs
+++ b/agent/ec2-resource-agent/src/provider.rs
@@ -1,9 +1,10 @@
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_ec2::model::{
-    ArchitectureValues, Filter, IamInstanceProfileSpecification, InstanceType, ResourceType,
-    SecurityGroup, Subnet, Tag, TagSpecification,
+    ArchitectureValues, IamInstanceProfileSpecification, InstanceType, ResourceType, Tag,
+    TagSpecification,
 };
 use aws_sdk_ec2::Region;
+use ec2_resource_agent::ClusterInfo;
 use model::{Configuration, SecretName};
 use resource_agent::clients::InfoClient;
 use resource_agent::provider::{
@@ -15,8 +16,6 @@ use std::env;
 use std::fmt::Debug;
 use std::iter::FromIterator;
 
-/// The default region for the cluster.
-const DEFAULT_REGION: &str = "us-west-2";
 /// The default number of instances to spin up.
 const DEFAULT_INSTANCE_COUNT: i32 = 2;
 
@@ -42,12 +41,6 @@ pub struct Ec2ProductionRequest {
     /// The AMI ID of the AMI to use for the worker nodes.
     node_ami: String,
 
-    /// The name of the eks cluster to create the instances in.
-    cluster_name: String,
-
-    /// The AWS region to create the instance. If no value is provided `us-west-2` will be used.
-    region: Option<String>,
-
     /// The number of instances to create. If no value is provided 2 instances will be created.
     instance_count: Option<i32>,
 
@@ -55,8 +48,8 @@ pub struct Ec2ProductionRequest {
     /// recommended for arm64. If no value is provided the recommended type will be used.
     instance_type: Option<String>,
 
-    /// The arn of the instance profile.
-    instance_profile_name: Option<String>,
+    /// All of the cluster based information needed to run instances.
+    cluster: ClusterInfo,
 }
 
 impl Configuration for Ec2ProductionRequest {}
@@ -91,69 +84,24 @@ impl Create for Ec2Creator {
             .get_info()
             .await
             .context(Resources::Unknown, "Unable to get info from info client")?;
-        let region = request
-            .configuration
-            .region
-            .unwrap_or_else(|| DEFAULT_REGION.to_string());
-        // Setup aws_sdk_config and clients.
-        let region_provider = RegionProviderChain::first_try(Some(Region::new(region.clone())));
+
         // Write aws credentials if we need them so we can run eksctl
         if let Some(aws_secret_name) = request.secrets.get("aws-credentials") {
             setup_env(client, aws_secret_name, &memo).await?;
             memo.aws_secret_name = Some(aws_secret_name.clone());
         }
 
+        let cluster = &request.configuration.cluster;
+
+        // Setup aws_sdk_config and clients.
+        let region_provider =
+            RegionProviderChain::first_try(Some(Region::new(cluster.region.clone())));
         let shared_config = aws_config::from_env().region(region_provider).load().await;
-        let eks_client = aws_sdk_eks::Client::new(&shared_config);
         let ec2_client = aws_sdk_ec2::Client::new(&shared_config);
-        let iam_client = aws_sdk_iam::Client::new(&shared_config);
-
-        let cluster_name = &request.configuration.cluster_name;
-
-        let eks_subnet_ids = eks_subnet_ids(&eks_client, cluster_name, &memo).await?;
-        let endpoint = &endpoint(&eks_client, cluster_name, &memo).await?;
-        let certificate = &certificate(&eks_client, cluster_name, &memo).await?;
-
-        let private_subnet_ids = subnet_ids(
-            &ec2_client,
-            cluster_name,
-            eks_subnet_ids.clone(),
-            SubnetType::Private,
-            &memo,
-        )
-        .await?;
-
-        let nodegroup_sg = security_group(
-            &ec2_client,
-            cluster_name,
-            SecurityGroupType::NodeGroup,
-            &memo,
-        )
-        .await?;
-
-        let controlplane_sg = security_group(
-            &ec2_client,
-            cluster_name,
-            SecurityGroupType::ControlPlane,
-            &memo,
-        )
-        .await?;
 
         let mut security_groups = vec![];
-        for security_group in nodegroup_sg {
-            security_groups.push(
-                security_group
-                    .group_id
-                    .context(&memo, "Security group missing group_id field")?,
-            )
-        }
-        for security_group in controlplane_sg {
-            security_groups.push(
-                security_group
-                    .group_id
-                    .context(&memo, "Security group missing group_id field")?,
-            )
-        }
+        security_groups.append(&mut cluster.nodegroup_sg.clone());
+        security_groups.append(&mut cluster.clustershared_sg.clone());
 
         // Determine the instance type to use. If provided use that one. Otherwise, for `x86_64` use `m5.large`
         // and for `aarch64` use `m6g.large`
@@ -162,14 +110,6 @@ impl Create for Ec2Creator {
         } else {
             instance_type(&ec2_client, &request.configuration.node_ami, &memo).await?
         };
-
-        // Determine the instance profile name to use.
-        let instance_profile_name =
-            if let Some(instance_profile_name) = request.configuration.instance_profile_name {
-                instance_profile_name
-            } else {
-                instance_profile_name(&iam_client, &memo).await?
-            };
 
         // Run the ec2 instances
         let instance_count = request
@@ -180,15 +120,19 @@ impl Create for Ec2Creator {
             .run_instances()
             .min_count(instance_count)
             .max_count(instance_count)
-            .subnet_id(first_subnet_id(&private_subnet_ids, &memo)?)
+            .subnet_id(first_subnet_id(&cluster.private_subnet_ids, &memo)?)
             .set_security_group_ids(Some(security_groups))
             .image_id(request.configuration.node_ami)
             .instance_type(InstanceType::from(instance_type.as_str()))
-            .tag_specifications(tag_specifications(cluster_name))
-            .user_data(userdata(endpoint, cluster_name, certificate))
+            .tag_specifications(tag_specifications(&cluster.name))
+            .user_data(userdata(
+                &cluster.endpoint,
+                &cluster.name,
+                &cluster.certificate,
+            ))
             .iam_instance_profile(
                 IamInstanceProfileSpecification::builder()
-                    .name(instance_profile_name)
+                    .arn(&cluster.iam_instance_profile_arn)
                     .build(),
             );
 
@@ -210,13 +154,13 @@ impl Create for Ec2Creator {
 
         // We are done, set our custom status to say so.
         memo.current_status = "Instance(s) Created".into();
-        memo.region = region;
+        memo.region = cluster.region.clone();
         client
             .send_info(memo.clone())
             .await
             .context(memo, "Error sending final creation message")?;
 
-        // Return a description of the batch of robots that we created.
+        // Return a description of the batch of instances that we created.
         Ok(CreatedEc2Instances { ids: instance_ids })
     }
 }
@@ -264,165 +208,6 @@ where
     Ok(())
 }
 
-async fn eks_subnet_ids(
-    eks_client: &aws_sdk_eks::Client,
-    cluster_name: &str,
-    memo: &ProductionMemo,
-) -> ProviderResult<Vec<String>> {
-    let describe_results = eks_client
-        .describe_cluster()
-        .name(cluster_name)
-        .send()
-        .await
-        .context(memo, "Unable to get eks describe cluster")?;
-
-    // Extract the subnet ids from the cluster.
-    describe_results
-        .cluster
-        .as_ref()
-        .context(memo, "Response missing cluster field")?
-        .resources_vpc_config
-        .as_ref()
-        .context(memo, "Cluster missing resources_vpc_config field")?
-        .subnet_ids
-        .as_ref()
-        .context(memo, "resources_vpc_config missing subnet ids")
-        .map(|ids| ids.clone())
-}
-
-async fn endpoint(
-    eks_client: &aws_sdk_eks::Client,
-    cluster_name: &str,
-    memo: &ProductionMemo,
-) -> ProviderResult<String> {
-    let describe_results = eks_client
-        .describe_cluster()
-        .name(cluster_name)
-        .send()
-        .await
-        .context(memo, "Unable to get eks describe cluster")?;
-    // Extract the apiserver endpoint from the cluster.
-    describe_results
-        .cluster
-        .as_ref()
-        .context(memo, "Results missing cluster field")?
-        .endpoint
-        .as_ref()
-        .context(memo, "Cluster missing endpoint field")
-        .map(|ids| ids.clone())
-}
-
-async fn certificate(
-    eks_client: &aws_sdk_eks::Client,
-    cluster_name: &str,
-    memo: &ProductionMemo,
-) -> ProviderResult<String> {
-    let describe_results = eks_client
-        .describe_cluster()
-        .name(cluster_name)
-        .send()
-        .await
-        .context(memo, "Unable to get eks describe cluster")?;
-
-    // Extract the certificate authority from the cluster.
-    describe_results
-        .cluster
-        .as_ref()
-        .context(memo, "Results missing cluster field")?
-        .certificate_authority
-        .as_ref()
-        .context(memo, "Cluster missing certificate_authority field")?
-        .data
-        .as_ref()
-        .context(memo, "Certificate authority missing data")
-        .map(|ids| ids.clone())
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-enum SubnetType {
-    Public,
-    Private,
-}
-
-impl SubnetType {
-    fn tag(&self, cluster_name: &str) -> String {
-        let subnet_type = match self {
-            SubnetType::Public => "Public",
-            SubnetType::Private => "Private",
-        };
-        format!("eksctl-{}-cluster/Subnet{}*", cluster_name, subnet_type)
-    }
-}
-
-async fn subnet_ids(
-    ec2_client: &aws_sdk_ec2::Client,
-    cluster_name: &str,
-    eks_subnet_ids: Vec<String>,
-    subnet_type: SubnetType,
-    memo: &ProductionMemo,
-) -> ProviderResult<Vec<Subnet>> {
-    let describe_results = ec2_client
-        .describe_subnets()
-        .set_subnet_ids(Some(eks_subnet_ids))
-        .filters(
-            Filter::builder()
-                .name("tag:Name")
-                .values(subnet_type.tag(cluster_name))
-                .build(),
-        )
-        .send()
-        .await
-        .context(memo, "Unable to get private subnet ids")?;
-    describe_results
-        .subnets
-        .context(memo, "Results missing subnets field")
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-enum SecurityGroupType {
-    NodeGroup,
-    ClusterShared,
-    ControlPlane,
-}
-
-impl SecurityGroupType {
-    fn tag(&self, cluster_name: &str) -> String {
-        let sg = match self {
-            SecurityGroupType::NodeGroup => "nodegroup",
-            SecurityGroupType::ClusterShared => "clustershared",
-            SecurityGroupType::ControlPlane => "controlplane",
-        };
-        format!("*{}-{}*", cluster_name, sg)
-    }
-}
-
-async fn security_group(
-    ec2_client: &aws_sdk_ec2::Client,
-    cluster_name: &str,
-    security_group_type: SecurityGroupType,
-    memo: &ProductionMemo,
-) -> ProviderResult<Vec<SecurityGroup>> {
-    // Extract the security groups.
-    let describe_results = ec2_client
-        .describe_security_groups()
-        .filters(
-            Filter::builder()
-                .name("tag:Name")
-                .values(security_group_type.tag(cluster_name))
-                .build(),
-        )
-        .send()
-        .await
-        .context(
-            memo,
-            format!("Unable to get {:?} security group", security_group_type),
-        )?;
-
-    describe_results
-        .security_groups
-        .context(memo, "Results missing security_groups field")
-}
-
 async fn instance_type(
     ec2_client: &aws_sdk_ec2::Client,
     node_ami: &str,
@@ -450,37 +235,6 @@ async fn instance_type(
     .to_string())
 }
 
-async fn instance_profile_name(
-    iam_client: &aws_sdk_iam::Client,
-    memo: &ProductionMemo,
-) -> ProviderResult<String> {
-    let list_result = iam_client
-        .list_instance_profiles()
-        .send()
-        .await
-        .context(memo, "Unable to list instance profiles")?;
-    list_result
-        .instance_profiles
-        .as_ref()
-        .context(memo, "No instance profiles found")?
-        .iter()
-        .find(|x| {
-            x.instance_profile_name
-                .as_ref()
-                .unwrap_or(&"".to_string())
-                .contains("NodeInstanceProfile")
-        })
-        .as_ref()
-        .context(memo, "Node instance profile not found")?
-        .instance_profile_name
-        .as_ref()
-        .context(
-            memo,
-            "Node instance profile missing instance_profile_name field",
-        )
-        .map(|profile| profile.clone())
-}
-
 fn tag_specifications(cluster_name: &str) -> TagSpecification {
     TagSpecification::builder()
         .resource_type(ResourceType::Instance)
@@ -499,18 +253,11 @@ fn tag_specifications(cluster_name: &str) -> TagSpecification {
         .build()
 }
 
-fn first_subnet_id(
-    subnet_ids: &[aws_sdk_ec2::model::Subnet],
-    memo: &ProductionMemo,
-) -> ProviderResult<String> {
+fn first_subnet_id(subnet_ids: &[String], memo: &ProductionMemo) -> ProviderResult<String> {
     subnet_ids
         .get(0)
-        .as_ref()
-        .context(memo, "There are no private subnet ids")?
-        .subnet_id
-        .as_ref()
-        .cloned()
-        .context(memo, "Subnet missing subnet_id field")
+        .map(|id| id.to_string())
+        .context(memo, "There are no private subnet ids")
 }
 
 fn userdata(endpoint: &str, cluster_name: &str, certificate: &str) -> String {

--- a/agent/eks-resource-agent/Cargo.toml
+++ b/agent/eks-resource-agent/Cargo.toml
@@ -5,8 +5,14 @@
 
  [dependencies]
  async-trait = "0.1"
+ aws-config = "0.0.22-alpha"
+ aws-sdk-ec2 = "0.0.22-alpha"
+ aws-sdk-eks = "0.0.22-alpha"
+ aws-sdk-iam = "0.0.22-alpha"
  base64 = "0.13.0"
+ ec2-resource-agent = { path = "../ec2-resource-agent" }
  model = { path = "../../model" }
  resource-agent = { path = "../resource-agent" }
  serde = { version = "1", features = [ "derive" ] }
+ serde_json = "1"
  tokio = { version = "1", default-features = false, features = [ "time", "macros", "rt-multi-thread" ] }

--- a/agent/eks-resource-agent/src/provider.rs
+++ b/agent/eks-resource-agent/src/provider.rs
@@ -1,3 +1,7 @@
+use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_ec2::model::{Filter, SecurityGroup, Subnet};
+use aws_sdk_ec2::Region;
+use ec2_resource_agent::ClusterInfo;
 use model::{Configuration, SecretName};
 use resource_agent::clients::InfoClient;
 use resource_agent::provider::{
@@ -5,6 +9,7 @@ use resource_agent::provider::{
 };
 use serde::{Deserialize, Serialize};
 use std::env::{self, temp_dir};
+use std::path::Path;
 use std::process::Command;
 
 /// The default region for the cluster.
@@ -13,14 +18,29 @@ const DEFAULT_REGION: &str = "us-west-2";
 /// The configuration information for a eks instance provider.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 pub struct ClusterConfig {
-    /// The name of the eks cluster to create.
-    cluster_name: String,
+    #[serde(flatten)]
+    /// The name of the eks cluster to create or an existing cluster.
+    cluster_name: Cluster,
 
     /// The AWS region to create the cluster. If no value is provided `us-west-2` will be used.
     region: Option<String>,
 
     /// The availablility zones. (e.g. us-west-2a,us-west-2b)
     zones: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum Cluster {
+    #[serde(rename = "existing-cluster-name")]
+    Existing(String),
+    #[serde(rename = "cluster-name")]
+    Create(String),
+}
+
+impl Default for Cluster {
+    fn default() -> Cluster {
+        Self::Create(Default::default())
+    }
 }
 
 impl Configuration for ClusterConfig {}
@@ -33,7 +53,7 @@ pub struct ProductionMemo {
     pub aws_secret_name: Option<SecretName>,
 
     /// The name of the cluster we created.
-    pub cluster_name: Option<String>,
+    pub cluster_name: Option<Cluster>,
 
     // The region the cluster is in.
     pub region: Option<String>,
@@ -44,10 +64,7 @@ impl Configuration for ProductionMemo {}
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 pub struct CreatedCluster {
     /// The name of the cluster we created.
-    pub cluster_name: String,
-
-    /// The region the cluster is in.
-    pub region: String,
+    pub cluster: ClusterInfo,
 
     // Base64 encoded kubeconfig
     pub encoded_kubeconfig: String,
@@ -83,64 +100,51 @@ impl Create for EksCreator {
             .unwrap_or(&DEFAULT_REGION.to_string())
             .to_string();
 
-        let cluster_name = request.configuration.cluster_name;
-
         // Write aws credentials if we need them so we can run eksctl
         if let Some(aws_secret_name) = request.secrets.get("aws-credentials") {
             setup_env(client, aws_secret_name, Resources::Clear).await?;
             memo.aws_secret_name = Some(aws_secret_name.clone());
         }
 
-        memo.current_status = "Creating Cluster".into();
-        client
-            .send_info(memo.clone())
-            .await
-            .context(Resources::Clear, "Error sending cluster creation message")?;
-
         let kubeconfig_dir = temp_dir().join("kubeconfig.yaml");
 
-        let status = Command::new("eksctl")
-            .args([
-                "create",
-                "cluster",
-                "-r",
-                &region,
-                "--zones",
-                &request.configuration.zones.unwrap_or_default().join(","),
-                "--set-kubeconfig-context=false",
-                "--kubeconfig",
-                kubeconfig_dir.to_str().context(
-                    Resources::Clear,
-                    format!("Unable to convert '{:?}' to string path", kubeconfig_dir),
-                )?,
-                "-n",
-                &cluster_name,
-                "--nodes",
-                "0",
-                "--managed=false",
-            ])
-            .status()
-            .context(Resources::Clear, "Failed create cluster")?;
-
-        if !status.success() {
-            return Err(ProviderError::new_with_context(
-                Resources::Clear,
-                format!("Failed create cluster with status code {}", status),
-            ));
-        }
+        let cluster_name = match request.configuration.cluster_name.clone() {
+            Cluster::Existing(cluster_name) => {
+                memo.current_status = "Writing existing cluster kubeconfig".into();
+                client
+                    .send_info(memo.clone())
+                    .await
+                    .context(Resources::Clear, "Error sending kubeconfig write message")?;
+                write_kubeconfig(&cluster_name, &region, &kubeconfig_dir)?;
+                cluster_name
+            }
+            Cluster::Create(cluster_name) => {
+                memo.current_status = "Creating Cluster".into();
+                client
+                    .send_info(memo.clone())
+                    .await
+                    .context(Resources::Clear, "Error sending cluster creation message")?;
+                create_cluster(
+                    &cluster_name,
+                    &region,
+                    &request.configuration.zones,
+                    &kubeconfig_dir,
+                )?;
+                cluster_name
+            }
+        };
 
         let kubeconfig = std::fs::read_to_string(kubeconfig_dir)
             .context(Resources::Remaining, "Unable to read kubeconfig.")?;
         let encoded_kubeconfig = base64::encode(kubeconfig);
 
         let created_lot = CreatedCluster {
-            cluster_name: cluster_name.clone(),
-            region: region.clone(),
+            cluster: cluster_info(&cluster_name, &region).await?,
             encoded_kubeconfig,
         };
 
         memo.current_status = "Cluster Created".into();
-        memo.cluster_name = Some(cluster_name);
+        memo.cluster_name = Some(request.configuration.cluster_name);
         memo.region = Some(region);
         client.send_info(memo.clone()).await.context(
             Resources::Remaining,
@@ -200,6 +204,342 @@ where
     Ok(())
 }
 
+fn create_cluster(
+    cluster_name: &str,
+    region: &str,
+    zones: &Option<Vec<String>>,
+    kubeconfig_dir: &Path,
+) -> ProviderResult<()> {
+    let status = Command::new("eksctl")
+        .args([
+            "create",
+            "cluster",
+            "-r",
+            region,
+            "--zones",
+            &zones.clone().unwrap_or_default().join(","),
+            "--set-kubeconfig-context=false",
+            "--kubeconfig",
+            kubeconfig_dir.to_str().context(
+                Resources::Clear,
+                format!("Unable to convert '{:?}' to string path", kubeconfig_dir),
+            )?,
+            "-n",
+            cluster_name,
+            "--nodes",
+            "0",
+            "--managed=false",
+        ])
+        .status()
+        .context(Resources::Clear, "Failed create cluster")?;
+
+    if !status.success() {
+        return Err(ProviderError::new_with_context(
+            Resources::Clear,
+            format!("Failed create cluster with status code {}", status),
+        ));
+    }
+
+    Ok(())
+}
+
+fn write_kubeconfig(cluster_name: &str, region: &str, kubeconfig_dir: &Path) -> ProviderResult<()> {
+    let status = Command::new("eksctl")
+        .args([
+            "utils",
+            "write-kubeconfig",
+            "-r",
+            region,
+            &format!("--cluster={}", cluster_name),
+            &format!(
+                "--kubeconfig={}",
+                kubeconfig_dir.to_str().context(
+                    Resources::Clear,
+                    format!("Unable to convert '{:?}' to string path", kubeconfig_dir),
+                )?
+            ),
+        ])
+        .status()
+        .context(Resources::Clear, "Failed write kubeconfig")?;
+
+    if !status.success() {
+        return Err(ProviderError::new_with_context(
+            Resources::Clear,
+            format!("Failed write kubeconfig with status code {}", status),
+        ));
+    }
+
+    Ok(())
+}
+
+async fn cluster_info(cluster_name: &str, region: &str) -> ProviderResult<ClusterInfo> {
+    let region_provider = RegionProviderChain::first_try(Some(Region::new(region.to_string())));
+    let shared_config = aws_config::from_env().region(region_provider).load().await;
+    let eks_client = aws_sdk_eks::Client::new(&shared_config);
+    let ec2_client = aws_sdk_ec2::Client::new(&shared_config);
+    let iam_client = aws_sdk_iam::Client::new(&shared_config);
+
+    let eks_subnet_ids = eks_subnet_ids(&eks_client, cluster_name).await?;
+    let endpoint = endpoint(&eks_client, cluster_name).await?;
+    let certificate = certificate(&eks_client, cluster_name).await?;
+
+    let public_subnet_ids = subnet_ids(
+        &ec2_client,
+        cluster_name,
+        eks_subnet_ids.clone(),
+        SubnetType::Public,
+    )
+    .await?
+    .into_iter()
+    .filter_map(|subnet| subnet.subnet_id)
+    .collect();
+
+    let private_subnet_ids = subnet_ids(
+        &ec2_client,
+        cluster_name,
+        eks_subnet_ids.clone(),
+        SubnetType::Private,
+    )
+    .await?
+    .into_iter()
+    .filter_map(|subnet| subnet.subnet_id)
+    .collect();
+
+    let nodegroup_sg = security_group(&ec2_client, cluster_name, SecurityGroupType::NodeGroup)
+        .await?
+        .into_iter()
+        .filter_map(|security_group| security_group.group_id)
+        .collect();
+
+    let controlplane_sg =
+        security_group(&ec2_client, cluster_name, SecurityGroupType::ControlPlane)
+            .await?
+            .into_iter()
+            .filter_map(|security_group| security_group.group_id)
+            .collect();
+
+    let clustershared_sg =
+        security_group(&ec2_client, cluster_name, SecurityGroupType::ClusterShared)
+            .await?
+            .into_iter()
+            .filter_map(|security_group| security_group.group_id)
+            .collect();
+
+    let iam_instance_profile_arn = instance_profile(&iam_client, cluster_name).await?;
+
+    Ok(ClusterInfo {
+        name: cluster_name.to_string(),
+        region: region.to_string(),
+        endpoint,
+        certificate,
+        public_subnet_ids,
+        private_subnet_ids,
+        nodegroup_sg,
+        controlplane_sg,
+        clustershared_sg,
+        iam_instance_profile_arn,
+    })
+}
+
+async fn eks_subnet_ids(
+    eks_client: &aws_sdk_eks::Client,
+    cluster_name: &str,
+) -> ProviderResult<Vec<String>> {
+    let describe_results = eks_client
+        .describe_cluster()
+        .name(cluster_name)
+        .send()
+        .await
+        .context(Resources::Remaining, "Unable to get eks describe cluster")?;
+
+    // Extract the subnet ids from the cluster.
+    describe_results
+        .cluster
+        .as_ref()
+        .context(Resources::Remaining, "Response missing cluster field")?
+        .resources_vpc_config
+        .as_ref()
+        .context(
+            Resources::Remaining,
+            "Cluster missing resources_vpc_config field",
+        )?
+        .subnet_ids
+        .as_ref()
+        .context(
+            Resources::Remaining,
+            "resources_vpc_config missing subnet ids",
+        )
+        .map(|ids| ids.clone())
+}
+
+async fn endpoint(eks_client: &aws_sdk_eks::Client, cluster_name: &str) -> ProviderResult<String> {
+    let describe_results = eks_client
+        .describe_cluster()
+        .name(cluster_name)
+        .send()
+        .await
+        .context(Resources::Remaining, "Unable to get eks describe cluster")?;
+    // Extract the apiserver endpoint from the cluster.
+    describe_results
+        .cluster
+        .as_ref()
+        .context(Resources::Remaining, "Results missing cluster field")?
+        .endpoint
+        .as_ref()
+        .context(Resources::Remaining, "Cluster missing endpoint field")
+        .map(|ids| ids.clone())
+}
+
+async fn certificate(
+    eks_client: &aws_sdk_eks::Client,
+    cluster_name: &str,
+) -> ProviderResult<String> {
+    let describe_results = eks_client
+        .describe_cluster()
+        .name(cluster_name)
+        .send()
+        .await
+        .context(Resources::Remaining, "Unable to get eks describe cluster")?;
+
+    // Extract the certificate authority from the cluster.
+    describe_results
+        .cluster
+        .as_ref()
+        .context(Resources::Remaining, "Results missing cluster field")?
+        .certificate_authority
+        .as_ref()
+        .context(
+            Resources::Remaining,
+            "Cluster missing certificate_authority field",
+        )?
+        .data
+        .as_ref()
+        .context(Resources::Remaining, "Certificate authority missing data")
+        .map(|ids| ids.clone())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+enum SubnetType {
+    Public,
+    Private,
+}
+
+impl SubnetType {
+    fn tag(&self, cluster_name: &str) -> String {
+        let subnet_type = match self {
+            SubnetType::Public => "Public",
+            SubnetType::Private => "Private",
+        };
+        format!("eksctl-{}-cluster/Subnet{}*", cluster_name, subnet_type)
+    }
+}
+
+async fn subnet_ids(
+    ec2_client: &aws_sdk_ec2::Client,
+    cluster_name: &str,
+    eks_subnet_ids: Vec<String>,
+    subnet_type: SubnetType,
+) -> ProviderResult<Vec<Subnet>> {
+    let describe_results = ec2_client
+        .describe_subnets()
+        .set_subnet_ids(Some(eks_subnet_ids))
+        .filters(
+            Filter::builder()
+                .name("tag:Name")
+                .values(subnet_type.tag(cluster_name))
+                .build(),
+        )
+        .send()
+        .await
+        .context(Resources::Remaining, "Unable to get private subnet ids")?;
+    describe_results
+        .subnets
+        .context(Resources::Remaining, "Results missing subnets field")
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+enum SecurityGroupType {
+    NodeGroup,
+    ClusterShared,
+    ControlPlane,
+}
+
+impl SecurityGroupType {
+    fn tag(&self, cluster_name: &str) -> String {
+        let sg = match self {
+            SecurityGroupType::NodeGroup => "nodegroup",
+            SecurityGroupType::ClusterShared => "clustershared",
+            SecurityGroupType::ControlPlane => "controlplane",
+        };
+        format!("*{}-{}*", cluster_name, sg)
+    }
+}
+
+async fn security_group(
+    ec2_client: &aws_sdk_ec2::Client,
+    cluster_name: &str,
+    security_group_type: SecurityGroupType,
+) -> ProviderResult<Vec<SecurityGroup>> {
+    // Extract the security groups.
+    let describe_results = ec2_client
+        .describe_security_groups()
+        .filters(
+            Filter::builder()
+                .name("tag:Name")
+                .values(security_group_type.tag(cluster_name))
+                .build(),
+        )
+        .send()
+        .await
+        .context(
+            Resources::Remaining,
+            format!("Unable to get {:?} security group", security_group_type),
+        )?;
+
+    describe_results.security_groups.context(
+        Resources::Remaining,
+        "Results missing security_groups field",
+    )
+}
+
+async fn instance_profile(
+    iam_client: &aws_sdk_iam::Client,
+    cluster_name: &str,
+) -> ProviderResult<String> {
+    let list_result = iam_client
+        .list_instance_profiles()
+        .send()
+        .await
+        .context(Resources::Remaining, "Unable to list instance profiles")?;
+    let eksctl_prefix = format!("eksctl-{}", cluster_name);
+    list_result
+        .instance_profiles
+        .as_ref()
+        .context(Resources::Remaining, "No instance profiles found")?
+        .iter()
+        .filter(|x| {
+            x.instance_profile_name
+                .as_ref()
+                .unwrap_or(&"".to_string())
+                .contains("NodeInstanceProfile")
+        })
+        .filter(|x| {
+            x.instance_profile_name
+                .as_ref()
+                .unwrap_or(&"".to_string())
+                .contains(&eksctl_prefix)
+        })
+        .next()
+        .context(Resources::Remaining, "Node instance profile not found")?
+        .arn
+        .as_ref()
+        .context(
+            Resources::Remaining,
+            "Node instance profile missing arn field",
+        )
+        .map(|profile| profile.clone())
+}
+
 pub struct EksDestroyer {}
 
 #[async_trait::async_trait]
@@ -227,16 +567,21 @@ impl Destroy for EksDestroyer {
             if let Some(aws_secret_name) = &memo.aws_secret_name {
                 setup_env(client, aws_secret_name, Resources::Remaining).await?;
             }
-            let region = memo.clone().region.unwrap_or(DEFAULT_REGION.to_string());
-            let status = Command::new("eksctl")
-                .args(["delete", "cluster", "--name", &cluster_name, "-r", &region])
-                .status()
-                .context(Resources::Remaining, "Failed to run eksctl delete command")?;
-            if !status.success() {
-                return Err(ProviderError::new_with_context(
-                    Resources::Orphaned,
-                    format!("Failed to delete cluster with status code {}", status),
-                ));
+            let region = memo
+                .clone()
+                .region
+                .unwrap_or_else(|| DEFAULT_REGION.to_string());
+            if let Cluster::Create(cluster_name) = cluster_name {
+                let status = Command::new("eksctl")
+                    .args(["delete", "cluster", "--name", cluster_name, "-r", &region])
+                    .status()
+                    .context(Resources::Remaining, "Failed to run eksctl delete command")?;
+                if !status.success() {
+                    return Err(ProviderError::new_with_context(
+                        Resources::Orphaned,
+                        format!("Failed to delete cluster with status code {}", status),
+                    ));
+                }
             }
         }
 

--- a/agent/resource-agent/src/clients/implementation.rs
+++ b/agent/resource-agent/src/clients/implementation.rs
@@ -93,8 +93,11 @@ impl AgentClient for DefaultAgentClient {
         Request: Configuration,
     {
         let resource = self.resource_client.get(&self.data.resource_name).await?;
-
-        let request = Request::from_map(resource.spec.agent.configuration.unwrap_or_default())?;
+        let request = Request::from_map(
+            self.resource_client
+                .resolve_templated_config(resource.spec.agent.configuration.unwrap_or_default())
+                .await?,
+        )?;
         Ok(Spec {
             configuration: request,
             secrets: resource.spec.agent.secrets.unwrap_or_default(),

--- a/agent/sonobuoy-test-agent/src/lib.rs
+++ b/agent/sonobuoy-test-agent/src/lib.rs
@@ -1,7 +1,7 @@
 use model::Configuration;
 use serde::{Deserialize, Serialize};
 
-pub const SONOBUOY_AWS_SECRET_NAME: &str = "aws_credentials";
+pub const SONOBUOY_AWS_SECRET_NAME: &str = "aws-credentials";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SonobuoyConfig {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #152 


**Description of changes:**
Changes the eks agent to add cluster information to its created cluster. This allowed the ec2 provider to become simpler and use ec2's output.


**Testing done:**
Ran a test eks->ec2->sonobuoy with the following configuration:
```
apiVersion: testsys.bottlerocket.aws/v1
kind: Resource
metadata:
  name: eks
  namespace: testsys-bottlerocket-aws
spec:
  agent:
    name: eks-agent
    image: "eks-resource-agent:integ"
    keep_running: false
    secrets: 
      aws-credentials: aws-creds
    configuration:
      existing-cluster-name: "testsys-test"
      region: us-west-2
---
apiVersion: testsys.bottlerocket.aws/v1
kind: Resource
metadata:
  name: ec2
  namespace: testsys-bottlerocket-aws
spec:
  agent:
    name: ec2-agent
    image: "ec2-resource-agent:integ"
    keep_running: false
    secrets: 
      aws-credentials: aws-creds
    configuration:
      instance_count: 5
      cluster: "${eks.cluster}"
      node_ami: "ami-01f7aa6796f5da3dd"
    depends_on: [eks]
---
apiVersion: testsys.bottlerocket.aws/v1
kind: Test
metadata:
  name: sonobuoy1
  namespace: testsys-bottlerocket-aws
spec:
  agent:
    name: sonobuoy-agent
    image: "sonobuoy-test-agent:integ"
    keep_running: false
    secrets: 
      aws-credentials: aws-creds
    configuration:
      configuration:
      kubeconfig_base64: ${eks.encoded_kubeconfig}
      plugin: e2e
      mode: quick
      kubernetes_version: v1.21.2
  resources: [eks, ec2]
```
Note: this will be the base for a series of small fixes to make develop demo ready.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
