### PR TITLE
cli: fix a test

### DIFF
--- a/selftest/src/cluster.rs
+++ b/selftest/src/cluster.rs
@@ -136,7 +136,10 @@ impl Cluster {
     pub async fn wait_for_test_pod(&self, test_name: &str, duration: Duration) -> Result<()> {
         tokio::time::timeout(duration, self.wait_for_test_loop(test_name))
             .await
-            .context("Timeout waiting for test '{}' pod to be in the 'Running' state")?
+            .context(format!(
+                "Timeout waiting for test '{}' pod to be in the 'Running' state",
+                test_name
+            ))?
     }
 
     /// Waits for a Kubernetes object to become available (retries on 404).

--- a/testsys/tests/cli_test.rs
+++ b/testsys/tests/cli_test.rs
@@ -75,6 +75,9 @@ async fn test_status() {
         "controller:integ",
     ]);
     cmd.assert().success();
+
+    cluster.wait_for_controller(POD_TIMEOUT).await.unwrap();
+
     cluster
         .load_image_to_cluster("example-test-agent:integ")
         .unwrap();
@@ -87,8 +90,6 @@ async fn test_status() {
         data::hello_example_path().to_str().unwrap(),
     ]);
     cmd.assert().success();
-
-    cluster.wait_for_controller(POD_TIMEOUT).await.unwrap();
 
     cluster
         .wait_for_test_pod("hello-bones", POD_TIMEOUT)


### PR DESCRIPTION

**Issue number:**

Maybe fixes another problem causing #195

**Description of changes:**

test_status was running a test before waiting for the controller to
become active. This might have been the reason we were seeing timeouts
in CI.

**Testing done:**

Running `make integ-test` locally.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
