### PR TITLE
bottlerocket-agents: adds vsphere-vm-resource-agent

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,7 @@ jobs:
          - "example-test-agent"
          - "sonobuoy-test-agent"
          - "migration-test-agent"
+         - "vsphere-vm-resource-agent"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.22.1",
  "pin-project",
  "tokio",
  "tower",
@@ -326,7 +326,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.22.1",
  "lazy_static",
  "pin-project",
  "pin-project-lite",
@@ -459,9 +459,12 @@ dependencies = [
  "base64",
  "env_logger",
  "hex",
+ "k8s-openapi",
+ "kube",
  "log",
  "maplit",
  "model",
+ "reqwest",
  "resource-agent",
  "serde",
  "serde_json",
@@ -469,6 +472,8 @@ dependencies = [
  "snafu",
  "test-agent",
  "tokio",
+ "tough",
+ "url",
  "uuid",
  "yamlgen",
 ]
@@ -607,7 +612,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
 dependencies = [
- "sct",
+ "sct 0.6.1",
 ]
 
 [[package]]
@@ -725,6 +730,15 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "env_logger"
@@ -911,6 +925,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,11 +1060,24 @@ dependencies = [
  "futures-util",
  "hyper",
  "log",
- "rustls",
+ "rustls 0.19.1",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
- "webpki",
+ "tokio-rustls 0.22.0",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls 0.20.2",
+ "tokio",
+ "tokio-rustls 0.23.1",
 ]
 
 [[package]]
@@ -1100,6 +1140,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -1311,6 +1357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
 name = "mio"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,6 +1529,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "olpc-cjson"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ca49fe685014bbf124ee547da94ed7bb65a6eb9dc9c4711773c081af96a39c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +1602,24 @@ dependencies = [
  "lazy_static",
  "num",
  "regex",
+]
+
+[[package]]
+name = "path-absolutize"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b288298a7a3a7b42539e3181ba590d32f2d91237b0691ed5f103875c754b3bf5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfa72956f6be8524f7f7e2b07972dda393cb0008a6df4451f658b7e1bd1af80"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -1763,6 +1844,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bea77bc708afa10e59905c3d4af7c8fd43c9214251673095ff8b14345fcbc5"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls 0.23.0",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.20.2",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls 0.23.1",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
 name = "resource-agent"
 version = "0.1.0"
 dependencies = [
@@ -1812,8 +1930,20 @@ dependencies = [
  "base64",
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
+dependencies = [
+ "log",
+ "ring",
+ "sct 0.7.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -1823,9 +1953,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
 dependencies = [
  "openssl-probe",
- "rustls",
+ "rustls 0.19.1",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -1833,6 +1972,15 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1873,6 +2021,16 @@ name = "sct"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -1982,6 +2140,18 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95455e7e29fada2052e72170af226fbe368a4ca33dee847875325d9fdb133858"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -2329,9 +2499,20 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "rustls",
+ "rustls 0.19.1",
  "tokio",
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4baa378e417d780beff82bf54ceb0d195193ea6a00c14e22359e7f39456b5689"
+dependencies = [
+ "rustls 0.20.2",
+ "tokio",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -2360,6 +2541,33 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
+]
+
+[[package]]
+name = "tough"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99488309ba53ee931b6ccda1cde07feaab95f214d328e3a7244c0f7563b5909f"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "globset",
+ "hex",
+ "log",
+ "olpc-cjson",
+ "path-absolutize",
+ "pem",
+ "percent-encoding",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "snafu",
+ "tempfile",
+ "untrusted",
+ "url",
+ "walkdir",
 ]
 
 [[package]]
@@ -2583,6 +2791,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2621,6 +2840,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2673,6 +2904,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki 0.21.4",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2702,6 +2952,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "xattr"

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,29 @@ COPY --from=build /src/bottlerocket-agents/bin/ec2-resource-agent ./
 ENTRYPOINT ["./ec2-resource-agent"]
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
+# Builds the vSphere VM resource agent image
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 as vsphere-vm-resource-agent
+ARG ARCH
+ARG GOARCH
+ARG GOVC_VERSION=0.27.2
+ARG K8S_VERSION=1.21.6
+
+RUN yum install -y gcc tar gzip openssl-devel && yum clean all
+
+# Install GOVC
+RUN curl -L -o - "https://github.com/vmware/govmomi/releases/download/v${GOVC_VERSION}/govc_Linux_${ARCH}.tar.gz" \
+    | tar -C /usr/local/bin -xvzf - govc
+
+# Install kubeadm
+RUN curl -LO "https://dl.k8s.io/release/v${K8S_VERSION}/bin/linux/${GOARCH}/kubeadm" && \
+    install -o root -g root -m 0755 kubeadm /usr/local/bin/kubeadm
+
+# Copy binary
+COPY --from=build /src/bottlerocket-agents/bin/vsphere-vm-resource-agent ./
+
+ENTRYPOINT ["./vsphere-vm-resource-agent"]
+
+# =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Builds the EKS resource agent image
 FROM public.ecr.aws/amazonlinux/amazonlinux:2 as eks-resource-agent
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TOP := $(dir $(firstword $(MAKEFILE_LIST)))
 
 .PHONY: build sdk-openssl example-test-agent example-resource-agent \
 	controller images sonobuoy-test-agent integ-test ec2-resource-agent \
-	eks-resource-agent show-variables migration-test-agent
+	eks-resource-agent show-variables migration-test-agent vsphere-vm-resource-agent
 
 TESTSYS_BUILD_HOST_UNAME_ARCH=$(shell uname -m)
 TESTSYS_BUILD_HOST_GOARCH ?= $(lastword $(subst :, ,$(filter $(TESTSYS_BUILD_HOST_UNAME_ARCH):%,x86_64:amd64 aarch64:arm64)))
@@ -21,7 +21,8 @@ show-variables:
 fetch:
 	cargo fetch --locked
 
-images: fetch controller sonobuoy-test-agent ec2-resource-agent eks-resource-agent migration-test-agent
+images: fetch controller sonobuoy-test-agent ec2-resource-agent eks-resource-agent migration-test-agent \
+	vsphere-vm-resource-agent
 
 # Builds, Lints and Tests the Rust workspace
 build: fetch
@@ -63,7 +64,7 @@ controller: show-variables fetch
 		-f controller/Dockerfile .
 
 # Build the container image for a testsys agent
-eks-resource-agent ec2-resource-agent sonobuoy-test-agent migration-test-agent: show-variables fetch
+eks-resource-agent ec2-resource-agent vsphere-vm-resource-agent sonobuoy-test-agent migration-test-agent: show-variables fetch
 	docker build $(DOCKER_BUILD_FLAGS) \
 		--build-arg ARCH="$(TESTSYS_BUILD_HOST_UNAME_ARCH)" \
 		--build-arg GOARCH="$(TESTSYS_BUILD_HOST_GOARCH)" \

--- a/bottlerocket-agents/Cargo.toml
+++ b/bottlerocket-agents/Cargo.toml
@@ -14,17 +14,22 @@ aws-sdk-ssm = "0.0.26-alpha"
 base64 = "0.13.0"
 env_logger = "0.9"
 hex ="0.4.3"
+k8s-openapi = { version = "0", default-features = false, features = ["v1_20"] }
+kube = { version = "0.64", default-features = false, features = ["config", "derive", "client"] }
 log = "0.4"
 maplit = "1.0.2"
 model = { path = "../model" }
 resource-agent = { path = "../agent/resource-agent" }
+reqwest = { version = "0.11.1", default-features = false, features = ["rustls-tls", "blocking"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 ="0.9.8"
 snafu = "0.6"
 test-agent = { path = "../agent/test-agent" }
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
+tough = { version = "0.12", features = ["http"] }
 uuid = { version = "0.8", default-features = false, features = ["serde", "v4"] }
+url = "2.2"
 
 [build-dependencies]
 yamlgen = { path = "../yamlgen" }

--- a/bottlerocket-agents/src/bin/vsphere-vm-resource-agent/aws.rs
+++ b/bottlerocket-agents/src/bin/vsphere-vm-resource-agent/aws.rs
@@ -1,0 +1,138 @@
+use aws_sdk_iam::SdkError;
+use aws_sdk_ssm::model::{InstanceInformation, InstanceInformationStringFilter, Tag};
+use log::info;
+use resource_agent::provider::{IntoProviderError, ProviderError, ProviderResult, Resources};
+use serde_json::json;
+use std::thread::sleep;
+use std::time::Duration;
+
+/// AWS Role to assign to the managed VM
+const SSM_MANAGED_INSTANCE_SERVICE_ROLE_NAME: &str = "BR-SSMServiceRole";
+/// ARN of the SSM amanged instance policy
+const SSM_MANAGED_INSTANCE_POLICY_ARN: &str =
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore";
+
+pub(crate) async fn ensure_ssm_service_role(
+    iam_client: &aws_sdk_iam::Client,
+) -> ProviderResult<()> {
+    let get_role_result = iam_client
+        .get_role()
+        .role_name(SSM_MANAGED_INSTANCE_SERVICE_ROLE_NAME)
+        .send()
+        .await;
+    if let Err(sdk_err) = get_role_result {
+        match sdk_err {
+            SdkError::ServiceError { .. } => {
+                info!(
+                    "'{}' service role does not exist, creating the service role",
+                    SSM_MANAGED_INSTANCE_SERVICE_ROLE_NAME
+                );
+                let ssm_service_trust = json!({"Version": "2012-10-17", "Statement": {
+                    "Effect": "Allow",
+                    "Principal": {
+                        "Service": "ssm.amazonaws.com"
+                    },
+                    "Action": "sts:AssumeRole"
+                }});
+                let assume_role_doc = ssm_service_trust.to_string();
+                iam_client
+                    .create_role()
+                    .role_name(SSM_MANAGED_INSTANCE_SERVICE_ROLE_NAME)
+                    .assume_role_policy_document(assume_role_doc)
+                    .send()
+                    .await
+                    .context(
+                        Resources::Clear,
+                        "Could not create SSM managed instance service role",
+                    )?;
+            }
+            _ => {
+                return Err(ProviderError::new_with_source_and_context(
+                    Resources::Clear,
+                    format!(
+                        "Failed to determine whether SSM '{}' service role exists",
+                        SSM_MANAGED_INSTANCE_SERVICE_ROLE_NAME
+                    ),
+                    sdk_err,
+                ));
+            }
+        }
+    }
+
+    // Attach SSM managed instance policy to the service role
+    iam_client
+        .attach_role_policy()
+        .role_name(SSM_MANAGED_INSTANCE_SERVICE_ROLE_NAME)
+        .policy_arn(SSM_MANAGED_INSTANCE_POLICY_ARN)
+        .send()
+        .await
+        .context(
+            Resources::Clear,
+            "Could not attach SSM managed instance policy to the service role",
+        )?;
+
+    Ok(())
+}
+
+pub(crate) async fn create_ssm_activation(
+    resources: Resources,
+    cluster_name: &str,
+    num_registration: i32,
+    ssm_client: &aws_sdk_ssm::Client,
+) -> ProviderResult<(String, String)> {
+    let activations = ssm_client
+        .create_activation()
+        .iam_role(SSM_MANAGED_INSTANCE_SERVICE_ROLE_NAME)
+        .registration_limit(num_registration)
+        .tags(
+            Tag::builder()
+                .key("TESTSYS_VSPHERE_VMS")
+                .value(cluster_name)
+                .build(),
+        )
+        .send()
+        .await
+        .context(resources, "Failed to send SSM create activation command")?;
+    let activation_id = activations
+        .activation_id
+        .context(resources, "Unable to fetch SSM activation ID")?;
+    let activation_code = activations
+        .activation_code
+        .context(resources, "Unable to generate SSM activation code")?;
+    Ok((activation_id, activation_code))
+}
+
+// Waits for the SSM agent to be ready for a particular instance, returns the instance information
+pub(crate) async fn wait_for_ssm_ready(
+    resources: Resources,
+    ssm_client: &aws_sdk_ssm::Client,
+    activation_id: &str,
+    ip: &str,
+) -> ProviderResult<InstanceInformation> {
+    let seconds_between_checks = Duration::from_secs(5);
+    loop {
+        let instance_info = ssm_client
+            .describe_instance_information()
+            .filters(
+                InstanceInformationStringFilter::builder()
+                    .key("ActivationIds")
+                    .values(activation_id)
+                    .build(),
+            )
+            .send()
+            .await
+            .context(
+                resources,
+                "Failed to get registered managed instance information",
+            )?;
+        if let Some(info) = instance_info.instance_information_list().and_then(|list| {
+            list.iter()
+                .find(|info| info.ip_address == Some(ip.to_string()))
+        }) {
+            return Ok(info.to_owned());
+        } else {
+            // SSM agent not ready on instance, wait then check again
+            sleep(seconds_between_checks)
+        }
+    }
+}

--- a/bottlerocket-agents/src/bin/vsphere-vm-resource-agent/main.rs
+++ b/bottlerocket-agents/src/bin/vsphere-vm-resource-agent/main.rs
@@ -1,0 +1,57 @@
+mod aws;
+mod tuf;
+mod vsphere_vm_provider;
+
+use crate::vsphere_vm_provider::{VMCreator, VMDestroyer};
+use bottlerocket_agents::DEFAULT_AGENT_LEVEL_FILTER;
+use env_logger::Builder;
+use log::LevelFilter;
+use resource_agent::clients::{DefaultAgentClient, DefaultInfoClient};
+use resource_agent::error::AgentResult;
+use resource_agent::{Agent, BootstrapData, Types};
+use std::env;
+use std::marker::PhantomData;
+
+/// Extract the value of `RUST_LOG` if it exists, otherwise log this application at
+/// `DEFAULT_AGENT_LEVEL_FILTER`.
+pub fn init_agent_logger() {
+    match env::var(env_logger::DEFAULT_FILTER_ENV).ok() {
+        Some(_) => {
+            // RUST_LOG exists; env_logger will use it.
+            Builder::from_default_env().init();
+        }
+        None => {
+            // RUST_LOG does not exist; use default log level except AWS SDK.
+            Builder::new()
+                .filter_level(DEFAULT_AGENT_LEVEL_FILTER)
+                .filter(Some("aws_"), LevelFilter::Error)
+                .filter(Some("tracing"), LevelFilter::Error)
+                .init();
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    init_agent_logger();
+    let data = match BootstrapData::from_env() {
+        Ok(ok) => ok,
+        Err(e) => {
+            eprintln!("Unable to get bootstrap data: {}", e);
+            std::process::exit(1);
+        }
+    };
+    if let Err(e) = run(data).await {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    };
+}
+
+async fn run(data: BootstrapData) -> AgentResult<()> {
+    let types = Types {
+        info_client: PhantomData::<DefaultInfoClient>::default(),
+        agent_client: PhantomData::<DefaultAgentClient>::default(),
+    };
+    let agent = Agent::new(types, data, VMCreator {}, VMDestroyer {}).await?;
+    agent.run().await
+}

--- a/bottlerocket-agents/src/bin/vsphere-vm-resource-agent/tuf.rs
+++ b/bottlerocket-agents/src/bin/vsphere-vm-resource-agent/tuf.rs
@@ -1,0 +1,75 @@
+use resource_agent::provider::{IntoProviderError, ProviderResult, Resources};
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use tough::{ExpirationEnforcement, Prefix, RepositoryLoader, TargetName};
+use url::Url;
+
+const ROOT_FILE_NAME: &str = "1.root.json";
+
+pub(crate) fn download_target(
+    resources: Resources,
+    metadata_url: &Url,
+    targets_url: &Url,
+    outdir: &Path,
+    target_name: &str,
+) -> ProviderResult<()> {
+    // Need to download root.json. This is an unsafe operation but in the context of testing it's fine.
+    let root_path = download_root(resources, metadata_url, outdir)?;
+    let repository = RepositoryLoader::new(
+        File::open(&root_path).context(
+            resources,
+            "Failed to open root.json file for loading TUF repository",
+        )?,
+        metadata_url.to_owned(),
+        targets_url.to_owned(),
+    )
+    .expiration_enforcement(ExpirationEnforcement::Unsafe)
+    .load()
+    .context(resources, "Failed to load TUF repository")?;
+
+    repository
+        .save_target(
+            &TargetName::new(target_name).context(Resources::Clear, "Unsafe target file name")?,
+            outdir,
+            Prefix::None,
+        )
+        .context(
+            resources,
+            format!("Failed to download target file '{}'", target_name),
+        )?;
+
+    Ok(())
+}
+
+fn download_root<P>(
+    resources: Resources,
+    metadata_base_url: &Url,
+    outdir: P,
+) -> ProviderResult<PathBuf>
+where
+    P: AsRef<Path>,
+{
+    let path = outdir.as_ref().join(ROOT_FILE_NAME);
+    let url = metadata_base_url.join(ROOT_FILE_NAME).context(
+        resources,
+        format!(
+            "Could not parse url '{}'",
+            format!("{}/{}", metadata_base_url.as_str(), ROOT_FILE_NAME),
+        ),
+    )?;
+
+    let mut root_request = reqwest::blocking::get(url.as_str())
+        .context(resources, "Could not send HTTP GET request for root.json")?
+        .error_for_status()
+        .context(
+            Resources::Clear,
+            "Bad HTTP response when downloading root.json",
+        )?;
+
+    let mut f = File::create(&path).context(resources, "Failed to create root.json file")?;
+    root_request
+        .copy_to(&mut f)
+        .context(Resources::Clear, "Failed to copy root.json to file")?;
+
+    Ok(path)
+}

--- a/bottlerocket-agents/src/lib.rs
+++ b/bottlerocket-agents/src/lib.rs
@@ -13,6 +13,7 @@ use std::{env, fs};
 use test_agent::Runner;
 
 pub const AWS_CREDENTIALS_SECRET_NAME: &str = "awsCredentials";
+pub const VSPHERE_CREDENTIALS_SECRET_NAME: &str = "vsphereCredentials";
 pub const TEST_CLUSTER_KUBECONFIG_PATH: &str = "/local/test-cluster.kubeconfig";
 pub const DEFAULT_AGENT_LEVEL_FILTER: LevelFilter = LevelFilter::Info;
 
@@ -29,6 +30,14 @@ pub struct ClusterInfo {
     pub controlplane_sg: Vec<String>,
     pub clustershared_sg: Vec<String>,
     pub iam_instance_profile_arn: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct VSphereClusterInfo {
+    pub name: String,
+    pub control_plane_endpoint_ip: String,
+    pub kubeconfig_base64: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Resolves https://github.com/bottlerocket-os/bottlerocket-test-system/issues/33


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Tue Dec 7 16:12:17 2021 -0800

    bottlerocket-agents: adds vsphere-vm-resource-agent
```


**Testing done:**
After deploying the following manifest:
```
apiVersion: testsys.bottlerocket.aws/v1
kind: Resource
metadata:
  name: vsphere-vms
  namespace: testsys-bottlerocket-aws
spec:
  agent:
    name: vsphere-vm-agent
    image: "722737851570.dkr.ecr.us-west-2.amazonaws.com/vsphere-vm-resource-agent"
    keepRunning: false
    secrets:
      awsCredentials: mycreds
      vsphereCredentials: vcentercreds
    configuration:
      vmCount: 2
      ovaName: "bottlerocket-vmware-k8s-1.21-x86_64-v1.4.2.ova"
      tufRepo:
        metadataUrl: "https://updates.bottlerocket.aws/2020-07-07/vmware-k8s-1.21/x86_64/"
        targetsUrl: "https://updates.bottlerocket.aws/targets/"
      vcenterHostUrl: "https://vcenter.sddc-snip.vmwarevmc.com"
      vcenterDatacenter: "SDDC-Datacenter"
      vcenterDatastore: "WorkloadDatastore"
      vcenterNetwork: "sddc-cgw-network-2"
      vcenterResourcePool: "/SDDC-Datacenter/host/Cluster-1/Resources/Compute-ResourcePool"
      vcenterWorkloadFolder: "etung"
      cluster:
        name: 1-21-6-cluster
        controlPlaneEndpointIp: 198.19.11.61
        kubeconfigBase64: <vsphere-cluster's-kubeconfig>
```

The resource agent was able to create the VMs without problem:
```
ubuntu@ip-172-31-42-218:~/bottlerocket-test-system$ kubectl logs  vsphere-vms-creation-bmxvv -n testsys-bottlerocket-aws -f
[2021-12-10T20:20:04Z INFO  resource_agent::agent] Initializing Agent
[2021-12-10T20:20:04Z INFO  bottlerocket_agents] Decoding kubeconfig for test cluster
[2021-12-10T20:20:04Z INFO  bottlerocket_agents] Storing kubeconfig in /local/test-cluster.kubeconfig
[2021-12-10T20:20:04Z INFO  vsphere_vm_resource_agent::vsphere_vm_provider] Downloading OVA 'bottlerocket-vmware-k8s-1.21-x86_64-v1.4.2.ova'
[2021-12-10T20:20:07Z INFO  vsphere_vm_resource_agent::vsphere_vm_provider] Create a bootstrap token for node registrations
[2021-12-10T20:20:07Z INFO  vsphere_vm_resource_agent::vsphere_vm_provider] Importing OVA and creating a VM template out of it
[2021-12-10T20:20:20Z INFO  vsphere_vm_resource_agent::vsphere_vm_provider] Launching 2 Bottlerocket worker nodes
[2021-12-10T20:20:20Z INFO  vsphere_vm_resource_agent::vsphere_vm_provider] Cloning VM for worker node '1-21-6-cluster-node-1'
[2021-12-10T20:20:23Z INFO  vsphere_vm_resource_agent::vsphere_vm_provider] Powering on '1-21-6-cluster-node-1'...
[2021-12-10T20:20:52Z INFO  vsphere_vm_resource_agent::vsphere_vm_provider] Cloning VM for worker node '1-21-6-cluster-node-2'
[2021-12-10T20:20:54Z INFO  vsphere_vm_resource_agent::vsphere_vm_provider] Powering on '1-21-6-cluster-node-2'...
```

Checking the resources:
```
ubuntu@ip-172-31-42-218:~/bottlerocket-test-system$ testsys status -r
Resource Name: vsphere-vms
Resource Creation State: Completed
Resource Deletion State: Unknown

...
  Agent Info:
    Aws Secret Name:    mycreds
    Current Status:     VM(s) Created
    Ssm Activation Id:  2f31d253-0503-4f82-af4f-bc34156ac2f1
    Vm Template:        1-21-6-cluster-node-vmtemplate
    Vms:
      Instance Id:  mi-0f9c7b570dfb2b473
      Ip Address:   198.19.32.45
      Name:         1-21-6-cluster-node-1
      Instance Id:  mi-0e0d607a30cce2224
      Ip Address:   198.19.64.91
      Name:         1-21-6-cluster-node-2
  Created Resource:
    Instance Ids:
      mi-0f9c7b570dfb2b473
      mi-0e0d607a30cce2224
  Creation:
    Error:       <nil>
    Task State:  completed
  Destruction:
    Error:       <nil>
    Task State:  unknown
```

The VMs also show up as expected in vsphere, and they join the cluster fine:
```
ubuntu@ip-172-31-42-218:~/vsphere-testing/conformance-test$ kubectl --kubeconfig 1-21-6-cluster-actual.kubeconfig get nodes
NAME                   STATUS   ROLES                  AGE     VERSION
1-21-6-cluster-4d8zd   Ready    control-plane,master   3d21h   v1.21.6
198.19.32.45           Ready    <none>                 3m49s   v1.21.6
198.19.64.91           Ready    <none>                 3m12s   v1.21.6
```

If I delete the resources, they delete cleanly:
```
ubuntu@ip-172-31-42-218:~/bottlerocket-test-system$ testsys status -r 
Resource Name: vsphere-vms
Resource Creation State: Completed
Resource Deletion State: Completed

```

And the VMs are gone from vCenter

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
