### PR TITLE
optionally ignore resource destruction error

### DIFF
--- a/model/src/resource.rs
+++ b/model/src/resource.rs
@@ -38,6 +38,13 @@ pub struct ResourceSpec {
     #[serde(default)]
     #[schemars(schema_with = "crate::schema_utils::nullable_enum::<DestructionPolicy>")]
     pub destruction_policy: DestructionPolicy,
+    /// If the destruction pod fails with error it can be difficult to delete the resource from the
+    /// cluster. When you set this to `true` you are telling the controller that you understand the
+    /// physical resources were not destroyed, but you want the `Resource` CRD object delete from
+    /// the cluster anyway.
+    #[serde(deserialize_with = "crate::schema_utils::null_to_default")]
+    #[serde(default)]
+    pub ignore_destruction_failure: Option<bool>,
 }
 
 impl Resource {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Thoughts on #323

**Description of changes:**

An idea for abandoning resources when the destruction pod fails

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
