### PR TITLE
eks provider set context (5)

### DIFF
--- a/agent/eks-resource-agent/src/provider.rs
+++ b/agent/eks-resource-agent/src/provider.rs
@@ -218,7 +218,6 @@ fn create_cluster(
             region,
             "--zones",
             &zones.clone().unwrap_or_default().join(","),
-            "--set-kubeconfig-context=false",
             "--kubeconfig",
             kubeconfig_dir.to_str().context(
                 Resources::Clear,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #174 


**Description of changes:**
Removes the flag to not set context in the kubeconfig generated by the eks provider.


**Testing done:**
```
kind delete cluster --name test
kind create cluster --name test
kind load docker-image sonobuoy-test-agent:integ testsys-controller:integ eks-resource-agent:integ ec2-resource-agent:integ --name test
testsys install --controller-uri testsys-controller:integ
testsys add secret map --name "aws-creds" \
 "access-key-id=$(aws configure get default.aws_access_key_id)" \
 "secret-access-key=$(aws configure get default.aws_secret_access_key)"
testsys add file example-eks-resource.yaml
testsys add file example-ec2-resource.yaml
testsys run sonobuoy \
  --target-cluster-kubeconfig \${eks.encoded_kubeconfig} \
  --name sono-test \
  --image sonobuoy-test-agent:integ \
  --plugin e2e \
  --mode quick \
  --aws-secret aws-creds \
  --resource eks \
  --resource ec2 
kubectl -n testsys-bottlerocket-aws get pods
```

With `example-eks-resource.yaml`:
```
apiVersion: testsys.bottlerocket.aws/v1
kind: Resource
metadata:
  name: eks
  namespace: testsys-bottlerocket-aws
spec:
  agent:
    name: eks-agent
    image: "eks-resource-agent:integ"
    keep_running: false
    secrets: 
      aws-credentials: aws-creds
    configuration:
      cluster-name: "testsys-test"
      region: us-west-2
```
`example-ec2-resource.yaml`:
```
apiVersion: testsys.bottlerocket.aws/v1
kind: Resource
metadata:
  name: ec2
  namespace: testsys-bottlerocket-aws
spec:
  agent:
    name: ec2-agent
    image: "ec2-resource-agent:integ"
    keep_running: false
    secrets: 
      aws-credentials: aws-creds
    configuration:
      cluster: "${eks.cluster}"
      node_ami: "ami-01f7aa6796f5da3dd"
  depends_on: [eks]
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
