### PR TITLE
resource-agent: enable keep-running

### DIFF
--- a/agent/resource-agent/src/clients/agent_client.rs
+++ b/agent/resource-agent/src/clients/agent_client.rs
@@ -47,6 +47,8 @@ pub trait AgentClient: Sized {
 
     /// Notify Kubernetes that the destruction of resources failed and provide an error message.
     async fn send_destroy_failed(&self, error: &ProviderError) -> ClientResult<()>;
+
+    async fn get_keep_running(&self) -> ClientResult<bool>;
 }
 
 /// Provides the default [`AgentClient`] implementation.

--- a/agent/resource-agent/src/clients/implementation.rs
+++ b/agent/resource-agent/src/clients/implementation.rs
@@ -190,4 +190,14 @@ impl AgentClient for DefaultAgentClient {
             .await?;
         Ok(())
     }
+
+    async fn get_keep_running(&self) -> ClientResult<bool> {
+        Ok(self
+            .resource_client
+            .get(&self.data.resource_name)
+            .await?
+            .spec
+            .agent
+            .keep_running)
+    }
 }

--- a/agent/resource-agent/tests/mock/agent_client.rs
+++ b/agent/resource-agent/tests/mock/agent_client.rs
@@ -61,4 +61,8 @@ impl AgentClient for MockAgentClient {
     async fn send_destroy_failed(&self, _error: &ProviderError) -> ClientResult<()> {
         Ok(())
     }
+
+    async fn get_keep_running(&self) -> ClientResult<bool> {
+        Ok(false)
+    }
 }

--- a/bottlerocket-agents/src/lib.rs
+++ b/bottlerocket-agents/src/lib.rs
@@ -368,11 +368,11 @@ pub fn init_agent_logger(bin_crate: &str, log_level: Option<LevelFilter>) {
                 .filter_level(LevelFilter::Error)
                 // Set all of our crates to the desired level.
                 .filter(Some(bin_crate), log_level)
-                .filter(Some("agent-common"), log_level)
-                .filter(Some("bottlerocket-agents"), log_level)
+                .filter(Some("agent_common"), log_level)
+                .filter(Some("bottlerocket_agents"), log_level)
                 .filter(Some("model"), log_level)
-                .filter(Some("resource-agent"), log_level)
-                .filter(Some("test-agent"), log_level)
+                .filter(Some("resource_agent"), log_level)
+                .filter(Some("test_agent"), log_level)
                 .init();
         }
     }

--- a/testsys/src/run_aws_ecs.rs
+++ b/testsys/src/run_aws_ecs.rs
@@ -82,6 +82,10 @@ pub(crate) struct RunAwsEcs {
     #[structopt(long)]
     cluster_provider_pull_secret: Option<String>,
 
+    /// Keep the ECS cluster provider agent running after cluster creation.
+    #[structopt(long)]
+    keep_cluster_provider_running: bool,
+
     /// The EC2 AMI ID to use for cluster nodes.
     #[structopt(long)]
     ami: String,
@@ -105,6 +109,10 @@ pub(crate) struct RunAwsEcs {
     /// Name of the pull secret for the EC2 provider image.
     #[structopt(long)]
     ec2_provider_pull_secret: Option<String>,
+
+    /// Keep the EC2 instance provider running after instances are created.
+    #[structopt(long)]
+    keep_instance_provider_running: bool,
 
     /// Perform an upgrade downgrade test.
     #[structopt(long, requires_all(&["starting-version", "upgrade-version"]))]
@@ -305,7 +313,7 @@ impl RunAwsEcs {
                     name: "ecs-provider".to_string(),
                     image: self.cluster_provider_image.clone(),
                     pull_secret: self.cluster_provider_pull_secret.clone(),
-                    keep_running: false,
+                    keep_running: self.keep_cluster_provider_running,
                     timeout: None,
                     configuration: Some(
                         EcsClusterConfig {
@@ -361,7 +369,7 @@ impl RunAwsEcs {
                     name: "ec2-provider".to_string(),
                     image: self.ec2_provider_image.clone(),
                     pull_secret: self.ec2_provider_pull_secret.clone(),
-                    keep_running: false,
+                    keep_running: self.keep_instance_provider_running,
                     timeout: None,
                     configuration: Some(ec2_config),
                     secrets,

--- a/testsys/src/run_aws_k8s.rs
+++ b/testsys/src/run_aws_k8s.rs
@@ -96,6 +96,10 @@ pub(crate) struct RunAwsK8s {
     #[structopt(long)]
     cluster_provider_pull_secret: Option<String>,
 
+    /// Keep the EKS provider agent running after cluster creation.
+    #[structopt(long)]
+    keep_cluster_provider_running: bool,
+
     /// The EC2 AMI ID to use for cluster nodes.
     #[structopt(long)]
     ami: String,
@@ -119,6 +123,10 @@ pub(crate) struct RunAwsK8s {
     /// Name of the pull secret for the EC2 provider image.
     #[structopt(long)]
     ec2_provider_pull_secret: Option<String>,
+
+    /// Keep the EC2 instance provider running after instances are created.
+    #[structopt(long)]
+    keep_instance_provider_running: bool,
 
     /// Perform an upgrade downgrade test.
     #[structopt(long, requires_all(&["starting-version", "upgrade-version", "migration-agent-image"]))]
@@ -317,7 +325,7 @@ impl RunAwsK8s {
                     name: "eks-provider".to_string(),
                     image: self.cluster_provider_image.clone(),
                     pull_secret: self.cluster_provider_pull_secret.clone(),
-                    keep_running: false,
+                    keep_running: self.keep_cluster_provider_running,
                     timeout: None,
                     configuration: Some(
                         EksClusterConfig {
@@ -384,7 +392,7 @@ impl RunAwsK8s {
                     name: "ec2-provider".to_string(),
                     image: self.ec2_provider_image.clone(),
                     pull_secret: self.ec2_provider_pull_secret.clone(),
-                    keep_running: false,
+                    keep_running: self.keep_instance_provider_running,
                     timeout: None,
                     configuration: Some(ec2_config),
                     secrets,

--- a/testsys/src/run_vmware.rs
+++ b/testsys/src/run_vmware.rs
@@ -135,13 +135,17 @@ pub(crate) struct RunVmware {
     #[structopt(long, parse(from_os_str))]
     target_cluster_kubeconfig_path: PathBuf,
 
-    /// The ip for the cluster's control plane enedpoint ip.
+    /// The ip for the cluster's control plane endpoint ip.
     #[structopt(long)]
     cluster_endpoint: String,
 
     /// Capabilities that should be enabled in the resource provider and the test agent.
     #[structopt(long)]
     capabilities: Vec<String>,
+
+    /// Keep the VMWare instance provider running after instances are created.
+    #[structopt(long)]
+    keep_instance_provider_running: bool,
 
     /// Perform an upgrade downgrade test.
     #[structopt(long, requires_all(&["starting-version", "upgrade-version"]))]
@@ -345,7 +349,7 @@ impl RunVmware {
                     name: "vsphere-vm-provider".to_string(),
                     image: self.vm_provider_image.clone(),
                     pull_secret: self.vm_provider_pull_secret.clone(),
-                    keep_running: false,
+                    keep_running: self.keep_instance_provider_running,
                     timeout: None,
                     configuration: Some(vm_config),
                     secrets,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #79
Needed for troubleshooting during #267

**Description of changes:**

- In the resource-agent, make sure we stay running when asked to.
- In the test-agent, print error messages before going into our wait loop.
- In the CLI, make these available to the aws-k8s, aws-ecs and vmware-k8s commands.
- Fix the logging init function.

**Testing done:**

Tested using `testsys run aws-k8s` and it looks good.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
