### PR TITLE
cli: do not pass k8s version to sonobuoy

### DIFF
--- a/bottlerocket-agents/src/lib.rs
+++ b/bottlerocket-agents/src/lib.rs
@@ -52,6 +52,11 @@ pub struct SonobuoyConfig {
     pub kubeconfig_base64: String,
     pub plugin: String,
     pub mode: Mode,
+    /// This will be passed to `sonobuoy run` as `--kubernetes-version` if `kube_conformance_image`
+    /// is `None`. **Caution**: if you provide `kubernetes_version`, it must precisely match the
+    /// control plane version. If it is off by even a patch-level from the control plane, some tests
+    /// may fail. Unless you have a specific reason to pass `kubernetes_version`, it is best to
+    /// leave this as `None` and let the sonobuoy binary choose the right value.
     pub kubernetes_version: Option<K8sVersion>,
     pub kube_conformance_image: Option<String>,
 }

--- a/testsys/src/run_aws_k8s.rs
+++ b/testsys/src/run_aws_k8s.rs
@@ -47,10 +47,6 @@ pub(crate) struct RunAwsK8s {
     #[structopt(long, default_value = "quick")]
     sonobuoy_mode: Mode,
 
-    /// The kubernetes version (with or without the v prefix). Examples: v1.21, 1.21.3, v1.20.1
-    #[structopt(long)]
-    kubernetes_version: Option<K8sVersion>,
-
     /// The kubernetes conformance image used for the sonobuoy test.
     #[structopt(long)]
     kubernetes_conformance_image: Option<String>,
@@ -73,6 +69,12 @@ pub(crate) struct RunAwsK8s {
     /// you desire a specific resource name, then you do not need to supply a resource name here.
     #[structopt(long)]
     cluster_resource_name: Option<String>,
+
+    /// The version of the EKS cluster that is to be created (with or without the 'v', e.g. 1.20 or
+    /// v1.21, etc.) *This only affects EKS cluster creation!* If the cluster already exists, this
+    /// option will have no affect.
+    #[structopt(long)]
+    cluster_version: Option<K8sVersion>,
 
     /// Whether or not we want the EKS cluster to be created. The possible values are:
     /// - `create`: the cluster will be created, it is an error for the cluster to pre-exist
@@ -333,7 +335,7 @@ impl RunAwsK8s {
                             creation_policy: Some(self.cluster_creation_policy),
                             region: Some(self.region.clone()),
                             zones: None,
-                            version: self.kubernetes_version,
+                            version: self.cluster_version,
                         }
                         .into_map()
                         .context(error::ConfigMapSnafu)?,
@@ -438,7 +440,7 @@ impl RunAwsK8s {
                             ),
                             plugin: self.sonobuoy_plugin.clone(),
                             mode: self.sonobuoy_mode,
-                            kubernetes_version: self.kubernetes_version,
+                            kubernetes_version: None,
                             kube_conformance_image: self.kubernetes_conformance_image.clone(),
                         }
                         .into_map()

--- a/testsys/src/run_sonobuoy.rs
+++ b/testsys/src/run_sonobuoy.rs
@@ -1,6 +1,6 @@
 use crate::error::{self, Result};
 use bottlerocket_agents::sonobuoy::Mode;
-use bottlerocket_agents::{K8sVersion, SonobuoyConfig, AWS_CREDENTIALS_SECRET_NAME};
+use bottlerocket_agents::{SonobuoyConfig, AWS_CREDENTIALS_SECRET_NAME};
 use kube::{api::ObjectMeta, Client};
 use model::clients::CrdClient;
 use model::constants::NAMESPACE;
@@ -53,11 +53,6 @@ pub(crate) struct RunSonobuoy {
     #[structopt(long, default_value = "quick")]
     mode: Mode,
 
-    /// The kubernetes conformance version used for the sonobuoy test  (with or without the v
-    /// prefix). Examples: v1.21, 1.21.3, v1.20.1
-    #[structopt(long)]
-    kubernetes_version: Option<K8sVersion>,
-
     /// The kubernetes conformance image used for the sonobuoy test.
     #[structopt(long)]
     kubernetes_conformance_image: Option<String>,
@@ -103,7 +98,7 @@ impl RunSonobuoy {
                             kubeconfig_base64: kubeconfig_string,
                             plugin: self.plugin.clone(),
                             mode: self.mode,
-                            kubernetes_version: self.kubernetes_version,
+                            kubernetes_version: None,
                             kube_conformance_image: self.kubernetes_conformance_image.clone(),
                         }
                         .into_map()

--- a/testsys/src/run_vmware.rs
+++ b/testsys/src/run_vmware.rs
@@ -2,8 +2,8 @@ use crate::error::{self, Result};
 use bottlerocket_agents::sonobuoy::Mode;
 use bottlerocket_agents::wireguard::WIREGUARD_SECRET_NAME;
 use bottlerocket_agents::{
-    K8sVersion, MigrationConfig, SonobuoyConfig, TufRepoConfig, VSphereClusterInfo,
-    VSphereVmConfig, AWS_CREDENTIALS_SECRET_NAME, VSPHERE_CREDENTIALS_SECRET_NAME,
+    MigrationConfig, SonobuoyConfig, TufRepoConfig, VSphereClusterInfo, VSphereVmConfig,
+    AWS_CREDENTIALS_SECRET_NAME, VSPHERE_CREDENTIALS_SECRET_NAME,
 };
 use kube::ResourceExt;
 use kube::{api::ObjectMeta, Client};
@@ -49,10 +49,6 @@ pub(crate) struct RunVmware {
     /// `non-disruptive-conformance`, we default to `quick` to make a quick test the most ergonomic.
     #[structopt(long, default_value = "quick")]
     sonobuoy_mode: Mode,
-
-    /// The kubernetes version (with or without the v prefix). Examples: v1.21, 1.21.3, v1.20.1
-    #[structopt(long)]
-    kubernetes_version: Option<K8sVersion>,
 
     /// The kubernetes conformance image used for the sonobuoy test.
     #[structopt(long)]
@@ -389,7 +385,7 @@ impl RunVmware {
                             kubeconfig_base64: encoded_kubeconfig.to_string(),
                             plugin: self.sonobuoy_plugin.clone(),
                             mode: self.sonobuoy_mode,
-                            kubernetes_version: self.kubernetes_version,
+                            kubernetes_version: None,
                             kube_conformance_image: self.kubernetes_conformance_image.clone(),
                         }
                         .into_map()


### PR DESCRIPTION
We have seen issues when passing the wrong version of k8s to sonobuoy,
and we do not see a use case for passing it anyway. This commit removes
the foot gun.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #338 

**Description of changes:**

We will no longer take `--kubernetes-version` in the CLI since it is a foot gun.

**Testing done:**

Ran `aws-k8s`:

```
 NAME                            TYPE       STATE       PASSED   SKIPPED   FAILED 
 demo-test                       Test       passed      1        5769      0      
 super-duper-cluster             Resource   completed                             
 super-duper-cluster-instances   Resource   completed 
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
