### PR TITLE
cli: `delete --all`

### DIFF
--- a/model/src/clients/crd_client.rs
+++ b/model/src/clients/crd_client.rs
@@ -105,6 +105,20 @@ pub trait CrdClient: Sized {
             .into_inner())
     }
 
+    async fn delete_all(&self) -> Result<Option<Vec<Self::Crd>>> {
+        Ok(self
+            .api()
+            .delete_collection(&Default::default(), &Default::default())
+            .await
+            .context(error::KubeApiCallSnafu {
+                method: "delete_collection",
+                what: self.kind(),
+            })?
+            .map_right(|_| None)
+            .map_left(|deleted_test| Some(deleted_test.items))
+            .into_inner())
+    }
+
     /// Loop until `get(name)` returns `StatusCode::NOT_FOUND`
     async fn wait_for_deletion<S>(&self, name: S) -> ()
     where


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #304 

**Description of changes:**

Adds a `--all` flag to the delete command to delete all testsys object in a _smart_ way. First, all tests are deleted at the same time. After the tests are deleted resources are deleted in batches based on their dependencies. This allows us to delete a set of many tests in a similar amount of time as a single test.

**Testing done:**

Ran `testsys run aws-ecs --upgrade-downgrade` 2 times and used `testsys delete --all` to clean everything up.

Output:
```
~/bottlerocket-test-system% testsys delete --all
Deleting all tests...
Test deletion complete.
Deleting all resources following dependencies...
Deleting resource 'testsys-test2-instances' ...
Deleting resource 'testsys-test1-instances' ...
Resource 'testsys-test1-instances' has been deleted
Resource 'testsys-test2-instances' has been deleted
Deleting resource 'testsys-test1' ...
Deleting resource 'testsys-test2' ...
Resource 'testsys-test1' has been deleted
Resource 'testsys-test2' has been deleted
All resources have been deleted.
```

Help:
```
~/bottlerocket-test-system% testsys delete -h
testsys-delete 0.1.0
Delete a testsys object

USAGE:
    testsys delete [FLAGS] <object-type> <object-name>

FLAGS:
        --all                  Delete all tests and resources from a testsys cluster
    -h, --help                 Prints help information
        --include-resources    Include this flag if all resources this object depends on should be deleted as well
    -V, --version              Prints version information

ARGS:
    <object-type>    The type of object that is being delete must be either `test` or `resource`
    <object-name>    The name of the test/resource that should be deleted
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
