### PR TITLE
Fix glibc requirement for aws iam

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,7 +206,7 @@ RUN mkdir aws-iam-authenticator && \
 
 WORKDIR /home/builder/aws-iam-authenticator/
 RUN go mod vendor
-RUN go build -mod=vendor -o /tmp/aws-iam-authenticator \
+RUN CGO_ENABLED=0 go build -mod=vendor -o /tmp/aws-iam-authenticator \
       ./cmd/aws-iam-authenticator
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Al2 does not contain the necessary glibc version for the aws iam authenticator so we need to set `CGO_ENABLED=0` in order to use the aws iam authenticator in the sonobuoy test agent.

**Testing done:**
Sonobuoy test now performs as expected.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
