### PR TITLE
build: reduce integ test parallelism

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       - run: make integ-test
         env:
           TESTSYS_SELFTEST_SKIP_IMAGE_BUILDS: true
-          TESTSYS_SELFTEST_THREADS: 6
+          TESTSYS_SELFTEST_THREADS: 1
   images:
     runs-on: [ self-hosted, linux, x64 ]
     steps:


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #281
(Maybe)

**Description of changes:**

GitHub actions runs are failing with a cryptic Kubernetes failure.
Maybe if we reduce the number of silmultaneous kind cluster spinups it
will alleviate the problem.

**Testing done:**

We will need to run it a few times on GitHub actions to see what affect it has, if any.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
