### PR TITLE
Test-agents to AL2 instead of scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -276,7 +276,7 @@ ENTRYPOINT ["./ecs-resource-agent"]
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Builds the ECS test agent image
-FROM scratch as ecs-test-agent
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 as ecs-test-agent
 # Copy binary
 COPY --from=build-src /src/bottlerocket-agents/bin/ecs-test-agent ./
 # Copy licenses
@@ -325,7 +325,7 @@ COPY --from=build-src /usr/share/licenses/testsys /licenses/testsys
 ENTRYPOINT ["./sonobuoy-test-agent"]
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
-FROM scratch as migration-test-agent
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 as migration-test-agent
 # Copy binary
 COPY --from=build-src /src/bottlerocket-agents/bin/migration-test-agent ./
 # Copy SSM documents


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Test agents rely on creating a temp directory, scratch doesn't have this capability.

**Testing done:**

Ecs test agent now works properly.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
