### PR TITLE
build: use cargo deny to check licenses

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,3 +70,9 @@ jobs:
       - run: make integ-test
         env:
           TESTSYS_SELFTEST_SKIP_IMAGE_BUILDS: true
+  license-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup update stable
+      - run: make cargo-deny

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TOP := $(dir $(firstword $(MAKEFILE_LIST)))
 .PHONY: build sdk-openssl example-test-agent example-resource-agent \
 	controller images sonobuoy-test-agent integ-test ec2-resource-agent \
 	eks-resource-agent ecs-resource-agent show-variables migration-test-agent \
-	vsphere-vm-resource-agent ecs-test-agent
+	vsphere-vm-resource-agent ecs-test-agent cargo-deny
 
 TESTSYS_BUILD_HOST_UNAME_ARCH=$(shell uname -m)
 TESTSYS_BUILD_HOST_GOARCH ?= $(lastword $(subst :, ,$(filter $(TESTSYS_BUILD_HOST_UNAME_ARCH):%,x86_64:amd64 aarch64:arm64)))
@@ -94,3 +94,9 @@ integ-test: $(if $(TESTSYS_SELFTEST_SKIP_IMAGE_BUILDS), ,controller example-test
 	docker tag controller controller:integ
 	docker tag duplicator-resource-agent duplicator-resource-agent:integ
 	cargo test --features integ -- --test-threads=1
+
+cargo-deny:
+	# Install cargo-deny to CARGO_HOME which is set to be .cargo in this repository
+	cargo install --version 0.9.1 cargo-deny --locked
+	cargo fetch
+	cargo deny --all-features --no-default-features check --disable-fetch licenses sources

--- a/agent/agent-common/Cargo.toml
+++ b/agent/agent-common/Cargo.toml
@@ -3,6 +3,7 @@ name = "agent-common"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 model = { path = "../../model" }

--- a/agent/resource-agent/Cargo.toml
+++ b/agent/resource-agent/Cargo.toml
@@ -3,6 +3,7 @@ name = "resource-agent"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 agent-common = { path = "../agent-common" }

--- a/agent/test-agent/Cargo.toml
+++ b/agent/test-agent/Cargo.toml
@@ -3,6 +3,7 @@ name = "test-agent"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 agent-common = { path = "../agent-common" }

--- a/bottlerocket-agents/Cargo.toml
+++ b/bottlerocket-agents/Cargo.toml
@@ -2,6 +2,8 @@
 name = "bottlerocket-agents"
 version = "0.1.0"
 edition = "2018"
+publish = false
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 agent-common = { path = "../agent/agent-common" }

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -3,6 +3,7 @@ name = "controller"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,55 @@
+[licenses]
+unlicensed = "deny"
+
+# Deny licenses unless they are specifically listed here
+copyleft = "deny"
+allow-osi-fsf-free = "neither"
+default = "deny"
+
+# We want really high confidence when inferring licenses from text
+confidence-threshold = 0.93
+
+# Licenses that are OK but currently unused are commented to prevent a warning
+allow = [
+    "Apache-2.0",
+    #"BSD-2-Clause",
+    "BSD-3-Clause",
+    #"BSL-1.0",
+    #"CC0-1.0",
+    "ISC",
+    "MIT",
+    "OpenSSL",
+    #"Unlicense",
+    #"Zlib"
+]
+
+exceptions = [ { allow = [ "MPL-2.0" ], name = "webpki-roots" } ]
+
+# https://github.com/hsivonen/encoding_rs The non-test code that isn't generated from the WHATWG data in this crate is
+# under Apache-2.0 OR MIT. Test code is under CC0.
+[[licenses.clarify]]
+name = "encoding_rs"
+version = "*"
+expression = "(Apache-2.0 OR MIT) AND BSD-3-Clause"
+license-files = [
+    { path = "COPYRIGHT", hash = 0x39f8ad31 }
+]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "ISC"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[sources]
+# Deny crates from unknown registries or git repositories.
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -3,6 +3,7 @@ name = "model"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 async-recursion = "1"

--- a/selftest/Cargo.toml
+++ b/selftest/Cargo.toml
@@ -2,6 +2,8 @@
 name = "selftest"
 version = "0.1.0"
 edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
 
 
 [dependencies]

--- a/testsys/Cargo.toml
+++ b/testsys/Cargo.toml
@@ -3,6 +3,7 @@ name = "testsys"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 base64 = "0.13.0"

--- a/yamlgen/Cargo.toml
+++ b/yamlgen/Cargo.toml
@@ -3,6 +3,7 @@ name = "yamlgen"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license = "MIT OR Apache-2.0"
 
 [build-dependencies]
 kube = { version = "0.67", default-features = false }


### PR DESCRIPTION
Adds a step to the build and makefile to use cargo deny to check
licenses.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #55

**Description of changes:**

Use cargo deny to make sure we only use the licenses that we want to use. I opened an issue to take a closer look at webpki-roots.

**Testing done:**

Ran `make cargo-deny` and we'll check the actions outcome as well.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
