### PR TITLE
eks-resource-agent: subnet name tag update

### DIFF
--- a/bottlerocket-agents/src/bin/eks-resource-agent/eks_provider.rs
+++ b/bottlerocket-agents/src/bin/eks-resource-agent/eks_provider.rs
@@ -549,7 +549,7 @@ impl SubnetType {
             SubnetType::Public => "Public",
             SubnetType::Private => "Private",
         };
-        format!("eksctl-{}-cluster/Subnet{}*", cluster_name, subnet_type)
+        format!("eksctl-{}-cluster/*{}*", cluster_name, subnet_type)
     }
 }
 


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
The names of the subnets created by eksctl is not consistent, this filter
would catch both `SubnetPublic*` and `PublicSubnet*` naming conventions.
```


**Testing done:**
testsys can create a cluster CRD out of a pre-existing IPv6 cluster, public and private subnet IDs are properly populated.
```
    Private Subnet Id:         subnet-0153e8ea2dc9a840e
    Public Subnet Id:          subnet-0441f51922664ed19

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
