### PR TITLE
build: enable docker builds on internal hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@ USER builder
 ARG GOARCH
 ARG GOOS=linux
 ARG GOROOT="/usr/libexec/go"
+ARG GOPROXY
 
 ENV PATH="${GOROOT}/bin:${PATH}"
+ENV GOPROXY="${GOPROXY}"
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 FROM build as build-src

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,13 +91,16 @@ RUN mkdir eksctl && curl -L ${EKSCTL_SOURCE_URL} \
     rm eksctl_${EKSCTL_VERSION}.tar.gz
 
 WORKDIR /home/builder/eksctl/
-RUN go mod vendor
-RUN cp -p LICENSE /usr/share/licenses/eksctl && \
-    /usr/libexec/tools/bottlerocket-license-scan \
-      --clarify /src/clarify.toml \
-      --spdx-data /usr/libexec/tools/spdx-data \
-      --out-dir /usr/share/licenses/eksctl/vendor \
-      go-vendor ./vendor
+# TODO - restore this with a fix for https://github.com/bottlerocket-os/bottlerocket-test-system/issues/288
+# For reasons not yet understood, this can take an hour or more in certain environments. For now we need
+# to skip it until we can figure out what is happening.
+#RUN go mod vendor
+#RUN cp -p LICENSE /usr/share/licenses/eksctl && \
+#    /usr/libexec/tools/bottlerocket-license-scan \
+#      --clarify /src/clarify.toml \
+#      --spdx-data /usr/libexec/tools/spdx-data \
+#      --out-dir /usr/share/licenses/eksctl/vendor \
+#      go-vendor ./vendor
 RUN curl -L "${EKSCTL_BINARY_URL}" \
       -o eksctl_${EKSCTL_VERSION}_${GOOS}_${GOARCH}.tar.gz && \
     grep eksctl_${EKSCTL_VERSION}_${GOOS}_${GOARCH}.tar.gz \
@@ -253,8 +256,9 @@ FROM scratch as eks-resource-agent
 
 # Copy eksctl binary
 COPY --from=eksctl-build /tmp/eksctl /usr/bin/eksctl
+# TODO - restore this with a fix for https://github.com/bottlerocket-os/bottlerocket-test-system/issues/288
 # Copy eksctl licenses
-COPY --from=eksctl-build /usr/share/licenses/eksctl /licenses/eksctl
+#COPY --from=eksctl-build /usr/share/licenses/eksctl /licenses/eksctl
 
 # Copy binary
 COPY --from=build-src /src/bottlerocket-agents/bin/eks-resource-agent ./

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ TOP := $(dir $(firstword $(MAKEFILE_LIST)))
 TESTSYS_BUILD_HOST_UNAME_ARCH=$(shell uname -m)
 TESTSYS_BUILD_HOST_GOARCH ?= $(lastword $(subst :, ,$(filter $(TESTSYS_BUILD_HOST_UNAME_ARCH):%,x86_64:amd64 aarch64:arm64)))
 TESTSYS_BUILD_HOST_PLATFORM=$(shell uname | tr '[:upper:]' '[:lower:]')
+# On some hosts we get an x509 certificate error and need to set GOPROXY to "direct"
+TESTSYS_BUILD_GOPROXY ?= direct
 
 BOTTLEROCKET_SDK_VERSION = v0.25.1
 BOTTLEROCKET_SDK_ARCH = $(TESTSYS_BUILD_HOST_UNAME_ARCH)
@@ -21,6 +23,7 @@ show-variables:
 	$(info TESTSYS_BUILD_HOST_UNAME_ARCH=$(TESTSYS_BUILD_HOST_UNAME_ARCH))
 	$(info TESTSYS_BUILD_HOST_GOARCH=$(TESTSYS_BUILD_HOST_GOARCH))
 	$(info TESTSYS_BUILD_HOST_PLATFORM=$(TESTSYS_BUILD_HOST_PLATFORM))
+	$(info TESTSYS_BUILD_GOPROXY=$(TESTSYS_BUILD_GOPROXY))
 	@echo > /dev/null
 
 # Fetches crates from upstream
@@ -81,6 +84,8 @@ eks-resource-agent ec2-resource-agent ecs-resource-agent vsphere-vm-resource-age
 		--build-arg ARCH="$(TESTSYS_BUILD_HOST_UNAME_ARCH)" \
 		--build-arg BUILDER_IMAGE="$(BUILDER_IMAGE)" \
 		--build-arg GOARCH="$(TESTSYS_BUILD_HOST_GOARCH)" \
+		--build-arg GOPROXY="$(TESTSYS_BUILD_GOPROXY)" \
+		--network=host \
 		--target $@ \
 		--tag $@ \
 		.


### PR DESCRIPTION

**Issue number:**

Provides a temporary, unblocking workaround for #288 
Enables further work on #267

**Description of changes:**

On our internal build host we need `--network=host` and `GOPROXY=direct` in order for the docker builds to work function.

After that it was discovered that `go mod vendor` for `eksctl` takes over an hour. Something is wrong here, but in order to unblock, we can skip the license inclusion of eksctl until we are ready to publish containers.

**Testing done:**

The containers build on our build host in about 10 minutes, which is reasonable starting from a clean slate.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
