### PR TITLE
Ec2 instance creation and termination timeout

### DIFF
--- a/bottlerocket-agents/src/bin/ec2-resource-agent/ec2_provider.rs
+++ b/bottlerocket-agents/src/bin/ec2-resource-agent/ec2_provider.rs
@@ -182,7 +182,7 @@ impl Create for Ec2Creator {
         // Ensure the instances reach a running state.
         info!("Waiting for instances to reach the running state");
         tokio::time::timeout(
-            Duration::from_secs(60),
+            Duration::from_secs(300),
             wait_for_conforming_instances(
                 &ec2_client,
                 &instance_ids,
@@ -532,7 +532,7 @@ impl Destroy for Ec2Destroyer {
 
         // Ensure the instances reach a terminated state.
         tokio::time::timeout(
-            Duration::from_secs(300),
+            Duration::from_secs(600),
             wait_for_conforming_instances(
                 &ec2_client,
                 &ids,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #337 

**Description of changes:**

Increases the timeout for waiting for running instances and terminated instances.

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
