### PR TITLE
eks resource-agent: creation policy

### DIFF
--- a/bottlerocket-agents/src/bin/eks-resource-agent/main.rs
+++ b/bottlerocket-agents/src/bin/eks-resource-agent/main.rs
@@ -1,6 +1,7 @@
 mod eks_provider;
 
 use crate::eks_provider::{EksCreator, EksDestroyer};
+use bottlerocket_agents::init_agent_logger;
 use resource_agent::clients::{DefaultAgentClient, DefaultInfoClient};
 use resource_agent::error::AgentResult;
 use resource_agent::{Agent, BootstrapData, Types};
@@ -8,6 +9,7 @@ use std::marker::PhantomData;
 
 #[tokio::main]
 async fn main() {
+    init_agent_logger();
     let data = match BootstrapData::from_env() {
         Ok(ok) => ok,
         Err(e) => {

--- a/testsys/tests/data.rs
+++ b/testsys/tests/data.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 use std::path::PathBuf;
 
 pub fn integ_test_dependent_path() -> PathBuf {


### PR DESCRIPTION

**Issue number:**

Closes #211

**Description of changes:**

Make it possible to configure whether or not the EKS resource-agent
should actually create the EKS cluster, or use an existing one.

**Testing done:**

- I tested an existing cluster with creation policy `never` and it worked.
- I tested policy `never` when the cluster did not exist and got an error as expected.
- I tested `ifNotExists` with an existing cluster and cluster creation was skipped as desired.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
