### PR TITLE
Iam instance profile creation wait

### DIFF
--- a/bottlerocket-agents/Cargo.toml
+++ b/bottlerocket-agents/Cargo.toml
@@ -30,7 +30,7 @@ serde_plain = "1"
 sha2 = "0.10"
 snafu = "0.7"
 test-agent = { path = "../agent/test-agent" }
-tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
 tough = { version = "0.12", features = ["http"] }
 url = "2.2"
 uuid = { version = "0.8", default-features = false, features = ["serde", "v4"] }

--- a/bottlerocket-agents/src/bin/ecs-resource-agent/ecs_provider.rs
+++ b/bottlerocket-agents/src/bin/ecs-resource-agent/ecs_provider.rs
@@ -11,7 +11,6 @@ use resource_agent::provider::{
     Create, Destroy, IntoProviderError, ProviderResult, Resources, Spec,
 };
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
 
 /// The default region for the cluster.
 const DEFAULT_REGION: &str = "us-west-2";
@@ -173,8 +172,6 @@ async fn create_iam_instance_profile(iam_client: &aws_sdk_iam::Client) -> Provid
                 Resources::Remaining,
                 "Unable to add role to instance profile",
             )?;
-        // TODO: find a better way to allow propagation than a sleep.
-        tokio::time::sleep(Duration::from_secs(60)).await;
         instance_profile_arn(iam_client).await
     }
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #258 

**Description of changes:**

Allows the ec2 resource provider to rerun `run_instances` 60s after failing due to `InvalidParameterValue`. This error is typically caused by an iam instance profile that has been created, but is not yet ready.

**Testing done:**

Creates and ecs cluster with a new iam instance profile, and ec2 run_instance was successful after rerunning.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
