### PR TITLE
build: use self-hosted runners in ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,66 +11,26 @@ on:
     branches: [develop]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v2
       - run: rustup update stable
       - run: make build
-      # Seems like artifact upload/download doesn't like hidden files.
-      - run: mv .cargo cargo
-      # Tar these with quick compression.
-      - run: tar cf - cargo | lz4 -2 - cargo.tar.lz4
-      - run: tar cf - target | lz4 -2 - target.tar.lz4
-      # Upload these artifacts for later use.
-      - uses: actions/upload-artifact@v2
-        with:
-          name: build-artifacts
-          path: |
-            cargo.tar.lz4
-            target.tar.lz4
-  images:
-    strategy:
-      matrix:
-        make_target:
-         - "controller"
-         - "duplicator-resource-agent"
-         - "ec2-resource-agent"
-         - "eks-resource-agent"
-         - "example-resource-agent"
-         - "example-test-agent"
-         - "sonobuoy-test-agent"
-         - "migration-test-agent"
-         - "vsphere-vm-resource-agent"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: make ${{ matrix.make_target }}
-      - run: docker save ${{ matrix.make_target }}:latest --output /tmp/${{ matrix.make_target }}.tar
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.make_target }}
-          path: /tmp/${{ matrix.make_target }}.tar
-  integ:
-    needs: [images, build]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          path: /tmp
-      - run: docker load --input /tmp/controller/controller.tar
-      - run: docker load --input /tmp/duplicator-resource-agent/duplicator-resource-agent.tar
-      - run: docker load --input /tmp/example-resource-agent/example-resource-agent.tar
-      - run: docker load --input /tmp/example-test-agent/example-test-agent.tar
-      - run: docker load --input /tmp/sonobuoy-test-agent/sonobuoy-test-agent.tar
-      - run: cd /tmp/build-artifacts && lz4 cargo.tar.lz4 - | tar xvf -
-      - run: cd /tmp/build-artifacts && lz4 target.tar.lz4 - | tar xvf -
-      - run: mv /tmp/build-artifacts/cargo .cargo
-      - run: mv /tmp/build-artifacts/target target
+      - run: make controller
+      - run: make duplicator-resource-agent
+      - run: make example-resource-agent
+      - run: make example-test-agent
       - run: make integ-test
         env:
           TESTSYS_SELFTEST_SKIP_IMAGE_BUILDS: true
+          TESTSYS_SELFTEST_THREADS: 6
+  images:
+    runs-on: [ self-hosted, linux, x64 ]
+    steps:
+      - uses: actions/checkout@v2
+      - run: make images
   license-check:
+    # A small machine is OK for this independent job.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -85,15 +85,19 @@ eks-resource-agent ec2-resource-agent ecs-resource-agent vsphere-vm-resource-age
 		--tag $@ \
 		.
 
-# If TESTSYS_SELFTEST_SKIP_IMAGE_BUILDS is set to a non-zero-length string, the container images
-# will not be rebuilt.
+# TESTSYS_SELFTEST_SKIP_IMAGE_BUILDS - If this is set to a non-zero-length string, the container images will will be
+#                                      expected to already exist and will not be built.
+# TESTSYS_SELFTEST_THREADS           - The number of tests that cargo will run in parallel. This defaults to 1 since the
+#                                      integration tests run Kubernetes clusters in kind which can be resource-intensive
+#                                      for some machines.
 integ-test: export TESTSYS_SELFTEST_KIND_PATH := $(shell pwd)/bin/kind
+integ-test: TESTSYS_SELFTEST_THREADS ?= 1
 integ-test: $(if $(TESTSYS_SELFTEST_SKIP_IMAGE_BUILDS), ,controller example-test-agent duplicator-resource-agent)
 	$(shell pwd)/bin/download-kind.sh --platform $(TESTSYS_BUILD_HOST_PLATFORM) --goarch ${TESTSYS_BUILD_HOST_GOARCH}
 	docker tag example-test-agent example-test-agent:integ
 	docker tag controller controller:integ
 	docker tag duplicator-resource-agent duplicator-resource-agent:integ
-	cargo test --features integ -- --test-threads=1
+	cargo test --features integ -- --test-threads=$(TESTSYS_SELFTEST_THREADS)
 
 cargo-deny:
 	# Install cargo-deny to CARGO_HOME which is set to be .cargo in this repository


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #262

**Description of changes:**

Reduce actions run time from over 50 minutes to under 20 minutes by using 16-core machines and eliminating the artifact upload and download steps.

**Testing done:**

Ran make integ-test locally and ran GitHub actions.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
