### PR TITLE
clippy: turn on warning enforcement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ images: fetch controller sonobuoy-test-agent ec2-resource-agent eks-resource-age
 # Builds, Lints and Tests the Rust workspace
 build: fetch
 	cargo fmt -- --check
-	cargo clippy --locked
+	cargo clippy --locked -- -D warnings
 	cargo build --locked
 	cargo test --locked
 	cargo test --features integ --no-run

--- a/bottlerocket-agents/src/bin/vsphere-vm-resource-agent/tuf.rs
+++ b/bottlerocket-agents/src/bin/vsphere-vm-resource-agent/tuf.rs
@@ -53,8 +53,9 @@ where
     let url = metadata_base_url.join(ROOT_FILE_NAME).context(
         resources,
         format!(
-            "Could not parse url '{}'",
-            format!("{}/{}", metadata_base_url.as_str(), ROOT_FILE_NAME),
+            "Could not parse url '{}/{}'",
+            metadata_base_url.as_str(),
+            ROOT_FILE_NAME
         ),
     )?;
 

--- a/bottlerocket-agents/src/sonobuoy.rs
+++ b/bottlerocket-agents/src/sonobuoy.rs
@@ -4,7 +4,7 @@ use model::{Outcome, TestResults};
 use serde::{Deserialize, Serialize};
 use serde_plain::{derive_display_from_serialize, derive_fromstr_from_deserialize};
 use snafu::{ensure, OptionExt, ResultExt};
-use std::path::PathBuf;
+use std::path::Path;
 use std::process::Command;
 
 /// What mode to run the e2e plugin in. Valid modes are `non-disruptive-conformance`,
@@ -38,7 +38,7 @@ derive_fromstr_from_deserialize!(Mode);
 pub async fn run_sonobuoy(
     kubeconfig_path: &str,
     sonobuoy_config: &SonobuoyConfig,
-    results_dir: &PathBuf,
+    results_dir: &Path,
 ) -> Result<TestResults, error::Error> {
     let kubeconfig_arg = vec!["--kubeconfig", kubeconfig_path];
     let k8s_image_arg = match (

--- a/controller/src/resource_controller/action.rs
+++ b/controller/src/resource_controller/action.rs
@@ -98,7 +98,7 @@ async fn dependency_wait_action(r: &ResourceInterface) -> Result<Option<Creation
         let needed_resource = r.resource_client().get(needed).await?;
         if needed_resource.created_resource().is_none() {
             return Ok(Some(CreationAction::WaitForDependency(
-                needed_resource.name().to_owned(),
+                needed_resource.name(),
             )));
         }
     }

--- a/model/src/clients/resource_client.rs
+++ b/model/src/clients/resource_client.rs
@@ -190,10 +190,7 @@ impl ResourceClient {
     async fn resolve_input(&self, input: Value) -> Result<Value> {
         match input {
             Value::String(input_string) => self.resolve_input_string(input_string).await,
-            Value::Object(map) => self
-                .resolve_templated_config(map)
-                .await
-                .map(|map| Value::Object(map)),
+            Value::Object(map) => self.resolve_templated_config(map).await.map(Value::Object),
             non_string_input => Ok(non_string_input),
         }
     }
@@ -217,7 +214,7 @@ impl ResourceClient {
 }
 
 fn resource_name_and_field_name(input: &str) -> Result<Option<(String, String)>> {
-    let captures = match REGEX.captures(&input) {
+    let captures = match REGEX.captures(input) {
         None => return Ok(None),
         Some(some) => some,
     };

--- a/model/src/clients/test_client.rs
+++ b/model/src/clients/test_client.rs
@@ -43,12 +43,7 @@ impl TestClient {
     where
         S: AsRef<str> + Send,
     {
-        Ok(self
-            .get(name)
-            .await?
-            .status
-            .unwrap_or_else(Default::default)
-            .agent)
+        Ok(self.get(name).await?.status.unwrap_or_default().agent)
     }
 
     pub async fn send_resource_error(&self, test_name: &str, error: &str) -> Result<Test> {

--- a/testsys/src/run_sonobuoy.rs
+++ b/testsys/src/run_sonobuoy.rs
@@ -106,7 +106,7 @@ impl RunSonobuoy {
                         SonobuoyConfig {
                             kubeconfig_base64: kubeconfig_string,
                             plugin: self.plugin.clone(),
-                            mode: self.mode.clone(),
+                            mode: self.mode,
                             kubernetes_version: self.kubernetes_version.clone(),
                             kube_conformance_image: self.kubernetes_conformance_image.clone(),
                         }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Clippy tends to be less useful if we accumulate warnings in the codebase, so we might as well turn on `-D warnings` for pull requests and make people fix them during PRs.

Note: we will get hit with new lints as they are added to clippy each time Rust comes out with a new version.

**Testing done:**

It compiles!

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
