### PR TITLE
cli: upgrade/downgrade testing for `aws-k8s`, `aws-ecs`, `vmware`

### DIFF
--- a/testsys/src/run_aws_ecs.rs
+++ b/testsys/src/run_aws_ecs.rs
@@ -1,7 +1,9 @@
 use crate::error::{self, Result};
 use bottlerocket_agents::{
-    ClusterType, Ec2Config, EcsClusterConfig, EcsTestConfig, AWS_CREDENTIALS_SECRET_NAME,
+    ClusterType, Ec2Config, EcsClusterConfig, EcsTestConfig, MigrationConfig, TufRepoConfig,
+    AWS_CREDENTIALS_SECRET_NAME,
 };
+use kube::ResourceExt;
 use kube::{api::ObjectMeta, Client};
 use maplit::btreemap;
 use model::clients::{CrdClient, ResourceClient, TestClient};
@@ -9,7 +11,9 @@ use model::constants::NAMESPACE;
 use model::{
     Agent, Configuration, DestructionPolicy, Resource, ResourceSpec, SecretName, Test, TestSpec,
 };
+use serde_json::Value;
 use snafu::ResultExt;
+use std::collections::BTreeMap;
 use structopt::StructOpt;
 
 /// Create an EKS resource, EC2 resource and run Sonobuoy.
@@ -101,6 +105,35 @@ pub(crate) struct RunAwsEcs {
     /// Name of the pull secret for the EC2 provider image.
     #[structopt(long)]
     ec2_provider_pull_secret: Option<String>,
+
+    /// Perform an upgrade downgrade test.
+    #[structopt(long, requires_all(&["starting-version", "upgrade-version"]))]
+    upgrade_downgrade: bool,
+
+    /// Starting version for an upgrade/downgrade test.
+    #[structopt(long, requires("upgrade-downgrade"))]
+    starting_version: Option<String>,
+
+    /// Version the ec2 instances should be upgraded to in an upgrade/downgrade test.
+    #[structopt(long, requires("upgrade-downgrade"))]
+    upgrade_version: Option<String>,
+
+    /// Location of the tuf repo metadata.
+    #[structopt(long, requires_all(&["tuf-repo-targets-url", "upgrade-downgrade"]))]
+    tuf_repo_metadata_url: Option<String>,
+
+    /// Location of the tuf repo targets.
+    #[structopt(long, requires_all(&["tuf-repo-metadata-url", "upgrade-downgrade"]))]
+    tuf_repo_targets_url: Option<String>,
+
+    /// Location of the migration agent image.
+    // TODO - default to an ECR public repository image
+    #[structopt(long)]
+    migration_agent_image: Option<String>,
+
+    /// Name of the pull secret for the ecs migration image (if needed).
+    #[structopt(long)]
+    migration_agent_pull_secret: Option<String>,
 }
 
 impl RunAwsEcs {
@@ -111,115 +144,118 @@ impl RunAwsEcs {
             .unwrap_or(&self.cluster_name);
         let ec2_resource_name = self
             .ec2_resource_name
+            .clone()
             .unwrap_or(format!("{}-instances", self.cluster_name));
         let aws_secret_map = self.aws_secret.as_ref().map(|secret_name| {
             btreemap! [ AWS_CREDENTIALS_SECRET_NAME.to_string() => secret_name.clone()]
         });
 
-        let ecs_resource = Resource {
-            metadata: ObjectMeta {
-                name: Some(cluster_resource_name.clone()),
-                namespace: Some(NAMESPACE.into()),
-                ..Default::default()
-            },
-            spec: ResourceSpec {
-                depends_on: None,
-                agent: Agent {
-                    name: "ecs-provider".to_string(),
-                    image: self.cluster_provider_image,
-                    pull_secret: self.cluster_provider_pull_secret,
-                    keep_running: false,
-                    timeout: None,
-                    configuration: Some(
-                        EcsClusterConfig {
-                            cluster_name: self.cluster_name.to_owned(),
-                            region: Some(self.region.clone()),
-                            vpc: self.vpc,
-                        }
-                        .into_map()
-                        .context(error::ConfigMapSnafu)?,
-                    ),
-                    secrets: aws_secret_map.clone(),
-                    capabilities: None,
-                },
-                ..Default::default()
-            },
-            status: None,
+        let ecs_resource = self.ecs_resource(cluster_resource_name, aws_secret_map.clone())?;
+
+        let ec2_resource = self.ec2_resource(
+            &ec2_resource_name,
+            aws_secret_map.clone(),
+            cluster_resource_name,
+        )?;
+
+        let tests = if self.upgrade_downgrade {
+            if let (Some(starting_version), Some(upgrade_version), Some(migration_agent_image)) = (
+                self.starting_version.as_ref(),
+                self.upgrade_version.as_ref(),
+                self.migration_agent_image.as_ref(),
+            ) {
+                let tuf_repo = if let (Some(tuf_repo_metadata_url), Some(tuf_repo_targets_url)) = (
+                    self.tuf_repo_metadata_url.as_ref(),
+                    self.tuf_repo_targets_url.as_ref(),
+                ) {
+                    Some(TufRepoConfig {
+                        metadata_url: tuf_repo_metadata_url.to_string(),
+                        targets_url: tuf_repo_targets_url.to_string(),
+                    })
+                } else {
+                    None
+                };
+                let init_test_name = format!("{}-1-initial", self.name);
+                let upgrade_test_name = format!("{}-2-migrate", self.name);
+                let upgraded_test_name = format!("{}-3-migrated", self.name);
+                let downgrade_test_name = format!("{}-4-migrate", self.name);
+                let final_test_name = format!("{}-5-final", self.name);
+                let init_ecs_test = self.ecs_test(
+                    &init_test_name,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    None,
+                )?;
+                let upgrade_test = self.migration_test(
+                    &upgrade_test_name,
+                    upgrade_version,
+                    tuf_repo.clone(),
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![init_test_name.clone()]),
+                    migration_agent_image,
+                    &self.migration_agent_pull_secret,
+                )?;
+                let upgraded_ecs_test = self.ecs_test(
+                    &upgraded_test_name,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![init_test_name.clone(), upgrade_test_name.clone()]),
+                )?;
+                let downgrade_test = self.migration_test(
+                    &downgrade_test_name,
+                    starting_version,
+                    tuf_repo,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![
+                        init_test_name.clone(),
+                        upgrade_test_name.clone(),
+                        upgraded_test_name.clone(),
+                    ]),
+                    migration_agent_image,
+                    &self.migration_agent_pull_secret,
+                )?;
+                let final_ecs_test = self.ecs_test(
+                    &final_test_name,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![
+                        init_test_name,
+                        upgrade_test_name,
+                        upgraded_test_name,
+                        downgrade_test_name,
+                    ]),
+                )?;
+                vec![
+                    init_ecs_test,
+                    upgrade_test,
+                    upgraded_ecs_test,
+                    downgrade_test,
+                    final_ecs_test,
+                ]
+            } else {
+                return Err(error::Error::InvalidArguments {
+                    why: "If performing an upgrade/downgrade test, \
+                        `starting-version`, `upgrade-version` must be provided."
+                        .to_string(),
+                });
+            }
+        } else {
+            vec![self.ecs_test(
+                &self.name,
+                aws_secret_map.clone(),
+                &ec2_resource_name,
+                cluster_resource_name,
+                None,
+            )?]
         };
 
-        let ec2_config = Ec2Config {
-            node_ami: self.ami,
-            // TODO - configurable
-            instance_count: Some(2),
-            instance_type: self.instance_type,
-            cluster_name: self.cluster_name.clone(),
-            region: self.region,
-            instance_profile_arn: self
-                .iam_instance_profile_arn
-                .unwrap_or_else(|| format!("${{{}.iamInstanceProfileArn}}", cluster_resource_name)),
-            subnet_id: format!("${{{}.publicSubnetId}}", cluster_resource_name),
-            cluster_type: ClusterType::Ecs,
-            ..Default::default()
-        }
-        .into_map()
-        .context(error::ConfigMapSnafu)?;
-
-        let ec2_resource = Resource {
-            metadata: ObjectMeta {
-                name: Some(ec2_resource_name.clone()),
-                namespace: Some(NAMESPACE.into()),
-                ..Default::default()
-            },
-            spec: ResourceSpec {
-                depends_on: Some(vec![cluster_resource_name.to_owned()]),
-                agent: Agent {
-                    name: "ec2-provider".to_string(),
-                    image: self.ec2_provider_image,
-                    pull_secret: self.ec2_provider_pull_secret,
-                    keep_running: false,
-                    timeout: None,
-                    configuration: Some(ec2_config),
-                    secrets: aws_secret_map.clone(),
-                    capabilities: None,
-                },
-                destruction_policy: DestructionPolicy::OnDeletion,
-            },
-            status: None,
-        };
-
-        let test = Test {
-            metadata: ObjectMeta {
-                name: Some(self.name.clone()),
-                namespace: Some(NAMESPACE.into()),
-                ..Default::default()
-            },
-            spec: TestSpec {
-                resources: vec![ec2_resource_name.clone(), cluster_resource_name.clone()],
-                depends_on: Default::default(),
-                agent: Agent {
-                    name: "ecs-test-agent".to_string(),
-                    image: self.test_agent_image.clone(),
-                    pull_secret: self.test_agent_pull_secret.clone(),
-                    keep_running: self.keep_running,
-                    timeout: None,
-                    configuration: Some(
-                        EcsTestConfig {
-                            region: Some(format!("${{{}.region}}", cluster_resource_name)),
-                            cluster_name: format!("${{{}.clusterName}}", cluster_resource_name),
-                            task_count: self.task_count,
-                            subnet: format!("${{{}.publicSubnetId}}", cluster_resource_name),
-                            task_definition_name_and_revision: self
-                                .task_definition_name_and_revision,
-                        }
-                        .into_map()
-                        .context(error::ConfigMapSnafu)?,
-                    ),
-                    secrets: aws_secret_map,
-                    capabilities: None,
-                },
-            },
-            status: None,
-        };
         let resource_client = ResourceClient::new_from_k8s_client(k8s_client.clone());
         let test_client = TestClient::new_from_k8s_client(k8s_client);
 
@@ -239,14 +275,200 @@ impl RunAwsEcs {
             })?;
         println!("Created resource object '{}'", ec2_resource_name);
 
-        let _ = test_client
-            .create(test)
-            .await
-            .context(error::ModelClientSnafu {
-                message: "Unable to create test object",
-            })?;
-        println!("Created test object '{}'", self.name);
-
+        for test in tests {
+            let name = test.name();
+            let _ = test_client
+                .create(test)
+                .await
+                .context(error::ModelClientSnafu {
+                    message: "Unable to create test object",
+                })?;
+            println!("Created test object '{}'", name);
+        }
         Ok(())
+    }
+
+    fn ecs_resource(
+        &self,
+        name: &str,
+        secrets: Option<BTreeMap<String, SecretName>>,
+    ) -> Result<Resource> {
+        Ok(Resource {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: ResourceSpec {
+                depends_on: None,
+                agent: Agent {
+                    name: "ecs-provider".to_string(),
+                    image: self.cluster_provider_image.clone(),
+                    pull_secret: self.cluster_provider_pull_secret.clone(),
+                    keep_running: false,
+                    timeout: None,
+                    configuration: Some(
+                        EcsClusterConfig {
+                            cluster_name: self.cluster_name.to_owned(),
+                            region: Some(self.region.clone()),
+                            vpc: self.vpc.clone(),
+                        }
+                        .into_map()
+                        .context(error::ConfigMapSnafu)?,
+                    ),
+                    secrets,
+                    capabilities: None,
+                },
+                ..Default::default()
+            },
+            status: None,
+        })
+    }
+
+    fn ec2_resource(
+        &self,
+        name: &str,
+        secrets: Option<BTreeMap<String, SecretName>>,
+        cluster_resource_name: &str,
+    ) -> Result<Resource> {
+        let ec2_config = Ec2Config {
+            node_ami: self.ami.clone(),
+            // TODO - configurable
+            instance_count: Some(2),
+            instance_type: self.instance_type.clone(),
+            cluster_name: self.cluster_name.clone(),
+            region: self.region.clone(),
+            instance_profile_arn: self
+                .iam_instance_profile_arn
+                .clone()
+                .unwrap_or_else(|| format!("${{{}.iamInstanceProfileArn}}", cluster_resource_name)),
+            subnet_id: format!("${{{}.publicSubnetId}}", cluster_resource_name),
+            cluster_type: ClusterType::Ecs,
+            ..Default::default()
+        }
+        .into_map()
+        .context(error::ConfigMapSnafu)?;
+
+        Ok(Resource {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: ResourceSpec {
+                depends_on: Some(vec![cluster_resource_name.to_owned()]),
+                agent: Agent {
+                    name: "ec2-provider".to_string(),
+                    image: self.ec2_provider_image.clone(),
+                    pull_secret: self.ec2_provider_pull_secret.clone(),
+                    keep_running: false,
+                    timeout: None,
+                    configuration: Some(ec2_config),
+                    secrets,
+                    capabilities: None,
+                },
+                destruction_policy: DestructionPolicy::OnDeletion,
+            },
+            status: None,
+        })
+    }
+
+    fn ecs_test(
+        &self,
+        name: &str,
+        secrets: Option<BTreeMap<String, SecretName>>,
+        ec2_resource_name: &str,
+        cluster_resource_name: &str,
+        depends_on: Option<Vec<String>>,
+    ) -> Result<Test> {
+        Ok(Test {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: TestSpec {
+                resources: vec![
+                    ec2_resource_name.to_owned(),
+                    cluster_resource_name.to_owned(),
+                ],
+                depends_on,
+                agent: Agent {
+                    name: "ecs-test-agent".to_string(),
+                    image: self.test_agent_image.clone(),
+                    pull_secret: self.test_agent_pull_secret.clone(),
+                    keep_running: self.keep_running,
+                    timeout: None,
+                    configuration: Some(
+                        EcsTestConfig {
+                            region: Some(format!("${{{}.region}}", cluster_resource_name)),
+                            cluster_name: format!("${{{}.clusterName}}", cluster_resource_name),
+                            task_count: self.task_count,
+                            subnet: format!("${{{}.publicSubnetId}}", cluster_resource_name),
+                            task_definition_name_and_revision: self
+                                .task_definition_name_and_revision
+                                .clone(),
+                        }
+                        .into_map()
+                        .context(error::ConfigMapSnafu)?,
+                    ),
+                    secrets,
+                    capabilities: None,
+                },
+            },
+            status: None,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn migration_test(
+        &self,
+        name: &str,
+        version: &str,
+        tuf_repo: Option<TufRepoConfig>,
+        secrets: Option<BTreeMap<String, SecretName>>,
+        ec2_resource_name: &str,
+        cluster_resource_name: &str,
+        depends_on: Option<Vec<String>>,
+        migration_agent_image: &str,
+        migration_agent_pull_secret: &Option<String>,
+    ) -> Result<Test> {
+        let mut migration_config = MigrationConfig {
+            aws_region: format!("${{{}.region}}", cluster_resource_name),
+            instance_ids: Default::default(),
+            migrate_to_version: version.to_string(),
+            tuf_repo,
+        }
+        .into_map()
+        .context(error::ConfigMapSnafu)?;
+        migration_config.insert(
+            "instanceIds".to_string(),
+            Value::String(format!("${{{}.ids}}", ec2_resource_name)),
+        );
+        Ok(Test {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: TestSpec {
+                resources: vec![
+                    ec2_resource_name.to_owned(),
+                    cluster_resource_name.to_owned(),
+                ],
+                depends_on,
+                agent: Agent {
+                    name: "ecs-test-agent".to_string(),
+                    image: migration_agent_image.to_string(),
+                    pull_secret: migration_agent_pull_secret.clone(),
+                    keep_running: self.keep_running,
+                    timeout: None,
+                    configuration: Some(migration_config),
+                    secrets,
+                    capabilities: None,
+                },
+            },
+            status: None,
+        })
     }
 }

--- a/testsys/src/run_aws_k8s.rs
+++ b/testsys/src/run_aws_k8s.rs
@@ -1,9 +1,10 @@
 use crate::error::{self, Result};
 use bottlerocket_agents::sonobuoy::Mode;
 use bottlerocket_agents::{
-    ClusterType, CreationPolicy, Ec2Config, EksClusterConfig, K8sVersion, SonobuoyConfig,
-    AWS_CREDENTIALS_SECRET_NAME,
+    ClusterType, CreationPolicy, Ec2Config, EksClusterConfig, K8sVersion, MigrationConfig,
+    SonobuoyConfig, TufRepoConfig, AWS_CREDENTIALS_SECRET_NAME,
 };
+use kube::ResourceExt;
 use kube::{api::ObjectMeta, Client};
 use maplit::btreemap;
 use model::clients::{CrdClient, ResourceClient, TestClient};
@@ -13,6 +14,7 @@ use model::{
 };
 use serde_json::Value;
 use snafu::ResultExt;
+use std::collections::BTreeMap;
 use structopt::StructOpt;
 
 /// Create an EKS resource, EC2 resource and run Sonobuoy.
@@ -117,6 +119,35 @@ pub(crate) struct RunAwsK8s {
     /// Name of the pull secret for the EC2 provider image.
     #[structopt(long)]
     ec2_provider_pull_secret: Option<String>,
+
+    /// Perform an upgrade downgrade test.
+    #[structopt(long, requires_all(&["starting-version", "upgrade-version", "migration-agent-image"]))]
+    upgrade_downgrade: bool,
+
+    /// Starting version for an upgrade/downgrade test.
+    #[structopt(long, requires("upgrade-downgrade"))]
+    starting_version: Option<String>,
+
+    /// Version the ec2 instances should be upgraded to in an upgrade/downgrade test.
+    #[structopt(long, requires("upgrade-downgrade"))]
+    upgrade_version: Option<String>,
+
+    /// Location of the tuf repo metadata.
+    #[structopt(long, requires_all(&["tuf-repo-targets-url", "upgrade-downgrade"]))]
+    tuf_repo_metadata_url: Option<String>,
+
+    /// Location of the tuf repo targets.
+    #[structopt(long, requires_all(&["tuf-repo-metadata-url", "upgrade-downgrade"]))]
+    tuf_repo_targets_url: Option<String>,
+
+    /// Location of the migration agent image.
+    // TODO - default to an ECR public repository image
+    #[structopt(long, short)]
+    migration_agent_image: Option<String>,
+
+    /// Name of the pull secret for the eks migration image (if needed).
+    #[structopt(long)]
+    migration_agent_pull_secret: Option<String>,
 }
 
 impl RunAwsK8s {
@@ -127,128 +158,115 @@ impl RunAwsK8s {
             .unwrap_or(&self.cluster_name);
         let ec2_resource_name = self
             .ec2_resource_name
+            .clone()
             .unwrap_or(format!("{}-instances", self.cluster_name));
         let aws_secret_map = self.aws_secret.as_ref().map(|secret_name| {
             btreemap! [ AWS_CREDENTIALS_SECRET_NAME.to_string() => secret_name.clone()]
         });
 
-        let eks_resource = Resource {
-            metadata: ObjectMeta {
-                name: Some(cluster_resource_name.clone()),
-                namespace: Some(NAMESPACE.into()),
-                ..Default::default()
-            },
-            spec: ResourceSpec {
-                depends_on: None,
-                agent: Agent {
-                    name: "eks-provider".to_string(),
-                    image: self.cluster_provider_image,
-                    pull_secret: self.cluster_provider_pull_secret,
-                    keep_running: false,
-                    timeout: None,
-                    configuration: Some(
-                        EksClusterConfig {
-                            cluster_name: self.cluster_name.to_owned(),
-                            creation_policy: Some(self.cluster_creation_policy),
-                            region: Some(self.region.clone()),
-                            zones: None,
-                            version: self.kubernetes_version,
-                        }
-                        .into_map()
-                        .context(error::ConfigMapSnafu)?,
-                    ),
-                    secrets: aws_secret_map.clone(),
-                    capabilities: None,
-                },
-                destruction_policy: self.cluster_destruction_policy,
-            },
-            status: None,
-        };
+        let eks_resource = self.eks_resource(cluster_resource_name, aws_secret_map.clone())?;
+        let ec2_resource = self.ec2_resource(
+            &ec2_resource_name,
+            aws_secret_map.clone(),
+            cluster_resource_name,
+        )?;
 
-        let mut ec2_config = Ec2Config {
-            node_ami: self.ami,
-            // TODO - configurable
-            instance_count: Some(2),
-            instance_type: self.instance_type,
-            cluster_name: self.cluster_name.clone(),
-            region: self.region,
-            instance_profile_arn: format!("${{{}.iamInstanceProfileArn}}", cluster_resource_name),
-            subnet_id: format!("${{{}.publicSubnetId}}", cluster_resource_name),
-            cluster_type: ClusterType::Eks,
-            endpoint: Some(format!("${{{}.endpoint}}", cluster_resource_name)),
-            certificate: Some(format!("${{{}.certificate}}", cluster_resource_name)),
-            security_groups: vec![],
-        }
-        .into_map()
-        .context(error::ConfigMapSnafu)?;
-
-        // TODO - we have change the raw map to reference/template a non string field.
-        let previous_value = ec2_config.insert(
-            "securityGroups".to_owned(),
-            Value::String(format!("${{{}.securityGroups}}", cluster_resource_name)),
-        );
-        if previous_value.is_none() {
-            todo!("This is an error: fields in the Ec2Config struct have changed")
-        }
-
-        let ec2_resource = Resource {
-            metadata: ObjectMeta {
-                name: Some(ec2_resource_name.clone()),
-                namespace: Some(NAMESPACE.into()),
-                ..Default::default()
-            },
-            spec: ResourceSpec {
-                depends_on: Some(vec![cluster_resource_name.to_owned()]),
-                agent: Agent {
-                    name: "ec2-provider".to_string(),
-                    image: self.ec2_provider_image,
-                    pull_secret: self.ec2_provider_pull_secret,
-                    keep_running: false,
-                    timeout: None,
-                    configuration: Some(ec2_config),
-                    secrets: aws_secret_map.clone(),
-                    capabilities: None,
-                },
-                destruction_policy: DestructionPolicy::OnDeletion,
-            },
-            status: None,
-        };
-
-        let test = Test {
-            metadata: ObjectMeta {
-                name: Some(self.name.clone()),
-                namespace: Some(NAMESPACE.into()),
-                ..Default::default()
-            },
-            spec: TestSpec {
-                resources: vec![ec2_resource_name.clone(), cluster_resource_name.clone()],
-                depends_on: Default::default(),
-                agent: Agent {
-                    name: "sonobuoy-test-agent".to_string(),
-                    image: self.test_agent_image.clone(),
-                    pull_secret: self.test_agent_pull_secret.clone(),
-                    keep_running: self.keep_running,
-                    timeout: None,
-                    configuration: Some(
-                        SonobuoyConfig {
-                            kubeconfig_base64: format!(
-                                "${{{}.encodedKubeconfig}}",
-                                cluster_resource_name
-                            ),
-                            plugin: self.sonobuoy_plugin.clone(),
-                            mode: self.sonobuoy_mode,
-                            kubernetes_version: self.kubernetes_version,
-                            kube_conformance_image: self.kubernetes_conformance_image.clone(),
-                        }
-                        .into_map()
-                        .context(error::ConfigMapSnafu)?,
-                    ),
-                    secrets: aws_secret_map,
-                    // FIXME: Add CLI option for setting this
-                    capabilities: None,
-                },
-            },
-            status: None,
+        let tests = if self.upgrade_downgrade {
+            if let (Some(starting_version), Some(upgrade_version), Some(migration_agent_image)) = (
+                self.starting_version.as_ref(),
+                self.upgrade_version.as_ref(),
+                self.migration_agent_image.as_ref(),
+            ) {
+                let tuf_repo = if let (Some(tuf_repo_metadata_url), Some(tuf_repo_targets_url)) = (
+                    self.tuf_repo_metadata_url.as_ref(),
+                    self.tuf_repo_targets_url.as_ref(),
+                ) {
+                    Some(TufRepoConfig {
+                        metadata_url: tuf_repo_metadata_url.to_string(),
+                        targets_url: tuf_repo_targets_url.to_string(),
+                    })
+                } else {
+                    None
+                };
+                let init_test_name = format!("{}-1-initial", self.name);
+                let upgrade_test_name = format!("{}-2-migrate", self.name);
+                let upgraded_test_name = format!("{}-3-migrated", self.name);
+                let downgrade_test_name = format!("{}-4-migrate", self.name);
+                let final_test_name = format!("{}-5-final", self.name);
+                let init_eks_test = self.sonobuoy_test(
+                    &init_test_name,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    None,
+                )?;
+                let upgrade_test = self.migration_test(
+                    &upgrade_test_name,
+                    upgrade_version,
+                    tuf_repo.clone(),
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![init_test_name.clone()]),
+                    migration_agent_image,
+                    &self.migration_agent_pull_secret,
+                )?;
+                let upgraded_eks_test = self.sonobuoy_test(
+                    &upgraded_test_name,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![init_test_name.clone(), upgrade_test_name.clone()]),
+                )?;
+                let downgrade_test = self.migration_test(
+                    &downgrade_test_name,
+                    starting_version,
+                    tuf_repo,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![
+                        init_test_name.clone(),
+                        upgrade_test_name.clone(),
+                        upgraded_test_name.clone(),
+                    ]),
+                    migration_agent_image,
+                    &self.migration_agent_pull_secret,
+                )?;
+                let final_eks_test = self.sonobuoy_test(
+                    &final_test_name,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![
+                        init_test_name,
+                        upgrade_test_name,
+                        upgraded_test_name,
+                        downgrade_test_name,
+                    ]),
+                )?;
+                vec![
+                    init_eks_test,
+                    upgrade_test,
+                    upgraded_eks_test,
+                    downgrade_test,
+                    final_eks_test,
+                ]
+            } else {
+                return Err(error::Error::InvalidArguments {
+                    why: "If performing an upgrade/downgrade test,\
+                        `starting-version`, `upgrade-version` must be provided."
+                        .to_string(),
+                });
+            }
+        } else {
+            vec![self.sonobuoy_test(
+                &self.name,
+                aws_secret_map.clone(),
+                &ec2_resource_name,
+                cluster_resource_name,
+                None,
+            )?]
         };
         let resource_client = ResourceClient::new_from_k8s_client(k8s_client.clone());
         let test_client = TestClient::new_from_k8s_client(k8s_client);
@@ -269,14 +287,212 @@ impl RunAwsK8s {
             })?;
         println!("Created resource object '{}'", ec2_resource_name);
 
-        let _ = test_client
-            .create(test)
-            .await
-            .context(error::ModelClientSnafu {
-                message: "Unable to create test object",
-            })?;
-        println!("Created test object '{}'", self.name);
-
+        for test in tests {
+            let name = test.name();
+            let _ = test_client
+                .create(test)
+                .await
+                .context(error::ModelClientSnafu {
+                    message: "Unable to create test object",
+                })?;
+            println!("Created test object '{}'", name);
+        }
         Ok(())
+    }
+
+    fn eks_resource(
+        &self,
+        name: &str,
+        secrets: Option<BTreeMap<String, SecretName>>,
+    ) -> Result<Resource> {
+        Ok(Resource {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: ResourceSpec {
+                depends_on: None,
+                agent: Agent {
+                    name: "eks-provider".to_string(),
+                    image: self.cluster_provider_image.clone(),
+                    pull_secret: self.cluster_provider_pull_secret.clone(),
+                    keep_running: false,
+                    timeout: None,
+                    configuration: Some(
+                        EksClusterConfig {
+                            cluster_name: self.cluster_name.clone(),
+                            creation_policy: Some(self.cluster_creation_policy),
+                            region: Some(self.region.clone()),
+                            zones: None,
+                            version: self.kubernetes_version,
+                        }
+                        .into_map()
+                        .context(error::ConfigMapSnafu)?,
+                    ),
+                    secrets,
+                    capabilities: None,
+                },
+                destruction_policy: self.cluster_destruction_policy,
+            },
+            status: None,
+        })
+    }
+
+    fn ec2_resource(
+        &self,
+        name: &str,
+        secrets: Option<BTreeMap<String, SecretName>>,
+        cluster_resource_name: &str,
+    ) -> Result<Resource> {
+        let mut ec2_config = Ec2Config {
+            node_ami: self.ami.clone(),
+            // TODO - configurable
+            instance_count: Some(2),
+            instance_type: self.instance_type.clone(),
+            cluster_name: self.cluster_name.clone(),
+            region: self.region.clone(),
+            instance_profile_arn: format!("${{{}.iamInstanceProfileArn}}", cluster_resource_name),
+            subnet_id: format!("${{{}.publicSubnetId}}", cluster_resource_name),
+            cluster_type: ClusterType::Eks,
+            endpoint: Some(format!("${{{}.endpoint}}", cluster_resource_name)),
+            certificate: Some(format!("${{{}.certificate}}", cluster_resource_name)),
+            security_groups: vec![],
+        }
+        .into_map()
+        .context(error::ConfigMapSnafu)?;
+
+        // TODO - we have change the raw map to reference/template a non string field.
+        let previous_value = ec2_config.insert(
+            "securityGroups".to_owned(),
+            Value::String(format!("${{{}.securityGroups}}", cluster_resource_name)),
+        );
+        if previous_value.is_none() {
+            todo!("This is an error: fields in the Ec2Config struct have changed")
+        }
+
+        Ok(Resource {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: ResourceSpec {
+                depends_on: Some(vec![cluster_resource_name.to_owned()]),
+                agent: Agent {
+                    name: "ec2-provider".to_string(),
+                    image: self.ec2_provider_image.clone(),
+                    pull_secret: self.ec2_provider_pull_secret.clone(),
+                    keep_running: false,
+                    timeout: None,
+                    configuration: Some(ec2_config),
+                    secrets,
+                    capabilities: None,
+                },
+                destruction_policy: DestructionPolicy::OnDeletion,
+            },
+            status: None,
+        })
+    }
+
+    fn sonobuoy_test(
+        &self,
+        name: &str,
+        secrets: Option<BTreeMap<String, SecretName>>,
+        ec2_resource_name: &str,
+        cluster_resource_name: &str,
+        depends_on: Option<Vec<String>>,
+    ) -> Result<Test> {
+        Ok(Test {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: TestSpec {
+                resources: vec![
+                    ec2_resource_name.to_string(),
+                    cluster_resource_name.to_string(),
+                ],
+                depends_on,
+                agent: Agent {
+                    name: "sonobuoy-test-agent".to_string(),
+                    image: self.test_agent_image.clone(),
+                    pull_secret: self.test_agent_pull_secret.clone(),
+                    keep_running: self.keep_running,
+                    timeout: None,
+                    configuration: Some(
+                        SonobuoyConfig {
+                            kubeconfig_base64: format!(
+                                "${{{}.encodedKubeconfig}}",
+                                cluster_resource_name
+                            ),
+                            plugin: self.sonobuoy_plugin.clone(),
+                            mode: self.sonobuoy_mode,
+                            kubernetes_version: self.kubernetes_version,
+                            kube_conformance_image: self.kubernetes_conformance_image.clone(),
+                        }
+                        .into_map()
+                        .context(error::ConfigMapSnafu)?,
+                    ),
+                    secrets,
+                    // FIXME: Add CLI option for setting this
+                    capabilities: None,
+                },
+            },
+            status: None,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn migration_test(
+        &self,
+        name: &str,
+        version: &str,
+        tuf_repo: Option<TufRepoConfig>,
+        secrets: Option<BTreeMap<String, SecretName>>,
+        ec2_resource_name: &str,
+        cluster_resource_name: &str,
+        depends_on: Option<Vec<String>>,
+        migration_agent_image: &str,
+        migration_agent_pull_secret: &Option<String>,
+    ) -> Result<Test> {
+        let mut migration_config = MigrationConfig {
+            aws_region: format!("${{{}.region}}", cluster_resource_name),
+            instance_ids: Default::default(),
+            migrate_to_version: version.to_string(),
+            tuf_repo,
+        }
+        .into_map()
+        .context(error::ConfigMapSnafu)?;
+        migration_config.insert(
+            "instanceIds".to_string(),
+            Value::String(format!("${{{}.ids}}", ec2_resource_name)),
+        );
+        Ok(Test {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: TestSpec {
+                resources: vec![
+                    ec2_resource_name.to_owned(),
+                    cluster_resource_name.to_owned(),
+                ],
+                depends_on,
+                agent: Agent {
+                    name: "eks-test-agent".to_string(),
+                    image: migration_agent_image.to_string(),
+                    pull_secret: migration_agent_pull_secret.clone(),
+                    keep_running: self.keep_running,
+                    timeout: None,
+                    configuration: Some(migration_config),
+                    secrets,
+                    capabilities: None,
+                },
+            },
+            status: None,
+        })
     }
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

#292 

**Description of changes:**

Adds `--upgrade-downgrade` flag to each command will extra needed information.
If an upgrade/downgrade is being run, 5 test agents are created named:
`{test_name}-initial-test`: An initial test for the respective cluster (ecs task, sonobuoy)
`{test_name}-upgrade-migration-test`: Upgrade each instance from `starting-version` to `upgrade-version`
`{test_name}-upgraded-test`: Test the instances at `upgrade-version`
`{test_name}-downgrade-migration-test`: Downgrade each instance from `upgrade-version` to `starting-version`
`{test_name}-final-test`: Test the instances at `starting-version`.

**Testing done:**
System runs successfully for `testsys run aws-ecs --upgrade-downgrade ...` and `testsys run aws-eks --upgrade-downgrade ...`.
`testsys run vmware --upgrade-downgrade` is currently untested due to a network issue.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
