### PR TITLE
Task definition creation

### DIFF
--- a/bottlerocket-agents/src/error.rs
+++ b/bottlerocket-agents/src/error.rs
@@ -1,6 +1,7 @@
 use aws_sdk_ecs::error::{
-    DeleteServiceError, DeregisterTaskDefinitionError, DescribeClustersError, DescribeTasksError,
-    RegisterTaskDefinitionError, RunTaskError, UpdateServiceError,
+    DeleteServiceError, DeregisterTaskDefinitionError, DescribeClustersError,
+    DescribeTaskDefinitionError, DescribeTasksError, RegisterTaskDefinitionError, RunTaskError,
+    UpdateServiceError,
 };
 use aws_sdk_ssm::error::{
     CreateDocumentError, DescribeInstanceInformationError, ListCommandInvocationsError,
@@ -117,6 +118,11 @@ pub enum Error {
         source: SdkError<RegisterTaskDefinitionError>,
     },
 
+    #[snafu(display("Unable to describe task definition: {}", source))]
+    TaskDefinitionDescribe {
+        source: SdkError<DescribeTaskDefinitionError>,
+    },
+
     #[snafu(display("Unable to run task: {}", source))]
     TaskRunCreation { source: SdkError<RunTaskError> },
 
@@ -153,4 +159,10 @@ pub enum Error {
 
     #[snafu(display("Registered container instances did not start in time: {}", source))]
     InstanceTimeout { source: tokio::time::error::Elapsed },
+
+    #[snafu(display("The default task does not exist"))]
+    TaskExist,
+
+    #[snafu(display("The task definition is missing"))]
+    TaskDefinitionMissing,
 }

--- a/bottlerocket-agents/src/lib.rs
+++ b/bottlerocket-agents/src/lib.rs
@@ -285,6 +285,8 @@ impl FromStr for K8sVersion {
 
 derive_serialize_from_display!(K8sVersion);
 derive_deserialize_from_fromstr!(K8sVersion, "k8s version such as v1.21 or 1.21.1");
+pub const DEFAULT_TASK_DEFINITION: &str = "testsys-bottlerocket-aws-default-ecs-smoke-test-v1";
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EcsTestConfig {
@@ -293,7 +295,12 @@ pub struct EcsTestConfig {
     #[serde(default = "default_count")]
     pub task_count: i32,
     pub subnet: String,
-    pub task_definition: String,
+    /// The task definition (including the revision number) for a custom task to be run. If the task
+    /// name is `foo` and the revision is `3`, use `foo:3`. If no
+    /// `task_definition_name_and_revision` is provided, the agent will use the latest task
+    /// definition named `testsys-bottlerocket-aws-default-ecs-smoke-test-v1` or create a new task
+    /// definition by that name if it hasn't been created yet.
+    pub task_definition_name_and_revision: Option<String>,
 }
 
 fn default_count() -> i32 {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #236 

Requires #254 

**Description of changes:**
Allows the user to specify an existing task definition that should be run, or use a testsys provided task definition that will be updated using `CreationPolicy`.


**Testing done:**
Tested all creation policies as well as an existing task definition.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
