### PR TITLE
cli: `testsys logs`

### DIFF
--- a/testsys/src/error.rs
+++ b/testsys/src/error.rs
@@ -51,6 +51,12 @@ pub(crate) enum Error {
         source: kube::Error,
     },
 
+    #[snafu(display("Unable to get logs for '{}': {}", pod, source))]
+    Logs { pod: String, source: kube::Error },
+
+    #[snafu(display("Unable to get next log from stream: {}", source))]
+    LogsStream { source: kube::Error },
+
     #[snafu(display("Unable to get '{}': {}", what, source))]
     Get {
         what: String,

--- a/testsys/src/logs.rs
+++ b/testsys/src/logs.rs
@@ -1,0 +1,119 @@
+use crate::error::{self, Result};
+use futures::{stream::select_all, TryStreamExt};
+use k8s_openapi::api::core::v1::Pod;
+use kube::{
+    api::{ListParams, LogParams},
+    Api, Client, ResourceExt,
+};
+use model::{
+    clients::{CrdClient, TestClient},
+    constants::NAMESPACE,
+};
+use snafu::ResultExt;
+use structopt::StructOpt;
+
+/// Retrieve the logs for a testsys test and all resources it depends on.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Logs {
+    /// The name of the test.
+    #[structopt()]
+    test_name: String,
+
+    /// Include logs for the resource this test depends on.
+    #[structopt(long)]
+    include_resources: bool,
+
+    /// Keep and updated stream of logs.
+    #[structopt(long)]
+    follow: bool,
+}
+
+impl Logs {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        let test_client = TestClient::new_from_k8s_client(k8s_client.clone());
+        let test = test_client
+            .get(&self.test_name)
+            .await
+            .context(error::GetSnafu {
+                what: self.test_name.clone(),
+            })?;
+        let resources = test.spec.resources;
+
+        let pod_api = Api::<Pod>::namespaced(k8s_client, NAMESPACE);
+        let test_pods = pod_api
+            .list(&ListParams {
+                label_selector: Some(format!("job-name={}", &self.test_name)),
+                ..Default::default()
+            })
+            .await
+            .context(error::GetPodSnafu {
+                test_name: self.test_name.clone(),
+            })?;
+
+        let log_params = LogParams {
+            follow: self.follow,
+            pretty: true,
+            ..Default::default()
+        };
+
+        let mut streams = Vec::new();
+
+        if self.include_resources {
+            let mut pods = Vec::new();
+            for resource in resources {
+                pods.append(
+                    &mut pod_api
+                        .list(&ListParams {
+                            label_selector: Some(format!("job-name={}-creation", resource)),
+                            ..Default::default()
+                        })
+                        .await
+                        .context(error::GetPodSnafu {
+                            test_name: resource.clone(),
+                        })?
+                        .items,
+                );
+                pods.append(
+                    &mut pod_api
+                        .list(&ListParams {
+                            label_selector: Some(format!("job-name={}-destruction", resource)),
+                            ..Default::default()
+                        })
+                        .await
+                        .context(error::GetPodSnafu {
+                            test_name: resource.clone(),
+                        })?
+                        .items,
+                );
+            }
+            for pod in pods {
+                streams.push(
+                    pod_api
+                        .log_stream(&pod.name(), &log_params)
+                        .await
+                        .context(error::LogsSnafu { pod: pod.name() })?,
+                );
+            }
+        }
+        for pod in test_pods {
+            streams.push(
+                pod_api
+                    .log_stream(&pod.name(), &log_params)
+                    .await
+                    .context(error::LogsSnafu { pod: pod.name() })?,
+            );
+        }
+
+        let mut single_stream = select_all(streams);
+
+        while let Some(line) = single_stream
+            .try_next()
+            .await
+            .context(error::LogsStreamSnafu)?
+        {
+            println!("{:?}", String::from_utf8_lossy(&line));
+        }
+
+        Ok(())
+    }
+}

--- a/testsys/src/main.rs
+++ b/testsys/src/main.rs
@@ -11,6 +11,7 @@ mod add_secret_map;
 mod error;
 mod install;
 mod k8s;
+mod logs;
 mod results;
 mod run;
 mod run_aws_ecs;
@@ -55,6 +56,8 @@ enum Command {
     Set(set::Set),
     /// Retrieve the results tar from the test.
     Results(results::Results),
+    /// Retrieve the logs for a test pod.
+    Logs(logs::Logs),
 }
 
 #[tokio::main]
@@ -76,6 +79,7 @@ async fn run(args: Args) -> Result<()> {
         Command::Add(add) => add.run(k8s_client).await,
         Command::Set(set) => set.run(k8s_client).await,
         Command::Results(results) => results.run(k8s_client).await,
+        Command::Logs(logs) => logs.run(k8s_client).await,
     }
 }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #239

**Description of changes:**
`testsys logs <test-name>` retrieves the logs of the test pod. `--include-resources` can be added to also retrieve the logs of all resources for the test. `--follow` works in the same ways as `kubectl`.
```
testsys logs -h
testsys-logs 0.1.0
Read the logs for a TestSys test

USAGE:
    testsys logs [FLAGS] <test-name>

FLAGS:
        --follow               Keep and updated stream of logs
    -h, --help                 Prints help information
        --include-resources    Include logs for the resource this test depends on
    -V, --version              Prints version information

ARGS:
    <test-name>    The name of the test
```


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
