### PR TITLE
cli: `delete --force`

### DIFF
--- a/model/src/clients/error.rs
+++ b/model/src/clients/error.rs
@@ -56,6 +56,9 @@ pub(crate) enum InnerError {
         finalizer,
     ))]
     DeleteMissingFinalizer { finalizer: String },
+
+    #[snafu(display("A resource errored during deletion '{}'", name))]
+    DeleteFail { name: String },
 }
 
 impl From<ModelError> for Error {
@@ -81,9 +84,9 @@ impl HttpStatusCode for InnerError {
                 name: _,
                 source: e,
             } => e.status_code(),
-            InnerError::DuplicateFinalizer { .. } | InnerError::DeleteMissingFinalizer { .. } => {
-                None
-            }
+            InnerError::DuplicateFinalizer { .. }
+            | InnerError::DeleteMissingFinalizer { .. }
+            | InnerError::DeleteFail { .. } => None,
         }
     }
 }

--- a/model/src/clients/http_status_code.rs
+++ b/model/src/clients/http_status_code.rs
@@ -31,7 +31,7 @@ where
     }
 }
 
-pub trait IsFound<T, E>
+pub trait AllowNotFound<T, E>
 where
     E: HttpStatusCode + Display,
 {
@@ -49,25 +49,25 @@ where
     /// do so in `handle_not_found`.
     ///
     #[allow(clippy::wrong_self_convention)]
-    fn is_found<O>(self, handle_not_found: O) -> std::result::Result<bool, E>
+    fn allow_not_found<O>(self, handle_not_found: O) -> std::result::Result<Option<T>, E>
     where
         O: FnOnce(E);
 }
 
-impl<T, E> IsFound<T, E> for std::result::Result<T, E>
+impl<T, E> AllowNotFound<T, E> for std::result::Result<T, E>
 where
     E: HttpStatusCode + Display,
 {
-    fn is_found<O>(self, handle_not_found: O) -> Result<bool, E>
+    fn allow_not_found<O>(self, handle_not_found: O) -> Result<Option<T>, E>
     where
         O: FnOnce(E),
     {
         match self {
-            Ok(_) => Ok(true),
+            Ok(obj) => Ok(Some(obj)),
             Err(e) => {
                 if e.is_status_code(StatusCode::NOT_FOUND) {
                     handle_not_found(e);
-                    Ok(false)
+                    Ok(None)
                 } else {
                     Err(e)
                 }

--- a/model/src/clients/mod.rs
+++ b/model/src/clients/mod.rs
@@ -9,4 +9,4 @@ mod resource_client;
 mod test_client;
 
 pub use crd_client::CrdClient;
-pub use http_status_code::{HttpStatusCode, IsFound, StatusCode};
+pub use http_status_code::{AllowNotFound, HttpStatusCode, StatusCode};

--- a/testsys/src/error.rs
+++ b/testsys/src/error.rs
@@ -42,6 +42,9 @@ pub(crate) enum Error {
         source: model::clients::Error,
     },
 
+    #[snafu(display("{} objects failed to be deleted.", count))]
+    DeleteCommand { count: i32 },
+
     #[snafu(display("Error deleting {} '{}': {}", what, name, source))]
     DeleteObject {
         what: String,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #323

**Description of changes:**

This PR addressed 2 issues.
1) If a deletion pod errored the delete command has no way of knowing and will continue to wait forever. This pr adds a check to the wait for deletion loop to look at the destruction task state and error if the task state is `Error`.
2) Provide a `--force` flag to the delete command. This command allows the user to delete a resource even if the pods originally errored. Then the user can manually clean up the resources created by the pod. Using the force flag deletes the resource, deletes the job and deletes the errored pod.

The `IsFound` trait is changed to `AllowNotFound`. This allows a single api call to check if an object still exists and if it does, gain a reference to that object.

**Testing done:**

Using `testsys delete --all`:
```
testsys delete --all
Deleting all tests...
Test deletion complete.
Deleting all resources following dependencies...
Deleting resource 'testsys-test1-instances' ...
Deleting resource 'testsys-test2-instances' ...
Resource 'testsys-test2-instances' has been deleted
Resource 'testsys-test1-instances' has been deleted
Deleting resource 'testsys-test1' ...
Deleting resource 'testsys-test2' ...
Resource 'testsys-test2' failed to delete.
Use `testsys delete resource testsys-test2 --force` to manually clean up the resource.
Resource 'testsys-test1' failed to delete.
Use `testsys delete resource testsys-test1 --force` to manually clean up the resource.
Some resources failed to be deleted.
2 objects failed to be deleted.
```
For clean up:
```
testsys delete resource testsys-test2 --force
```
Upon inspection the job, resource, and pod are all properly deleted.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
