### PR TITLE
model: add print columns

### DIFF
--- a/model/src/resource.rs
+++ b/model/src/resource.rs
@@ -21,7 +21,10 @@ use std::fmt::{Display, Formatter};
     plural = "resources",
     singular = "resource",
     status = "ResourceStatus",
-    version = "v1"
+    version = "v1",
+    printcolumn = r#"{"name":"DestructionPolicy", "type":"string", "jsonPath":".spec.destructionPolicy"}"#,
+    printcolumn = r#"{"name":"CreationState", "type":"string", "jsonPath":".status.creation.taskState"}"#,
+    printcolumn = r#"{"name":"DestructionState", "type":"string", "jsonPath":".status.destruction.taskState"}"#
 )]
 #[serde(rename_all = "camelCase")]
 pub struct ResourceSpec {
@@ -34,7 +37,6 @@ pub struct ResourceSpec {
     #[serde(deserialize_with = "crate::schema_utils::null_to_default")]
     #[serde(default)]
     #[schemars(schema_with = "crate::schema_utils::nullable_enum::<DestructionPolicy>")]
-    // #[schemars(nullable_enum)]
     pub destruction_policy: DestructionPolicy,
 }
 

--- a/model/src/test.rs
+++ b/model/src/test.rs
@@ -19,7 +19,9 @@ use std::borrow::Cow;
     plural = "tests",
     singular = "test",
     status = "TestStatus",
-    version = "v1"
+    version = "v1",
+    printcolumn = r#"{"name":"State", "type":"string", "jsonPath":".status.agent.taskState"}"#,
+    printcolumn = r#"{"name":"Result", "type":"string", "jsonPath":".status.agent.results.outcome"}"#
 )]
 #[serde(rename_all = "camelCase")]
 pub struct TestSpec {

--- a/yamlgen/deploy/testsys-crd.yaml
+++ b/yamlgen/deploy/testsys-crd.yaml
@@ -14,7 +14,13 @@ spec:
     singular: test
   scope: Namespaced
   versions:
-    - additionalPrinterColumns: []
+    - additionalPrinterColumns:
+        - jsonPath: ".status.agent.taskState"
+          name: State
+          type: string
+        - jsonPath: ".status.agent.results.outcome"
+          name: Result
+          type: string
       name: v1
       schema:
         openAPIV3Schema:
@@ -170,7 +176,16 @@ spec:
     singular: resource
   scope: Namespaced
   versions:
-    - additionalPrinterColumns: []
+    - additionalPrinterColumns:
+        - jsonPath: ".spec.destructionPolicy"
+          name: DestructionPolicy
+          type: string
+        - jsonPath: ".status.agent.creation.taskState"
+          name: CreationState
+          type: string
+        - jsonPath: ".status.agent.destruction.taskState"
+          name: CreationState
+          type: string
       name: v1
       schema:
         openAPIV3Schema:


### PR DESCRIPTION
Add columns that print when using kubectl get.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #268

**Description of changes:**

Add columns for kubectl get calls.

**Testing done:**
```
$ kubectl get resources
NAME                         DESTRUCTIONPOLICY   CREATIONSTATE   DESTRUCTIONSTATE
external-cluster             never               completed       unknown
external-cluster-instances   onDeletion          running         unknown
```

```
$ kubectl get tests 
NAME           STATE     RESULT
testsys-demo   running
```

```
$ kubectl get tests
NAME           STATE       RESULT
testsys-demo   completed   pass
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
