### PR TITLE
cli: `delete` object type lowercase

### DIFF
--- a/testsys/src/delete.rs
+++ b/testsys/src/delete.rs
@@ -25,6 +25,7 @@ pub(crate) struct Delete {
 }
 
 #[derive(Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
 enum ObjectType {
     Test,
     Resource,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

#293 

**Description of changes:**

Changes `ObjectType` to use lowercase for deserialization so that `testsys delete test` is accepted instead of `testsys delete Test`.

**Testing done:**

Delete works as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
