### PR TITLE
agents and cli: introduce a K8sVersion struct

### DIFF
--- a/bottlerocket-agents/src/sonobuoy.rs
+++ b/bottlerocket-agents/src/sonobuoy.rs
@@ -41,10 +41,11 @@ pub async fn run_sonobuoy(
     results_dir: &Path,
 ) -> Result<TestResults, error::Error> {
     let kubeconfig_arg = vec!["--kubeconfig", kubeconfig_path];
-    let k8s_image_arg = match (
-        &sonobuoy_config.kube_conformance_image,
-        &sonobuoy_config.kubernetes_version,
-    ) {
+    let version = sonobuoy_config
+        .kubernetes_version
+        .as_ref()
+        .map(|version| version.full_version_with_v());
+    let k8s_image_arg = match (&sonobuoy_config.kube_conformance_image, &version) {
         (Some(image), None) | (Some(image), Some(_)) => {
             vec!["--kube-conformance-image", image]
         }

--- a/testsys/src/run_sonobuoy.rs
+++ b/testsys/src/run_sonobuoy.rs
@@ -1,6 +1,6 @@
 use crate::error::{self, Result};
 use bottlerocket_agents::sonobuoy::Mode;
-use bottlerocket_agents::{SonobuoyConfig, AWS_CREDENTIALS_SECRET_NAME};
+use bottlerocket_agents::{K8sVersion, SonobuoyConfig, AWS_CREDENTIALS_SECRET_NAME};
 use kube::{api::ObjectMeta, Client};
 use model::clients::CrdClient;
 use model::{
@@ -58,7 +58,7 @@ pub(crate) struct RunSonobuoy {
 
     /// The kubernetes version used for the sonobuoy test.
     #[structopt(long)]
-    kubernetes_version: Option<String>,
+    kubernetes_version: Option<K8sVersion>,
 
     /// The kubernetes conformance image used for the sonobuoy test.
     #[structopt(long)]
@@ -107,7 +107,7 @@ impl RunSonobuoy {
                             kubeconfig_base64: kubeconfig_string,
                             plugin: self.plugin.clone(),
                             mode: self.mode,
-                            kubernetes_version: self.kubernetes_version.clone(),
+                            kubernetes_version: self.kubernetes_version,
                             kube_conformance_image: self.kubernetes_conformance_image.clone(),
                         }
                         .into_map()


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

It can be a pain to keep track of when to use a v prefix and when not
to when specifying k8s versions. This struct allows the presence or
absence of the v and provides functions for serializing it as
desired.


**Testing done:**

This is working in the combined testing I was doing on the `cli-eks` branch.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
