### PR TITLE
resource-agent: eks-tidy

### DIFF
--- a/yamlgen/deploy/testsys-crd.yaml
+++ b/yamlgen/deploy/testsys-crd.yaml
@@ -180,11 +180,11 @@ spec:
         - jsonPath: ".spec.destructionPolicy"
           name: DestructionPolicy
           type: string
-        - jsonPath: ".status.agent.creation.taskState"
+        - jsonPath: ".status.creation.taskState"
           name: CreationState
           type: string
-        - jsonPath: ".status.agent.destruction.taskState"
-          name: CreationState
+        - jsonPath: ".status.destruction.taskState"
+          name: DestructionState
           type: string
       name: v1
       schema:


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
Removes `public_subnet_ids` and `private_subnet_ids` from eks provider.
Removes duplicated `ClusterConfig` from eks provider.


**Testing done:**
`testsys run aws-k8s` runs as expected.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
