### PR TITLE
build: copy ca certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -217,6 +217,8 @@ COPY --from=build /etc/ssl /etc/ssl
 COPY --from=build /etc/pki /etc/pki
 # Copy binary
 COPY --from=build-src /src/bottlerocket-agents/bin/ec2-resource-agent ./
+# Copy licenses
+COPY --from=build-src /usr/share/licenses/testsys /licenses/testsys
 
 ENTRYPOINT ["./ec2-resource-agent"]
 
@@ -260,6 +262,9 @@ COPY --from=eksctl-build /tmp/eksctl /usr/bin/eksctl
 # Copy eksctl licenses
 #COPY --from=eksctl-build /usr/share/licenses/eksctl /licenses/eksctl
 
+# Copy CA certificates store
+COPY --from=build /etc/ssl /etc/ssl
+COPY --from=build /etc/pki /etc/pki
 # Copy binary
 COPY --from=build-src /src/bottlerocket-agents/bin/eks-resource-agent ./
 # Copy licenses


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #294

**Description of changes:**

We lost the CA cert copies in one of the agents.
Also one of the agents was missing the rust license copy.

**Testing done:**

If it builds, it should fix the problem.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
