### PR TITLE
Test Consolidation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,9 @@ eks-resource-agent ec2-resource-agent sonobuoy-test-agent migration-test-agent: 
 # If TESTSYS_SELFTEST_SKIP_IMAGE_BUILDS is set to a non-zero-length string, the container images
 # will not be rebuilt.
 integ-test: export TESTSYS_SELFTEST_KIND_PATH := $(shell pwd)/bin/kind
-integ-test: $(if $(TESTSYS_SELFTEST_SKIP_IMAGE_BUILDS), ,controller example-test-agent example-resource-agent sonobuoy-test-agent)
+integ-test: $(if $(TESTSYS_SELFTEST_SKIP_IMAGE_BUILDS), ,controller example-test-agent duplicator-resource-agent)
 	$(shell pwd)/bin/download-kind.sh --platform $(TESTSYS_BUILD_HOST_PLATFORM) --goarch ${TESTSYS_BUILD_HOST_GOARCH}
 	docker tag example-test-agent example-test-agent:integ
 	docker tag controller controller:integ
-	docker tag example-resource-agent example-resource-agent:integ
-	docker tag sonobuoy-test-agent sonobuoy-test-agent:integ
+	docker tag duplicator-resource-agent duplicator-resource-agent:integ
 	cargo test --features integ -- --test-threads=1

--- a/testsys/src/error.rs
+++ b/testsys/src/error.rs
@@ -51,8 +51,11 @@ pub(crate) enum Error {
         source: kube::Error,
     },
 
-    #[snafu(display("Unable to get test: {}", source))]
-    GetTest { source: model::clients::Error },
+    #[snafu(display("Unable to get '{}': {}", what, source))]
+    Get {
+        what: String,
+        source: model::clients::Error,
+    },
 
     #[snafu(display("The arguments given were invalid: {}", why))]
     InvalidArguments { why: String },

--- a/testsys/tests/data.rs
+++ b/testsys/tests/data.rs
@@ -6,3 +6,15 @@ pub fn hello_example_path() -> PathBuf {
     path.pop();
     path.join("testsys/tests/data/hello-example.yaml")
 }
+
+pub fn integ_test_dependent_path() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.join("testsys/tests/data/integ-test-dependent.yaml")
+}
+
+pub fn integ_test_depended_on_path() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.join("testsys/tests/data/integ-test-depended-on.yaml")
+}

--- a/testsys/tests/data/integ-test-depended-on.yaml
+++ b/testsys/tests/data/integ-test-depended-on.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: testsys.bottlerocket.aws/v1
+kind: Resource
+metadata:
+  name: dup-2
+  namespace: testsys-bottlerocket-aws
+spec:
+  agent:
+    name: dup-2-agent
+    image: "duplicator-resource-agent:integ"
+    keep_running: false
+    configuration:
+      info: 3
+  depends_on: []
+---
+apiVersion: testsys.bottlerocket.aws/v1
+kind: Test
+metadata:
+  name: hello-bones-2
+  namespace: testsys-bottlerocket-aws
+spec:
+  agent:
+    name: hello-agent
+    image: "example-test-agent:integ"
+    keep_running: false
+    configuration:
+      mode: Fast
+      person: Bones the Cat
+      hello_count: ${dup-1.info}
+      hello_duration_milliseconds: 500
+  resources: [dup-1]
+  depends_on: []

--- a/testsys/tests/data/integ-test-dependent.yaml
+++ b/testsys/tests/data/integ-test-dependent.yaml
@@ -1,0 +1,31 @@
+apiVersion: testsys.bottlerocket.aws/v1
+kind: Test
+metadata:
+  name: hello-bones-1
+  namespace: testsys-bottlerocket-aws
+spec:
+  agent:
+    name: hello-agent
+    image: "example-test-agent:integ"
+    keep_running: true
+    configuration:
+      mode: Fast
+      person: Bones the Cat
+      hello_count: 3
+      hello_duration_milliseconds: 500
+  resources: []
+  depends_on: [hello-bones-2]
+---
+apiVersion: testsys.bottlerocket.aws/v1
+kind: Resource
+metadata:
+  name: dup-1
+  namespace: testsys-bottlerocket-aws
+spec:
+  agent:
+    name: dup-1-agent
+    image: "duplicator-resource-agent:integ"
+    keep_running: false
+    configuration:
+      info: ${dup-2.info}
+  depends_on: [dup-2]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Adds resource and controller checking to status. Combines all tests into a single one (takes < 200s).

~~The new `testsys status` has the following functionality,~~
~~If a test name is given, only the status of that test is used. If a resource name is given only the status of that resource is used, and if the controller flag is present, only the status of the controller is used. If nothing is provided (no test name, no resource name and no controller flag), status will check all tests, resources, and the controller.~~

~~`testsys status`  will check the status of all tests, resources, and the controller.~~
~~`testsys status --wait` will run until all tests, resources have finished and the controller is in the running state.~~
~~`testsys status -t <test-name>` will only check the status of the specified test.~~
~~`testsys status -c` will only check the status of the controller.~~

The new `testsys status` has the following form, `--tests` is used to show that tests should be checked, if no tests are provided then all tests are checked. The same goes for resources. `--controller` means that the controller will be checked.



**Testing done:**
`test_system` runs locally.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
