### PR TITLE
cli: testsys run aws-k8s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,6 +2368,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "log",
+ "maplit",
  "model",
  "selftest",
  "serde",

--- a/bottlerocket-agents/src/bin/ec2-resource-agent/ec2_provider.rs
+++ b/bottlerocket-agents/src/bin/ec2-resource-agent/ec2_provider.rs
@@ -4,7 +4,7 @@ use aws_sdk_ec2::model::{
     TagSpecification,
 };
 use aws_sdk_ec2::Region;
-use bottlerocket_agents::{json_display, AWS_CREDENTIALS_SECRET_NAME};
+use bottlerocket_agents::{json_display, ClusterType, Ec2Config, AWS_CREDENTIALS_SECRET_NAME};
 use log::{debug, info, trace};
 use model::{Configuration, SecretName};
 use resource_agent::clients::InfoClient;
@@ -44,63 +44,6 @@ pub struct ProductionMemo {
 }
 
 impl Configuration for ProductionMemo {}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct Ec2Config {
-    /// The AMI ID of the AMI to use for the worker nodes.
-    node_ami: String,
-
-    /// The number of instances to create. If no value is provided 2 instances will be created.
-    instance_count: Option<i32>,
-
-    /// The type of instance to spin up. m5.large is recommended for x86_64 and m6g.large is
-    /// recommended for arm64 on eks. c3.large is recommended for ecs. If no value is provided
-    /// the recommended type will be used.
-    instance_type: Option<String>,
-
-    /// The name of the cluster we are creating instances for.
-    cluster_name: String,
-
-    /// The region the cluster is located in.
-    region: String,
-
-    /// The instance profile that should be attached to these instances.
-    instance_profile_arn: String,
-
-    /// The subnet the instances should be launched using.
-    subnet_id: String,
-
-    /// The type of cluster we are launching instances to.
-    cluster_type: ClusterType,
-
-    // Userdata related fields.
-    /// The eks server endpoint. The endpoint is required for eks clusters.
-    endpoint: Option<String>,
-
-    /// The eks certificate. The certificate is required for eks clusters.
-    certificate: Option<String>,
-
-    // Eks specific instance information.
-    /// The security groups that should be attached to the instances.
-    #[serde(default)]
-    security_groups: Vec<String>,
-}
-
-impl Configuration for Ec2Config {}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum ClusterType {
-    Eks,
-    Ecs,
-}
-
-impl Default for ClusterType {
-    fn default() -> Self {
-        Self::Eks
-    }
-}
 
 /// Once we have fulfilled the `Create` request, we return information about the batch of ec2 instances we
 /// created.

--- a/testsys/Cargo.toml
+++ b/testsys/Cargo.toml
@@ -12,6 +12,7 @@ futures = "0.3.8"
 k8s-openapi = { version = "0", features = ["v1_20", "api"], default-features = false }
 kube = { version = "0.64", default-features = true, features = ["config", "derive", "ws"] }
 log = "0.4"
+maplit = "1"
 model = { path = "../model" }
 serde = "1.0.130"
 serde_json = "1.0.61"

--- a/testsys/src/error.rs
+++ b/testsys/src/error.rs
@@ -69,6 +69,12 @@ pub(crate) enum Error {
     #[snafu(display("Could not extract registry url from '{}'", uri))]
     MissingRegistry { uri: String },
 
+    #[snafu(display("{}: {}", message, source))]
+    ModelClient {
+        message: String,
+        source: model::clients::Error,
+    },
+
     #[snafu(display("No stdout from request"))]
     NoOut,
 

--- a/testsys/src/main.rs
+++ b/testsys/src/main.rs
@@ -13,6 +13,7 @@ mod install;
 mod k8s;
 mod results;
 mod run;
+mod run_aws_k8s;
 mod run_file;
 mod run_sonobuoy;
 mod set;

--- a/testsys/src/run.rs
+++ b/testsys/src/run.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::{run_file, run_sonobuoy};
+use crate::{run_aws_k8s, run_file, run_sonobuoy};
 use kube::Client;
 use structopt::StructOpt;
 
@@ -16,13 +16,17 @@ enum Command {
     File(run_file::RunFile),
     /// Run a Sonobuoy test;.
     Sonobuoy(Box<run_sonobuoy::RunSonobuoy>),
+    /// Create an EKS resource, an EC2 resource, and run a Sonobuoy test. This test mode is useful
+    /// for the `aws-k8s` variants of Bottlerocket.
+    AwsK8s(Box<run_aws_k8s::RunAwsK8s>),
 }
 
 impl Run {
-    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
-        match &self.command {
+    pub(crate) async fn run(self, k8s_client: Client) -> Result<()> {
+        match self.command {
             Command::File(run_file) => run_file.run(k8s_client).await,
             Command::Sonobuoy(run_sonobuoy) => run_sonobuoy.run(k8s_client).await,
+            Command::AwsK8s(run_aws_k8s) => run_aws_k8s.run(k8s_client).await,
         }
     }
 }

--- a/testsys/src/run_aws_k8s.rs
+++ b/testsys/src/run_aws_k8s.rs
@@ -1,0 +1,281 @@
+use crate::error::{self, Result};
+use bottlerocket_agents::sonobuoy::Mode;
+use bottlerocket_agents::{
+    ClusterConfig, ClusterType, CreationPolicy, Ec2Config, K8sVersion, SonobuoyConfig,
+    AWS_CREDENTIALS_SECRET_NAME,
+};
+use kube::{api::ObjectMeta, Client};
+use maplit::btreemap;
+use model::clients::{CrdClient, ResourceClient, TestClient};
+use model::constants::{API_VERSION, NAMESPACE};
+use model::{
+    Agent, Configuration, DestructionPolicy, Resource, ResourceSpec, SecretName, Test, TestSpec,
+};
+use serde_json::Value;
+use snafu::ResultExt;
+use structopt::StructOpt;
+
+/// Create an EKS resource, EC2 resource and run Sonobuoy.
+#[derive(Debug, StructOpt)]
+pub(crate) struct RunAwsK8s {
+    /// Name of the sonobuoy test.
+    #[structopt(long, short)]
+    name: String,
+
+    /// Location of the sonobuoy test agent image.
+    // TODO - default to an ECR public repository image
+    #[structopt(long, short)]
+    test_agent_image: String,
+
+    /// Name of the pull secret for the sonobuoy test image (if needed).
+    #[structopt(long)]
+    test_agent_pull_secret: Option<String>,
+
+    /// Keep the test agent running after completion.
+    #[structopt(long)]
+    keep_running: bool,
+
+    /// The plugin used for the sonobuoy test. Normally this is `e2e` (the default).
+    #[structopt(long, default_value = "e2e")]
+    sonobuoy_plugin: String,
+
+    /// The mode used for the sonobuoy test. One of `non-disruptive-conformance`,
+    /// `certified-conformance`, `quick`. Although the Sonobuoy binary defaults to
+    /// `non-disruptive-conformance`, we default to `quick` to make a quick test the most ergonomic.
+    #[structopt(long, default_value = "quick")]
+    sonobuoy_mode: Mode,
+
+    /// The kubernetes version (with or without the v prefix). Examples: v1.21, 1.21.3, v1.20.1
+    #[structopt(long)]
+    kubernetes_version: Option<K8sVersion>,
+
+    /// The kubernetes conformance image used for the sonobuoy test.
+    #[structopt(long)]
+    kubernetes_conformance_image: Option<String>,
+
+    /// The name of the secret containing aws credentials.
+    #[structopt(long)]
+    aws_secret: Option<SecretName>,
+
+    /// The AWS region.
+    #[structopt(long, default_value = "us-west-2")]
+    region: String,
+
+    /// The name of the EKS cluster that will be used (whether it is being created or already
+    /// exists).
+    #[structopt(long)]
+    cluster_name: String,
+
+    /// The name of the TestSys resource that will represent this cluster. If you do not specify a
+    /// value, one will be created matching the `cluster-name`. Unless there is a name conflict or
+    /// you desire a specific resource name, then you do not need to supply a resource name here.
+    #[structopt(long)]
+    cluster_resource_name: Option<String>,
+
+    /// Whether or not we want the EKS cluster to be created. The possible values are:
+    /// - `create`: the cluster will be created, it is an error for the cluster to pre-exist
+    /// - `ifNotExists`: the cluster will be created if it does not already exist
+    /// - `never`: the cluster must pre-exist or else it is an error
+    #[structopt(long, default_value = "ifNotExists")]
+    cluster_creation_policy: CreationPolicy,
+
+    /// Whether or not we want the EKS cluster to be destroyed. The possible values are:
+    /// - `onDeletion`: the cluster will be destroyed when its TestSys resource is deleted.
+    /// - `never`: the cluster will not be destroyed.
+    #[structopt(long, default_value = "never")]
+    cluster_destruction_policy: DestructionPolicy,
+
+    /// The container image of the EKS resource provider.
+    // TODO - provide a default on ECR Public
+    #[structopt(long)]
+    cluster_provider_image: String,
+
+    /// Name of the pull secret for the cluster provider image.
+    #[structopt(long)]
+    cluster_provider_pull_secret: Option<String>,
+
+    /// The EC2 AMI ID to use for cluster nodes.
+    #[structopt(long)]
+    ami: String,
+
+    /// The EC2 instance type to use for cluster nodes. For example `m5.large`. If you do not
+    /// provide an instance type, an appropriate instance type will be used based on the AMI's
+    /// architecture.
+    #[structopt(long)]
+    instance_type: Option<String>,
+
+    /// The name of the TestSys resource that will represent EC2 instances serving as cluster nodes.
+    /// Defaults to `cluster-name-instances`.
+    #[structopt(long)]
+    ec2_resource_name: Option<String>,
+
+    /// The container image of the EC2 resource provider.
+    // TODO - provide a default on ECR Public
+    #[structopt(long)]
+    ec2_provider_image: String,
+
+    /// Name of the pull secret for the EC2 provider image.
+    #[structopt(long)]
+    ec2_provider_pull_secret: Option<String>,
+}
+
+impl RunAwsK8s {
+    pub(crate) async fn run(self, k8s_client: Client) -> Result<()> {
+        let cluster_resource_name = self
+            .cluster_resource_name
+            .as_ref()
+            .unwrap_or(&self.cluster_name);
+        let ec2_resource_name = self
+            .ec2_resource_name
+            .unwrap_or(format!("{}-instances", self.cluster_name));
+        let aws_secret_map = self.aws_secret.as_ref().map(|secret_name| {
+            btreemap! [ AWS_CREDENTIALS_SECRET_NAME.to_string() => secret_name.clone()]
+        });
+
+        let eks_resource = Resource {
+            api_version: API_VERSION.into(),
+            kind: "Resource".to_string(),
+            metadata: ObjectMeta {
+                name: Some(cluster_resource_name.clone()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: ResourceSpec {
+                depends_on: None,
+                agent: Agent {
+                    name: "eks-provider".to_string(),
+                    image: self.cluster_provider_image,
+                    pull_secret: self.cluster_provider_pull_secret,
+                    keep_running: false,
+                    timeout: None,
+                    configuration: Some(
+                        ClusterConfig {
+                            cluster_name: self.cluster_name.to_owned(),
+                            creation_policy: Some(self.cluster_creation_policy),
+                            region: Some(self.region.clone()),
+                            zones: None,
+                            version: self.kubernetes_version,
+                        }
+                        .into_map()
+                        .context(error::ConfigMap)?,
+                    ),
+                    secrets: aws_secret_map.clone(),
+                },
+                destruction_policy: self.cluster_destruction_policy,
+            },
+            status: None,
+        };
+
+        let mut ec2_config = Ec2Config {
+            node_ami: self.ami,
+            // TODO - configurable
+            instance_count: Some(2),
+            instance_type: self.instance_type,
+            cluster_name: self.cluster_name.clone(),
+            region: self.region,
+            instance_profile_arn: format!("${{{}.iamInstanceProfileArn}}", cluster_resource_name),
+            subnet_id: format!("${{{}.publicSubnetId}}", cluster_resource_name),
+            cluster_type: ClusterType::Eks,
+            endpoint: Some(format!("${{{}.endpoint}}", cluster_resource_name)),
+            certificate: Some(format!("${{{}.certificate}}", cluster_resource_name)),
+            security_groups: vec![],
+        }
+        .into_map()
+        .context(error::ConfigMap)?;
+
+        // TODO - we have change the raw map to reference/template a non string field.
+        let previous_value = ec2_config.insert(
+            "securityGroups".to_owned(),
+            Value::String(format!("${{{}.securityGroups}}", cluster_resource_name)),
+        );
+        if previous_value.is_none() {
+            todo!("This is an error: fields in the Ec2Config struct have changed")
+        }
+
+        let ec2_resource = Resource {
+            api_version: API_VERSION.into(),
+            kind: "Resource".to_string(),
+            metadata: ObjectMeta {
+                name: Some(ec2_resource_name.clone()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: ResourceSpec {
+                depends_on: Some(vec![cluster_resource_name.to_owned()]),
+                agent: Agent {
+                    name: "ec2-provider".to_string(),
+                    image: self.ec2_provider_image,
+                    pull_secret: self.ec2_provider_pull_secret,
+                    keep_running: false,
+                    timeout: None,
+                    configuration: Some(ec2_config),
+                    secrets: aws_secret_map.clone(),
+                },
+                destruction_policy: DestructionPolicy::OnDeletion,
+            },
+            status: None,
+        };
+
+        let test = Test {
+            api_version: API_VERSION.into(),
+            kind: "Test".to_string(),
+            metadata: ObjectMeta {
+                name: Some(self.name.clone()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: TestSpec {
+                resources: vec![ec2_resource_name.clone(), cluster_resource_name.clone()],
+                depends_on: Default::default(),
+                agent: Agent {
+                    name: "sonobuoy-test-agent".to_string(),
+                    image: self.test_agent_image.clone(),
+                    pull_secret: self.test_agent_pull_secret.clone(),
+                    keep_running: self.keep_running,
+                    timeout: None,
+                    configuration: Some(
+                        SonobuoyConfig {
+                            kubeconfig_base64: format!(
+                                "${{{}.encodedKubeconfig}}",
+                                cluster_resource_name
+                            ),
+                            plugin: self.sonobuoy_plugin.clone(),
+                            mode: self.sonobuoy_mode,
+                            kubernetes_version: self.kubernetes_version,
+                            kube_conformance_image: self.kubernetes_conformance_image.clone(),
+                        }
+                        .into_map()
+                        .context(error::ConfigMap)?,
+                    ),
+                    secrets: aws_secret_map,
+                },
+            },
+            status: None,
+        };
+        let resource_client = ResourceClient::new_from_k8s_client(k8s_client.clone());
+        let test_client = TestClient::new_from_k8s_client(k8s_client);
+
+        let _ = resource_client
+            .create(eks_resource)
+            .await
+            .context(error::ModelClient {
+                message: "Unable to create EKS cluster resource object",
+            })?;
+        println!("Created resource object '{}'", cluster_resource_name);
+
+        let _ = resource_client
+            .create(ec2_resource)
+            .await
+            .context(error::ModelClient {
+                message: "Unable to create EC2 instances resource object",
+            })?;
+        println!("Created resource object '{}'", ec2_resource_name);
+
+        let _ = test_client.create(test).await.context(error::ModelClient {
+            message: "Unable to create test object",
+        })?;
+        println!("Created test object '{}'", self.name);
+
+        Ok(())
+    }
+}

--- a/testsys/src/run_sonobuoy.rs
+++ b/testsys/src/run_sonobuoy.rs
@@ -56,7 +56,8 @@ pub(crate) struct RunSonobuoy {
     #[structopt(long, default_value = "quick")]
     mode: Mode,
 
-    /// The kubernetes version used for the sonobuoy test.
+    /// The kubernetes conformance version used for the sonobuoy test  (with or without the v
+    /// prefix). Examples: v1.21, 1.21.3, v1.20.1
     #[structopt(long)]
     kubernetes_version: Option<K8sVersion>,
 


### PR DESCRIPTION
(Re-opened after accidentally closing #246)

**Issue number:**

Closes #213

**Description of changes:**

Introduce a testsys command that creates an EKS cluster, runs instances,
and runs a Sonobuoy test.

```
$ cargo run --package testsys -- run aws-k8s --help
Create an EKS resource, an EC2 resource, and run a Sonobuoy test. This test mode is useful for the `aws-k8s` variants of
Bottlerocket

USAGE:
    testsys run aws-k8s [FLAGS] [OPTIONS] --ami <ami> --cluster-name <cluster-name> --cluster-provider-image <cluster-provider-image> --ec2-provider-image <ec2-provider-image> --name <name> --test-agent-image <test-agent-image>

FLAGS:
    -h, --help            Prints help information
        --keep-running    Keep the test agent running after completion
    -V, --version         Prints version information

OPTIONS:
        --ami <ami>                                                      The EC2 AMI ID to use for cluster nodes
        --aws-secret <aws-secret>
            The name of the secret containing aws credentials

        --cluster-creation-policy <cluster-creation-policy>
            Whether or not we want the EKS cluster to be created. The possible values are: - `create`: the cluster will
            be created, it is an error for the cluster to pre-exist - `ifNotExists`: the cluster will be created if it
            does not already exist - `never`: the cluster must pre-exist or else it is an error [default: ifNotExists]
        --cluster-destruction-policy <cluster-destruction-policy>
            Whether or not we want the EKS cluster to be destroyed. The possible values are: - `onDeletion`: the cluster
            will be destroyed when its TestSys resource is deleted. - `never`: the cluster will not be destroyed
            [default: never]
        --cluster-name <cluster-name>
            The name of the EKS cluster that will be used (whether it is being created or already exists)

        --cluster-provider-image <cluster-provider-image>
            The container image of the EKS resource provider

        --cluster-provider-pull-secret <cluster-provider-pull-secret>
            Name of the pull secret for the cluster provider image

        --cluster-resource-name <cluster-resource-name>
            The name of the TestSys resource that will represent this cluster. If you do not specify a value, one will
            be created matching the `cluster-name`. Unless there is a name conflict or you desire a specific resource
            name, then you do not need to supply a resource name here
        --ec2-provider-image <ec2-provider-image>
            The container image of the EC2 resource provider

        --ec2-provider-pull-secret <ec2-provider-pull-secret>
            Name of the pull secret for the EC2 provider image

        --ec2-resource-name <ec2-resource-name>
            The name of the TestSys resource that will represent EC2 instances serving as cluster nodes. Defaults to
            `cluster-name-instances`
        --instance-type <instance-type>
            The EC2 instance type to use for cluster nodes. For example `m5.large`. If you do not provide an instance
            type, an appropriate instance type will be used based on the AMI's architecture
        --kubernetes-conformance-image <kubernetes-conformance-image>
            The kubernetes conformance image used for the sonobuoy test

        --kubernetes-version <kubernetes-version>
            The kubernetes version (with or without the v prefix). Examples: v1.21, 1.21.3, v1.20.1

    -n, --name <name>                                                    Name of the sonobuoy test
        --region <region>                                                The AWS region [default: us-west-2]
        --sonobuoy-mode <sonobuoy-mode>
            The mode used for the sonobuoy test. One of `non-disruptive-conformance`, `certified-conformance`, `quick`.
            Although the Sonobuoy binary defaults to `non-disruptive-conformance`, we default to `quick` to make a quick
            test the most ergonomic [default: quick]
        --sonobuoy-plugin <sonobuoy-plugin>
            The plugin used for the sonobuoy test. Normally this is `e2e` (the default) [default: e2e]

    -t, --test-agent-image <test-agent-image>                            Location of the sonobuoy test agent image
        --test-agent-pull-secret <test-agent-pull-secret>
            Name of the pull secret for the sonobuoy test image (if needed)


```

**Testing done:**

# Testing the `testsys run aws-k8s` Command

## Reset (if needed due to running the test multiple times)

```shell
kubectl delete resource "${EKS_CLUSTER_NAME}" || \
kubectl delete resource "${EKS_CLUSTER_NAME}-instances" || \
kubectl delete test "${NAME}"
kind delete cluster --name "${NAME}"
rm -f "${KUBECONFIG}"
```

## Environment

```shell
export TESTSYS_DIR="$HOME/repos/bottlerocket-test-system"
export NAME=aws-k8s
export EKS_CLUSTER_NAME=aws-k8s-bottlerocket-cluster
export KUBECONFIG="/tmp/${NAME}.yaml"
export EKS_REGION="us-west-2"
export CARGO_HOME="${TESTSYS_DIR}/.cargo"
alias testsys="${TESTSYS_DIR}/.cargo/bin/testsys"
```

## Rebuild Containers and Testsys

```shell
cargo install --path "${TESTSYS_DIR}/testsys" --force

cd "${TESTSYS_DIR}"
make controller
make ec2-resource-agent
make eks-resource-agent
make sonobuoy-test-agent

docker tag controller controller:eks
docker tag ec2-resource-agent ec2-resource-agent:eks
docker tag eks-resource-agent eks-resource-agent:eks
docker tag sonobuoy-test-agent sonobuoy-test-agent:eks
```

## Create Testsys Cluster

```shell
kind create cluster --name "${NAME}"

kind load docker-image \
  controller:eks \
  ec2-resource-agent:eks \
  eks-resource-agent:eks \
  sonobuoy-test-agent:eks \
  --name "${NAME}"

testsys install --controller-uri controller:eks
kubectl config set-context --current --namespace="testsys-bottlerocket-aws"

# Add credentials
testsys add secret map  \
 --name "aws-creds" \
 "access-key-id=$(aws configure get default.aws_access_key_id)" \
 "secret-access-key=$(aws configure get default.aws_secret_access_key)"
```

## Launch Test

```shell
K8S_VER="1.21"
REGION="us-west-2"
ARCH="x86_64"
VARIANT="aws-k8s-${K8S_VER}"
STUPID_ARCH=$ARCH
if [ "${STUPID_ARCH}" = "aarch64" ]; then
    STUPID_ARCH=arm64
fi
export AMI_ID=$(aws ssm get-parameter \
  --region "${REGION}" \
  --name "/aws/service/bottlerocket/${VARIANT}/${STUPID_ARCH}/latest/image_id" \
  --query Parameter.Value --output text)

testsys run aws-k8s \
  --name "${NAME}" \
  --test-agent-image "sonobuoy-test-agent:eks" \
  --keep-running \
  --sonobuoy-mode "quick" \
  --kubernetes-version "v${K8S_VER}" \
  --aws-secret "aws-creds" \
  --region "${REGION}" \
  --cluster-name "${EKS_CLUSTER_NAME}" \
  --cluster-creation-policy "ifNotExists" \
  --cluster-destruction-policy "never" \
  --cluster-provider-image "eks-resource-agent:eks" \
  --ami "${AMI_ID}" \
  --ec2-provider-image "ec2-resource-agent:eks"
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
