### PR TITLE
build: compile integ tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ build: fetch
 	cargo clippy --locked
 	cargo build --locked
 	cargo test --locked
+	cargo test --features integ --no-run
 
 # Build the container image for the example test-agent program
 example-test-agent: show-variables fetch


### PR DESCRIPTION

**Issue number:**

Related to #56

**Description of changes:**

```
Compile integration tests (without running them) during make build so
that integration test code does not rot.
```
**Testing done:**

Ran it locally and via GitHub actions.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
