### PR TITLE
{eks,ec2}-resource-agent, testsys: generate cluster-dns-ip setting for BR userdata

### DIFF
--- a/bottlerocket-agents/src/bin/ec2-resource-agent/ec2_provider.rs
+++ b/bottlerocket-agents/src/bin/ec2-resource-agent/ec2_provider.rs
@@ -143,6 +143,7 @@ impl Create for Ec2Creator {
                 &spec.configuration.cluster_name,
                 &spec.configuration.endpoint,
                 &spec.configuration.certificate,
+                &spec.configuration.cluster_dns_ip,
                 &memo,
             )?)
             .iam_instance_profile(
@@ -301,6 +302,7 @@ fn userdata(
     cluster_name: &str,
     endpoint: &Option<String>,
     certificate: &Option<String>,
+    cluster_dns_ip: &Option<String>,
     memo: &ProductionMemo,
 ) -> ProviderResult<String> {
     Ok(match cluster_type {
@@ -311,14 +313,18 @@ ignore-waves = true
 [settings.kubernetes]
 api-server = "{}"
 cluster-name = "{}"
-cluster-certificate = "{}""#,
+cluster-certificate = "{}"
+cluster-dns-ip = "{}""#,
             endpoint
                 .as_ref()
                 .context(memo, "Server endpoint is required for eks clusters.")?,
             cluster_name,
             certificate
                 .as_ref()
-                .context(memo, "Cluster certificate is required for eks clusters.")?
+                .context(memo, "Cluster certificate is required for eks clusters.")?,
+            cluster_dns_ip
+                .as_ref()
+                .context(memo, "Cluster DNS IP is required for eks clusters.")?,
         )),
         ClusterType::Ecs => base64::encode(format!(
             r#"[settings.ecs]

--- a/bottlerocket-agents/src/lib.rs
+++ b/bottlerocket-agents/src/lib.rs
@@ -155,6 +155,9 @@ pub struct Ec2Config {
     /// The eks certificate. The certificate is required for eks clusters.
     pub certificate: Option<String>,
 
+    /// The cluster DNS IP for the K8s cluster. This is used to determine the IP family of the node IP.
+    pub cluster_dns_ip: Option<String>,
+
     // Eks specific instance information.
     /// The security groups that should be attached to the instances.
     #[serde(default)]

--- a/testsys/src/run_aws_k8s.rs
+++ b/testsys/src/run_aws_k8s.rs
@@ -357,6 +357,7 @@ impl RunAwsK8s {
             cluster_type: ClusterType::Eks,
             endpoint: Some(format!("${{{}.endpoint}}", cluster_resource_name)),
             certificate: Some(format!("${{{}.certificate}}", cluster_resource_name)),
+            cluster_dns_ip: Some(format!("${{{}.clusterDnsIp}}", cluster_resource_name)),
             security_groups: vec![],
         }
         .into_map()


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Partially addresses https://github.com/bottlerocket-os/bottlerocket-test-system/issues/252


**Description of changes:**
```
    {eks,ec2}-resource-agent, testsys: generate cluster-dns-ip setting for BR userdata
    
    The eks-resource-agent now determines the cluster-dns-ip from cluster
    info and sets it in the cluster output info.
    The ec2-resource-agent takes the cluster-dns-ip from the K8s cluster
    info and specifies the cluster-dns-ip setting in Bottlerocket's userdata
    when launching the nodes.
    
    All of this allows Bottlerocket to set its K8s node IP to the
    appropriate internal IP (either IPv4 address or IPv6 address)

```




**Testing done:**
Unit tests pass.

- [x] full EKS cluster creation -> EC2 resource agent test -> sonobuoy test succeeded.

```
ubuntu@ip-172-31-42-218:~/bottlerocket-test-system$ kubectl -n testsys-bottlerocket-aws logs ipv6-bottlerocket-creation-nsfjw 
[2022-02-18T00:12:33Z INFO  eks_resource_agent::eks_provider] Beginning creation of EKS cluster 'ipv6-bottlerocket' with creation policy 'Some(Never)'
[2022-02-18T00:12:33Z INFO  eks_resource_agent::eks_provider] Creation policy is 'Never' and cluster 'ipv6-bottlerocket' exists: not creating cluster
[2022-02-18T00:12:33Z INFO  eks_resource_agent::eks_provider] Writing kubeconfig file
2022-02-18 00:12:34 [ℹ]  eksctl version 0.82.0
2022-02-18 00:12:34 [ℹ]  using region us-west-2
2022-02-18 00:12:34 [✔]  saved kubeconfig as "/tmp/kubeconfig.yaml"
[2022-02-18T00:12:34Z INFO  eks_resource_agent::eks_provider] Gathering information about the cluster
[2022-02-18T00:12:34Z INFO  eks_resource_agent::eks_provider] Getting public subnet ids
[2022-02-18T00:12:34Z INFO  eks_resource_agent::eks_provider] Getting private subnet ids
[2022-02-18T00:12:34Z INFO  eks_resource_agent::eks_provider] Getting the nodegroup security group
[2022-02-18T00:12:34Z INFO  eks_resource_agent::eks_provider] Getting the controlplane security group
[2022-02-18T00:12:34Z INFO  eks_resource_agent::eks_provider] Getting the cluster shared security group
[2022-02-18T00:12:35Z INFO  eks_resource_agent::eks_provider] Getting cluster role ARN
[2022-02-18T00:12:35Z INFO  eks_resource_agent::eks_provider] Done

ubuntu@ip-172-31-42-218:~/bottlerocket-test-system$ kubectl -n testsys-bottlerocket-aws logs ipv6-bottlerocket-instances-creation-chhgf  -f
[2022-02-18T00:12:38Z INFO  ec2_resource_agent::ec2_provider] Beginning instance creation with instance UUID: bbf1df3b-78e9-415e-8726-82ca10402802
[2022-02-18T00:12:38Z INFO  ec2_resource_agent::ec2_provider] Using instance type 'm5.large'
[2022-02-18T00:12:38Z INFO  ec2_resource_agent::ec2_provider] Creating 2 instance(s)
[2022-02-18T00:12:38Z INFO  ec2_resource_agent::ec2_provider] Starting instances
[2022-02-18T00:12:40Z INFO  ec2_resource_agent::ec2_provider] Checking instance IDs
[2022-02-18T00:12:40Z INFO  ec2_resource_agent::ec2_provider] Waiting for instances to reach the running state
[2022-02-18T00:12:45Z INFO  ec2_resource_agent::ec2_provider] Done: instances {"i-09e6444b6df5c0af9", "i-0cf521a52b50ea8fa"} are running

ubuntu@ip-172-31-42-218:~/bottlerocket-test-system$ kubectl -n testsys-bottlerocket-aws logs ec2-ipv6-quick-5q6kl -f
[2022-02-18T00:12:48Z INFO  sonobuoy_test_agent] Initializing Sonobuoy test agent...
time="2022-02-18T00:12:48Z" level=info msg="created object" name=sonobuoy namespace= resource=namespaces
time="2022-02-18T00:12:48Z" level=info msg="created object" name=sonobuoy-serviceaccount namespace=sonobuoy resource=serviceaccounts
time="2022-02-18T00:12:48Z" level=info msg="created object" name=sonobuoy-serviceaccount-sonobuoy namespace= resource=clusterrolebindings
time="2022-02-18T00:12:48Z" level=info msg="created object" name=sonobuoy-serviceaccount-sonobuoy namespace= resource=clusterroles
time="2022-02-18T00:12:48Z" level=info msg="created object" name=sonobuoy-config-cm namespace=sonobuoy resource=configmaps
time="2022-02-18T00:12:48Z" level=info msg="created object" name=sonobuoy-plugins-cm namespace=sonobuoy resource=configmaps
time="2022-02-18T00:12:48Z" level=info msg="created object" name=sonobuoy namespace=sonobuoy resource=pods
time="2022-02-18T00:12:49Z" level=info msg="created object" name=sonobuoy-aggregator namespace=sonobuoy resource=services
202202180013_sonobuoy_d03793dd-ebc7-44b2-a746-787d54eb4211.tar.gz
time="2022-02-18T00:14:09Z" level=info msg=deleted kind=namespace namespace=sonobuoy
time="2022-02-18T00:14:09Z" level=info msg=deleted kind=clusterrolebindings
time="2022-02-18T00:14:09Z" level=info msg=deleted kind=clusterroles

```

The nodes have IPv6 node addresses:
```
$ kubectl get nodes -o wide
NAME                                           STATUS   ROLES    AGE     VERSION   INTERNAL-IP                              EXTERNAL-IP     OS-IMAGE                               KERNEL-VERSION   CONTAINER-RUNTIME
ip-192-168-73-157.us-west-2.compute.internal   Ready    <none>   2m50s   v1.21.9   2600:1f14:8f3:b902:f842:d8cb:51f2:3266   35.84.193.145   Bottlerocket OS 1.6.0 (aws-k8s-1.21)   5.10.93          containerd://1.5.9+bottlerocket
ip-192-168-91-186.us-west-2.compute.internal   Ready    <none>   2m55s   v1.21.9   2600:1f14:8f3:b902:556b:d3dd:bf21:a29c   35.86.242.145   Bottlerocket OS 1.6.0 (aws-k8s-1.21)   5.10.93          containerd://1.5.9+bottlerocket

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
