### PR TITLE
cli: Subcommand for AWS secret

### DIFF
--- a/testsys/src/add.rs
+++ b/testsys/src/add.rs
@@ -1,5 +1,5 @@
-use crate::add_secret;
 use crate::error::Result;
+use crate::{add_aws_secret, add_secret};
 use kube::Client;
 use structopt::StructOpt;
 
@@ -14,12 +14,16 @@ pub(crate) struct Add {
 enum Command {
     /// Add a secret to the cluster.
     Secret(add_secret::AddSecret),
+
+    /// Add AWS credentials as a secret.
+    AwsSecret(add_aws_secret::AddAwsSecret),
 }
 
 impl Add {
     pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
         match &self.command {
             Command::Secret(add_secret) => add_secret.run(k8s_client).await,
+            Command::AwsSecret(add_aws_secret) => add_aws_secret.run(k8s_client).await,
         }
     }
 }

--- a/testsys/src/add_aws_secret.rs
+++ b/testsys/src/add_aws_secret.rs
@@ -1,0 +1,59 @@
+use crate::error::Result;
+use crate::k8s::create_or_update;
+use k8s_openapi::api::core::v1::Secret;
+use kube::{Api, Client};
+use model::constants::NAMESPACE;
+use model::SecretName;
+use std::collections::BTreeMap;
+use structopt::StructOpt;
+
+/// Add a `Secret` with key value pairs.
+#[derive(Debug, StructOpt)]
+pub(crate) struct AddAwsSecret {
+    /// Name of the secret
+    #[structopt(short, long)]
+    name: SecretName,
+
+    /// Aws access key id.
+    #[structopt(short = "u", long)]
+    aws_access_key_id: String,
+
+    /// Aws secret access key.
+    #[structopt(short = "p", long)]
+    secret_access_key: String,
+}
+
+impl AddAwsSecret {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        let args: BTreeMap<String, String> = vec![
+            ("access-key-id".to_string(), self.aws_access_key_id.clone()),
+            (
+                "secret-access-key".to_string(),
+                self.secret_access_key.clone(),
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        let secrets: Api<k8s_openapi::api::core::v1::Secret> =
+            Api::namespaced(k8s_client.clone(), NAMESPACE);
+
+        let object_meta = kube::api::ObjectMeta {
+            name: Some(self.name.as_str().to_owned()),
+            ..Default::default()
+        };
+
+        // Create the secret we are going to add.
+        let secret = Secret {
+            data: None,
+            immutable: None,
+            metadata: object_meta,
+            string_data: Some(args),
+            type_: None,
+        };
+
+        create_or_update(&secrets, secret, "Secret").await?;
+        println!("Successfully added '{}' to secrets.", self.name);
+        Ok(())
+    }
+}

--- a/testsys/src/main.rs
+++ b/testsys/src/main.rs
@@ -5,6 +5,7 @@ This is the command line interface for setting up a TestSys Cluster and running 
 !*/
 
 mod add;
+mod add_aws_secret;
 mod add_secret;
 mod add_secret_map;
 mod error;


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #27 


**Description of changes:**
Adds a subcommand for aws secret.


**Testing done:**
Successfully added secret using
```
 testsys add aws-secret --name "aws-creds" \
 -u $(aws configure get default.aws_access_key_id) \
 -p $(aws configure get default.aws_secret_access_key)
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
