### PR TITLE
ec2 refactor

### DIFF
--- a/bottlerocket-agents/src/lib.rs
+++ b/bottlerocket-agents/src/lib.rs
@@ -19,21 +19,6 @@ pub const DEFAULT_AGENT_LEVEL_FILTER: LevelFilter = LevelFilter::Info;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
-pub struct ClusterInfo {
-    pub name: String,
-    pub region: String,
-    pub endpoint: String,
-    pub certificate: String,
-    pub public_subnet_ids: Vec<String>,
-    pub private_subnet_ids: Vec<String>,
-    pub nodegroup_sg: Vec<String>,
-    pub controlplane_sg: Vec<String>,
-    pub clustershared_sg: Vec<String>,
-    pub iam_instance_profile_arn: String,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
 pub struct VSphereClusterInfo {
     pub name: String,
     pub control_plane_endpoint_ip: String,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
There were issues implementing ecs clusters with the current `ec2`, `eks` and `ClusterInfo` types. This pr removes the `ClusterInfo` type and instead uses flat configs for instance creation.


**Testing done:**
I ran the following manifest and the results of `testsys status -r -t -c --json --wait` show the expected results.
```
{"tests":{"upgrade-ec2-test":{"name":"upgrade-ec2-test","state":"passed","passed":2,"failed":0,"skipped":0},"downgrade-ec2-test":{"name":"downgrade-ec2-test","state":"passed","passed":2,"failed":0,"skipped":0}},"resources":{"eks":{"name":"eks","create_state":"completed","delete_state":"unknown"},"ec2":{"name":"ec2","create_state":"completed","delete_state":"unknown"}},"controller_is_running":true}
```
```
apiVersion: testsys.bottlerocket.aws/v1
kind: Resource
metadata:
  name: eks
  namespace: testsys-bottlerocket-aws
spec:
  agent:
    name: eks-agent
    image: "eks-resource-agent:demo-ud"
    keepRunning: false
    secrets: 
      awsCredentials: aws-creds
    configuration:
      clusterName: "testsys-test"
      creationPolicy: never
      region: us-west-2
---
apiVersion: testsys.bottlerocket.aws/v1
kind: Resource
metadata:
  name: ec2
  namespace: testsys-bottlerocket-aws
spec:
  agent:
    name: ec2-agent
    image: "ec2-resource-agent:demo-ud"
    keepRunning: false
    secrets: 
      awsCredentials: aws-creds
    configuration:
      instanceCount: 2
      clusterName: ${eks.clusterName}
      clusterType: eks
      region: ${eks.region}
      subnetId: ${eks.publicSubnetId}
      endpoint: ${eks.endpoint}
      certificate: ${eks.certificate}
      instanceProfileArn: ${eks.iamInstanceProfileArn}
      nodeAmi: "ami-01f7aa6796f5da3dd"
      securityGroups: ${eks.securityGroups}
  dependsOn: [eks]
---
apiVersion: testsys.bottlerocket.aws/v1
kind: Test
metadata:
  name: upgrade-ec2-test
  namespace: testsys-bottlerocket-aws
spec:
  agent:
    configuration:
      awsRegion: us-west-2
      instanceIds: ${ec2.ids}
      migrateToVersion: v1.4.0
    image: migration-test-agent:demo-ud
    name: migration-test-agent
    keepRunning: false
    secrets: 
      awsCredentials: aws-creds
  resources: [ec2, eks]
---
apiVersion: testsys.bottlerocket.aws/v1
kind: Test
metadata:
  name: downgrade-ec2-test
  namespace: testsys-bottlerocket-aws
spec:
  agent:
    configuration:
      awsRegion: us-west-2
      instanceIds: ${ec2.ids}
      migrateToVersion: v1.3.0
    image: migration-test-agent:demo-ud
    name: migration-test-agent
    keepRunning: false
    secrets: 
      awsCredentials: aws-creds
  resources: [ec2, eks]
  dependsOn: [upgrade-ec2-test]
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
