### PR TITLE
cli: `restart test`

### DIFF
--- a/testsys/src/main.rs
+++ b/testsys/src/main.rs
@@ -13,6 +13,8 @@ mod error;
 mod install;
 mod k8s;
 mod logs;
+mod restart;
+mod restart_test;
 mod results;
 mod run;
 mod run_aws_ecs;
@@ -62,6 +64,8 @@ enum Command {
     Logs(logs::Logs),
     /// Delete a testsys object.
     Delete(delete::Delete),
+    /// Restart a testsys test.
+    Restart(restart::Restart),
 }
 
 #[tokio::main]
@@ -85,6 +89,7 @@ async fn run(args: Args) -> Result<()> {
         Command::Results(results) => results.run(k8s_client).await,
         Command::Logs(logs) => logs.run(k8s_client).await,
         Command::Delete(delete) => delete.run(k8s_client).await,
+        Command::Restart(restart) => restart.run(k8s_client).await,
     }
 }
 

--- a/testsys/src/restart.rs
+++ b/testsys/src/restart.rs
@@ -1,0 +1,25 @@
+use crate::error::Result;
+use crate::restart_test;
+use kube::Client;
+use structopt::StructOpt;
+
+/// Restart testsys tests.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Restart {
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, StructOpt)]
+enum Command {
+    /// Restart a testsys test.
+    Test(restart_test::RestartTest),
+}
+
+impl Restart {
+    pub(crate) async fn run(self, k8s_client: Client) -> Result<()> {
+        match self.command {
+            Command::Test(restart_test) => restart_test.run(k8s_client).await,
+        }
+    }
+}

--- a/testsys/src/restart_test.rs
+++ b/testsys/src/restart_test.rs
@@ -1,0 +1,40 @@
+use crate::error::{self, Result};
+use kube::Client;
+use model::clients::{CrdClient, TestClient};
+use snafu::ResultExt;
+use structopt::StructOpt;
+
+/// Restart an object from a testsys cluster.
+#[derive(Debug, StructOpt)]
+pub(crate) struct RestartTest {
+    /// The name of the test to be restarted.
+    #[structopt()]
+    test_name: String,
+}
+
+impl RestartTest {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        let test_client = TestClient::new_from_k8s_client(k8s_client.clone());
+        let mut test = test_client
+            .get(&self.test_name)
+            .await
+            .context(error::GetSnafu {
+                what: self.test_name.clone(),
+            })?;
+        // Created objects are not allowed to have `resource_version` set.
+        test.metadata.resource_version = None;
+        test.status = None;
+        test_client
+            .delete(&self.test_name)
+            .await
+            .context(error::DeleteSnafu {
+                what: self.test_name.clone(),
+            })?;
+        test_client.wait_for_deletion(&self.test_name).await;
+        test_client
+            .create(test)
+            .await
+            .context(error::CreateTestSnafu)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #340 

**Description of changes:**

Adds `testsys restart test <test-name>`. This command deletes the test object and then re-creates it.

**Testing done:**

Ran `testsys run aws-k8s ...` and after test completion used `testsys restart test ...` and the sonobuoy test was deleted and a new one was started.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
