### PR TITLE
docker: use syntax version hint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.1.3-experimental
 # This Dockfile contains separate targets for each testsys agent
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Shared build stage used to build the testsys agent binary

--- a/agent/resource-agent/examples/duplicator_resource_agent/Dockerfile
+++ b/agent/resource-agent/examples/duplicator_resource_agent/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.1.3-experimental
 ARG ARCH
 FROM public.ecr.aws/bottlerocket/bottlerocket-sdk-${ARCH}:v0.23.0 as build
 

--- a/agent/resource-agent/examples/example_resource_agent/Dockerfile
+++ b/agent/resource-agent/examples/example_resource_agent/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.1.3-experimental
 ARG ARCH
 FROM public.ecr.aws/bottlerocket/bottlerocket-sdk-${ARCH}:v0.23.0 as build
 

--- a/agent/test-agent/examples/example_test_agent/Dockerfile
+++ b/agent/test-agent/examples/example_test_agent/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.1.3-experimental
 ARG ARCH
 FROM public.ecr.aws/bottlerocket/bottlerocket-sdk-${ARCH}:v0.23.0 as build
 

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.1.3-experimental
 ARG ARCH
 FROM public.ecr.aws/bottlerocket/bottlerocket-sdk-${ARCH}:v0.23.0 as build
 


### PR DESCRIPTION

**Issue number:**

N/A

**Description of changes:**

```
In using a machine that has docker v19, it seems these
syntax version hints are necessary. Otherwise I was
getting an error indicating that buildkit was not
being used.
```

**Testing done:**

N/A

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
