### PR TITLE
closed pull request

### DIFF
--- a/bottlerocket-agents/src/bin/ec2-resource-agent/ec2_provider.rs
+++ b/bottlerocket-agents/src/bin/ec2-resource-agent/ec2_provider.rs
@@ -403,8 +403,9 @@ async fn wait_for_conforming_instances(
 ) -> ProviderResult<()> {
     loop {
         if !non_conforming_instances(ec2_client, instance_ids, &desired_instance_state, memo)
-            .await?
-            .is_empty()
+            .await
+            .map_err(|e| warn!("Error checking status of instances. Retrying: {}", e))
+            .map_or(true, |ids| ids.is_empty())
         {
             trace!("Some instances are not ready, sleeping and trying again");
             tokio::time::sleep(Duration::from_millis(1000)).await;


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

There were a few changes that needed to be made to integrate `testsys` with the mcm.
1. The ec2 provider occasionally errored due to instances not being ready when `non_conforming_instances` was called. Causing the resource pod to fail. Instead, the errors are logged, and the pod continues to try to get the instances.2. 
2. The eks provider was choosing the wrong `iamidentitymapping` to use for the ec2 instances (it was selecting the first). Now the eks provider filters the identity mappings and selects the correct one.

**Testing done:**

Integration with the mcm was successful for aws-k8s variants.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
