### PR TITLE
improve sonobuoy testing

### DIFF
--- a/bottlerocket-agents/src/lib.rs
+++ b/bottlerocket-agents/src/lib.rs
@@ -35,6 +35,7 @@ pub const AWS_CREDENTIALS_SECRET_NAME: &str = "awsCredentials";
 pub const VSPHERE_CREDENTIALS_SECRET_NAME: &str = "vsphereCredentials";
 pub const TEST_CLUSTER_KUBECONFIG_PATH: &str = "/local/test-cluster.kubeconfig";
 pub const DEFAULT_AGENT_LEVEL_FILTER: LevelFilter = LevelFilter::Info;
+pub const SONOBUOY_RESULTS_FILENAME: &str = "sonobuoy-results.tar.gz";
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]

--- a/controller/src/job/mod.rs
+++ b/controller/src/job/mod.rs
@@ -109,7 +109,7 @@ pub(crate) async fn delete_job(k8s_client: kube::Client, name: &str) -> JobResul
             &DeleteParams {
                 dry_run: false,
                 grace_period_seconds: Some(0),
-                propagation_policy: Some(PropagationPolicy::Foreground),
+                propagation_policy: Some(PropagationPolicy::Background),
                 preconditions: None,
             },
         )

--- a/model/src/clients/http_status_code.rs
+++ b/model/src/clients/http_status_code.rs
@@ -1,5 +1,6 @@
 pub use http::StatusCode;
 use kube::Error;
+use std::fmt::Display;
 
 pub trait HttpStatusCode {
     fn status_code(&self) -> Option<StatusCode>;
@@ -27,5 +28,50 @@ where
 {
     fn status_code(&self) -> Option<StatusCode> {
         self.as_ref().err().and_then(|e| e.status_code())
+    }
+}
+
+pub trait IsFound<T, E>
+where
+    E: HttpStatusCode + Display,
+{
+    /// When an operation returns a `Result`, sometimes it is ok if that result is a `404`. For
+    /// example, if you are deleting something and if it is fine for the object you were trying to
+    /// delete to not exist.
+    ///
+    /// In this case you can call `.is_found()` to transform the `Result` into a `bool` with the
+    /// following logic:
+    ///
+    /// Returns `Ok(true)` if the the result was `Ok`. Returns `Ok(false)` if the result was `Err`
+    /// but the error was a `404`. Returns `Err(e)` for any error that is not a `404`.
+    ///
+    /// If you want to log the error or do anything else with it in the case of a `404` then you can
+    /// do so in `handle_not_found`.
+    ///
+    #[allow(clippy::wrong_self_convention)]
+    fn is_found<O>(self, handle_not_found: O) -> std::result::Result<bool, E>
+    where
+        O: FnOnce(E);
+}
+
+impl<T, E> IsFound<T, E> for std::result::Result<T, E>
+where
+    E: HttpStatusCode + Display,
+{
+    fn is_found<O>(self, handle_not_found: O) -> Result<bool, E>
+    where
+        O: FnOnce(E),
+    {
+        match self {
+            Ok(_) => Ok(true),
+            Err(e) => {
+                if e.is_status_code(StatusCode::NOT_FOUND) {
+                    handle_not_found(e);
+                    Ok(false)
+                } else {
+                    Err(e)
+                }
+            }
+        }
     }
 }

--- a/model/src/clients/mod.rs
+++ b/model/src/clients/mod.rs
@@ -9,4 +9,4 @@ mod resource_client;
 mod test_client;
 
 pub use crd_client::CrdClient;
-pub use http_status_code::{HttpStatusCode, StatusCode};
+pub use http_status_code::{HttpStatusCode, IsFound, StatusCode};

--- a/testsys/src/run_aws_ecs.rs
+++ b/testsys/src/run_aws_ecs.rs
@@ -350,7 +350,7 @@ impl RunAwsEcs {
                 .iam_instance_profile_arn
                 .clone()
                 .unwrap_or_else(|| format!("${{{}.iamInstanceProfileArn}}", cluster_resource_name)),
-            subnet_id: format!("${{{}.publicSubnetId}}", cluster_resource_name),
+            subnet_id: format!("${{{}.privateSubnetId}}", cluster_resource_name),
             cluster_type: ClusterType::Ecs,
             ..Default::default()
         }
@@ -412,7 +412,7 @@ impl RunAwsEcs {
                             region: Some(format!("${{{}.region}}", cluster_resource_name)),
                             cluster_name: format!("${{{}.clusterName}}", cluster_resource_name),
                             task_count: self.task_count,
-                            subnet: format!("${{{}.publicSubnetId}}", cluster_resource_name),
+                            subnet: format!("${{{}.privateSubnetId}}", cluster_resource_name),
                             task_definition_name_and_revision: self
                                 .task_definition_name_and_revision
                                 .clone(),

--- a/testsys/src/run_aws_k8s.rs
+++ b/testsys/src/run_aws_k8s.rs
@@ -361,7 +361,7 @@ impl RunAwsK8s {
             cluster_name: self.cluster_name.clone(),
             region: self.region.clone(),
             instance_profile_arn: format!("${{{}.iamInstanceProfileArn}}", cluster_resource_name),
-            subnet_id: format!("${{{}.publicSubnetId}}", cluster_resource_name),
+            subnet_id: format!("${{{}.privateSubnetId}}", cluster_resource_name),
             cluster_type: ClusterType::Eks,
             endpoint: Some(format!("${{{}.endpoint}}", cluster_resource_name)),
             certificate: Some(format!("${{{}.certificate}}", cluster_resource_name)),


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #332
Attempts to improve #328
Closes #324
Closes #331

**Description of changes:**

```
When the testsys CLI is creating EC2 instances for EKS and ECS
clusters, it should default to using private subnets. Later if we need
public subnets for some reason, we can make this configurable.
```

```
The background propagation policy is described as "Allow[ing] the
garbage collector to delete the dependents in the background.
Hopefully this will speed up deletes.
```

```
When the CLI is performing a delete, and the item to be deleted does
not exist, we should not error out. Instead we should inform the user
that the item was not found.
```

```
sonobuoy-test-agent: print results in logs

This will make it easier to find out what tests failed. Sometimes all
you need is the name. At least now we can look at the pod logs.
```

**Testing done:**

- using private subnets works
- the background propagation policy... hard to say if it had any effect, but no harm was done
- print results in logs: this failed because there was a --kubeconfig argument. i have removed that argument since seeing that problem. the good news is, it didn't crash the agent since the code i wrote allows sonobuoy results to fail... so no harm done and i think it will work now
- used `testsys delete` to delete a test where the resources were missing and saw:

```
Resource 'aarch64-aws-k8s-121' does not exist. Skipping.
Resource 'aarch64-aws-k8s-121-instances' does not exist. Skipping.
Deleting test 'conformance-aarch64-aws-k8s-121-test'
Test 'conformance-aarch64-aws-k8s-121-test' has been deleted
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
