### PR TITLE
cli: `testsys delete`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,6 +2522,7 @@ dependencies = [
  "bottlerocket-agents",
  "env_logger",
  "futures",
+ "http",
  "k8s-openapi",
  "kube",
  "log",
@@ -2530,11 +2531,13 @@ dependencies = [
  "selftest",
  "serde",
  "serde_json",
+ "serde_plain",
  "serde_yaml",
  "snafu 0.7.0",
  "structopt",
  "tokio",
  "tokio-util",
+ "topological-sort",
  "yamlgen",
 ]
 
@@ -2710,6 +2713,12 @@ dependencies = [
  "slab",
  "tokio",
 ]
+
+[[package]]
+name = "topological-sort"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa7c7f42dea4b1b99439786f5633aeb9c14c1b53f75e282803c2ec2ad545873c"
 
 [[package]]
 name = "tough"

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -22,10 +22,11 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1"
 snafu = "0.7"
+tokio =  { version = "1", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
 selftest = { path = "../selftest" }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros"] }
 
 [features]
 # The `integ` feature enables integration tests. These tests require docker and kind.

--- a/testsys/Cargo.toml
+++ b/testsys/Cargo.toml
@@ -10,18 +10,21 @@ base64 = "0.13.0"
 bottlerocket-agents = { path = "../bottlerocket-agents" }
 env_logger = "0.9"
 futures = "0.3.8"
+http = "0"
 k8s-openapi = { version = "0.14", features = ["v1_20", "api"], default-features = false }
 kube = { version = "0.67", default-features = true, features = ["config", "derive", "ws"] }
 log = "0.4"
 maplit = "1"
 model = { path = "../model" }
 serde = "1.0.130"
+serde_plain = "1"
 serde_json = "1.0.61"
 serde_yaml = "0.8"
 snafu = "0.7"
 structopt = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
 tokio-util = "0.6.0"
+topological-sort = "0.1"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/testsys/src/delete.rs
+++ b/testsys/src/delete.rs
@@ -1,0 +1,163 @@
+use crate::error::{self, Result};
+use kube::Client;
+use model::clients::{CrdClient, ResourceClient, TestClient};
+use serde::Deserialize;
+use serde_plain::derive_fromstr_from_deserialize;
+use snafu::ResultExt;
+use std::collections::HashSet;
+use structopt::StructOpt;
+use topological_sort::TopologicalSort;
+
+/// Delete an object from a testsys cluster.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Delete {
+    /// The type of object that is being delete must be either `test` or `resource`.
+    #[structopt()]
+    object_type: ObjectType,
+
+    /// The name of the test/resource that should be deleted.
+    #[structopt()]
+    object_name: String,
+
+    /// Include this flag if all resources this object depends on should be deleted as well.
+    #[structopt(long)]
+    include_resources: bool,
+}
+
+#[derive(Deserialize, Debug, PartialEq, Eq)]
+enum ObjectType {
+    Test,
+    Resource,
+}
+
+derive_fromstr_from_deserialize!(ObjectType);
+
+impl Delete {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        match self.object_type {
+            ObjectType::Test => {
+                delete_test(k8s_client, &self.object_name, self.include_resources).await
+            }
+            ObjectType::Resource => {
+                delete_resource(k8s_client, &self.object_name, self.include_resources).await
+            }
+        }
+    }
+}
+
+/// Delete a testsys resource. If `include_resources`, all resources that this resource
+/// depended on will also be deleted.
+async fn delete_resource(
+    k8s_client: Client,
+    resource_name: &str,
+    include_resources: bool,
+) -> Result<()> {
+    let delete_order = if include_resources {
+        resource_dependency_delete_order(&k8s_client, vec![resource_name.to_string()]).await?
+    } else {
+        let mut topo_sort = TopologicalSort::new();
+        topo_sort.insert(resource_name);
+        topo_sort
+    };
+    delete_resources_in_order(&k8s_client, delete_order).await
+}
+
+/// Delete a testsys test. If `include_resources`, all resources that this test
+/// depended on will also be deleted.
+async fn delete_test(k8s_client: Client, test_name: &str, include_resources: bool) -> Result<()> {
+    let test_client = TestClient::new_from_k8s_client(k8s_client.clone());
+    let delete_order = if include_resources {
+        Some(resource_deletion_order_for_test(k8s_client.clone(), test_name).await?)
+    } else {
+        None
+    };
+    test_client
+        .delete(test_name)
+        .await
+        .context(error::DeleteSnafu {
+            what: test_name.to_string(),
+        })?;
+
+    println!("Deleting test '{}'", test_name);
+    test_client.wait_for_deletion(test_name).await;
+    println!("Test '{}' has been deleted", test_name);
+    if let Some(delete_order) = delete_order {
+        delete_resources_in_order(&k8s_client, delete_order).await
+    } else {
+        Ok(())
+    }
+}
+
+/// Delete all resources in a `TopologicalSort` in order. The function will wait
+/// for each resource to finish before starting to delete the next resource.
+async fn delete_resources_in_order(
+    k8s_client: &Client,
+    mut topo_sort: TopologicalSort<String>,
+) -> Result<()> {
+    let resource_client = ResourceClient::new_from_k8s_client(k8s_client.clone());
+    while !topo_sort.is_empty() {
+        if let Some(independent_resource) = topo_sort.pop() {
+            resource_client
+                .delete(&independent_resource)
+                .await
+                .context(error::DeleteSnafu {
+                    what: independent_resource.to_string(),
+                })?;
+
+            println!("Deleting resource '{}'", independent_resource);
+            resource_client
+                .wait_for_deletion(&independent_resource)
+                .await;
+            println!("Resource '{}' has been deleted", independent_resource);
+        }
+    }
+
+    Ok(())
+}
+
+/// Creates a `TopologicalSort` containing all resources that `test_name` depends on
+/// which provides an order for deletion.
+async fn resource_deletion_order_for_test(
+    k8s_client: Client,
+    test_name: &str,
+) -> Result<TopologicalSort<String>> {
+    let test_client = TestClient::new_from_k8s_client(k8s_client.clone());
+    let test = test_client.get(test_name).await.context(error::GetSnafu {
+        what: test_name.to_string(),
+    })?;
+    resource_dependency_delete_order(&k8s_client, test.spec.resources).await
+}
+
+/// Creates a `TopologicalSort` containing all resources including `initial_resources` that
+/// `initial_resources` depends on.
+async fn resource_dependency_delete_order(
+    k8s_client: &Client,
+    initial_resources: Vec<String>,
+) -> Result<TopologicalSort<String>> {
+    let resource_client = ResourceClient::new_from_k8s_client(k8s_client.clone());
+    let mut visited_resources = HashSet::<String>::from_iter(initial_resources.clone());
+    let mut to_be_visited = initial_resources.clone();
+
+    let mut topo_sort = TopologicalSort::new();
+
+    while let Some(resource_name) = to_be_visited.pop() {
+        let resource = resource_client
+            .get(&resource_name)
+            .await
+            .context(error::GetSnafu {
+                what: resource_name.to_string(),
+            })?;
+        if let Some(depended_resources) = resource.spec.depends_on {
+            for depended_resource in depended_resources {
+                topo_sort.add_dependency(resource_name.clone(), depended_resource.clone());
+
+                visited_resources.insert(depended_resource.clone());
+                to_be_visited.push(depended_resource);
+            }
+        } else {
+            topo_sort.insert(resource_name);
+        }
+    }
+
+    Ok(topo_sort)
+}

--- a/testsys/src/error.rs
+++ b/testsys/src/error.rs
@@ -36,6 +36,19 @@ pub(crate) enum Error {
     #[snafu(display("Error creating resource: {}", source))]
     CreateResource { source: model::clients::Error },
 
+    #[snafu(display("Unable to delete '{}': {}", what, source))]
+    Delete {
+        what: String,
+        source: model::clients::Error,
+    },
+
+    #[snafu(display("Error deleting {} '{}': {}", what, name, source))]
+    DeleteObject {
+        what: String,
+        name: String,
+        source: kube::Error,
+    },
+
     #[snafu(display("The following tests failed to run '{:?}'", tests))]
     FailedTest { tests: Vec<String> },
 

--- a/testsys/src/main.rs
+++ b/testsys/src/main.rs
@@ -8,6 +8,7 @@ mod add;
 mod add_aws_secret;
 mod add_secret;
 mod add_secret_map;
+mod delete;
 mod error;
 mod install;
 mod k8s;
@@ -58,6 +59,8 @@ enum Command {
     Results(results::Results),
     /// Retrieve the logs for a test pod.
     Logs(logs::Logs),
+    /// Delete a testsys object.
+    Delete(delete::Delete),
 }
 
 #[tokio::main]
@@ -80,6 +83,7 @@ async fn run(args: Args) -> Result<()> {
         Command::Set(set) => set.run(k8s_client).await,
         Command::Results(results) => results.run(k8s_client).await,
         Command::Logs(logs) => logs.run(k8s_client).await,
+        Command::Delete(delete) => delete.run(k8s_client).await,
     }
 }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #266 


**Description of changes:**
Adds `testsys delete`.
```
testsys delete -h
testsys-delete 0.1.0
Delete a testsys object

USAGE:
    testsys delete [FLAGS] <object-type> <object-name>

FLAGS:
    -h, --help                Prints help information
        --include-resource    Include this flag if all resources this object depends on should be deleted as well
    -V, --version             Prints version information

ARGS:
    <object-type>    The type of object that is being delete must be either `test` or `resource`
    <object-name>    The name of the test/resource that should be deleted
```

Correctly deletes resources in the order they were created in.
i.e A has resources B and C, and C depends on B
testsys must delete A first, then C and lastly B.


**Testing done:**
Used `testsys delete --include-resource test` and resources and test were deleted in the proper order.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
