### PR TITLE
Rerun sonobuoy

### DIFF
--- a/agent/test-agent/examples/example_test_agent/main.rs
+++ b/agent/test-agent/examples/example_test_agent/main.rs
@@ -82,24 +82,6 @@ impl test_agent::Runner for ExampleTestRunner {
             println!("Nested Data:\n {:?}", nested.data);
         }
         Ok(TestResults {
-            outcome: Outcome::Fail,
-            ..TestResults::default()
-        })
-    }
-
-    async fn rerun_failed(&mut self, _prev_result: &TestResults) -> Result<TestResults, Self::E> {
-        println!("ExampleTestRunner::run");
-        for i in 1..=self.config.hello_count {
-            println!("hello #{} to {}", i, self.config.person);
-            sleep(Duration::from_millis(
-                self.config.hello_duration_milliseconds.into(),
-            ))
-            .await
-        }
-        if let Some(nested) = &self.config.nested {
-            println!("Nested Data:\n {:?}", nested.data);
-        }
-        Ok(TestResults {
             outcome: Outcome::Pass,
             ..TestResults::default()
         })

--- a/agent/test-agent/examples/example_test_agent/main.rs
+++ b/agent/test-agent/examples/example_test_agent/main.rs
@@ -82,6 +82,24 @@ impl test_agent::Runner for ExampleTestRunner {
             println!("Nested Data:\n {:?}", nested.data);
         }
         Ok(TestResults {
+            outcome: Outcome::Fail,
+            ..TestResults::default()
+        })
+    }
+
+    async fn rerun_failed(&mut self, _prev_result: &TestResults) -> Result<TestResults, Self::E> {
+        println!("ExampleTestRunner::run");
+        for i in 1..=self.config.hello_count {
+            println!("hello #{} to {}", i, self.config.person);
+            sleep(Duration::from_millis(
+                self.config.hello_duration_milliseconds.into(),
+            ))
+            .await
+        }
+        if let Some(nested) = &self.config.nested {
+            println!("Nested Data:\n {:?}", nested.data);
+        }
+        Ok(TestResults {
             outcome: Outcome::Pass,
             ..TestResults::default()
         })

--- a/agent/test-agent/src/agent.rs
+++ b/agent/test-agent/src/agent.rs
@@ -99,7 +99,11 @@ where
         let retries = self.client.retries().await.unwrap_or_default();
         let mut retry_count = 0;
         while test_results.outcome != Outcome::Pass && retry_count < retries {
-            info!("Test did not pass, retrying ...");
+            info!(
+                "Test did not pass, retrying ({} of {})...",
+                retry_count + 1,
+                retries
+            );
             if let Err(e) = self
                 .client
                 .send_test_done(test_results.clone())

--- a/agent/test-agent/src/agent.rs
+++ b/agent/test-agent/src/agent.rs
@@ -1,6 +1,7 @@
 use crate::error::{self, AgentError, Error, Result};
 use crate::{BootstrapData, Client, Runner};
 use log::{debug, error, info, trace};
+use model::Outcome;
 use snafu::ResultExt;
 use std::fs::File;
 use std::path::PathBuf;
@@ -84,7 +85,7 @@ where
             .await
             .map_err(error::Error::Client)?;
 
-        let test_results = match self.runner.run().await.map_err(error::Error::Runner) {
+        let mut test_results = match self.runner.run().await.map_err(error::Error::Runner) {
             Ok(ok) => ok,
             Err(e) => {
                 self.send_error_best_effort(&e).await;
@@ -92,6 +93,37 @@ where
                 return Err(e);
             }
         };
+
+        // If we are unable to get the number of retries it is safer to assume it is zero
+        // then to error.
+        let retries = self.client.retries().await.unwrap_or_default();
+        let mut retry_count = 0;
+        while test_results.outcome != Outcome::Pass && retry_count < retries {
+            info!("Test did not pass, retrying ...");
+            if let Err(e) = self
+                .client
+                .send_test_done(test_results.clone())
+                .await
+                .map_err(error::Error::Client)
+            {
+                error!("Failed to send test results");
+                self.send_error_best_effort(&e).await;
+            }
+            test_results = match self
+                .runner
+                .rerun_failed(&test_results)
+                .await
+                .map_err(error::Error::Runner)
+            {
+                Ok(ok) => ok,
+                Err(e) => {
+                    self.send_error_best_effort(&e).await;
+                    self.terminate_best_effort().await;
+                    return Err(e);
+                }
+            };
+            retry_count += 1;
+        }
 
         if let Err(e) = self
             .client

--- a/agent/test-agent/src/k8s_client.rs
+++ b/agent/test-agent/src/k8s_client.rs
@@ -52,6 +52,11 @@ impl Client for DefaultClient {
         Ok(test_data.spec.agent.keep_running)
     }
 
+    async fn retries(&self) -> Result<u32, Self::E> {
+        let test_data = self.client.get(&self.name).await.context(K8sSnafu)?;
+        Ok(test_data.spec.retries.unwrap_or_default())
+    }
+
     async fn spec<C>(&self) -> Result<Spec<C>, Self::E>
     where
         C: Configuration,
@@ -85,6 +90,14 @@ impl Client for DefaultClient {
     async fn send_test_starting(&self) -> Result<(), Self::E> {
         self.client
             .send_agent_task_state(&self.name, TaskState::Running)
+            .await
+            .context(K8sSnafu)?;
+        Ok(())
+    }
+
+    async fn send_test_results(&self, results: TestResults) -> Result<(), Self::E> {
+        self.client
+            .send_test_results(&self.name, results)
             .await
             .context(K8sSnafu)?;
         Ok(())

--- a/agent/test-agent/tests/mock.rs
+++ b/agent/test-agent/tests/mock.rs
@@ -103,6 +103,11 @@ impl Client for MockClient {
         Ok(())
     }
 
+    async fn send_test_results(&self, results: TestResults) -> Result<(), Self::E> {
+        println!("MockClient::send_test_results: {:?}", results);
+        Ok(())
+    }
+
     async fn send_error<E>(&self, error: E) -> Result<(), Self::E>
     where
         E: Debug + Display + Send + Sync,
@@ -121,6 +126,10 @@ impl Client for MockClient {
 
     async fn results_file(&self) -> Result<PathBuf, Self::E> {
         Ok(self.results_file.path().join("result.tar.gz"))
+    }
+
+    async fn retries(&self) -> Result<u32, Self::E> {
+        Ok(0)
     }
 }
 

--- a/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
@@ -95,18 +95,7 @@ impl test_agent::Runner for SonobuoyTestRunner {
 
     async fn rerun_failed(&mut self, _prev_results: &TestResults) -> Result<TestResults, Self::E> {
         // Set up the aws credentials if they were provided.
-        if let Some(aws_secret_name) = &self.aws_secret_name {
-            setup_test_env(self, aws_secret_name).await?;
-        }
-
-        if let Some(wireguard_secret_name) = &self.wireguard_secret_name {
-            // If a wireguard secret is specified, try to set up an wireguard connection with the
-            // wireguard configuration stored in the secret.
-            let wireguard_secret = self
-                .get_secret(wireguard_secret_name)
-                .context(error::SecretMissingSnafu)?;
-            setup_wireguard(&wireguard_secret).await?;
-        }
+        aws_test_config(self, &self.aws_secret_name, &self.config.assume_role, &None).await?;
 
         delete_sonobuoy(TEST_CLUSTER_KUBECONFIG_PATH).await?;
 

--- a/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
@@ -34,7 +34,7 @@ spec:
 
 use async_trait::async_trait;
 use bottlerocket_agents::error::Error;
-use bottlerocket_agents::sonobuoy::{delete_sonobuoy, run_sonobuoy};
+use bottlerocket_agents::sonobuoy::{delete_sonobuoy, rerun_failed_sonobuoy, run_sonobuoy};
 use bottlerocket_agents::wireguard::setup_wireguard;
 use bottlerocket_agents::{
     aws_test_config, decode_write_kubeconfig, error, init_agent_logger,
@@ -86,6 +86,33 @@ impl test_agent::Runner for SonobuoyTestRunner {
         decode_write_kubeconfig(&self.config.kubeconfig_base64, TEST_CLUSTER_KUBECONFIG_PATH)
             .await?;
         run_sonobuoy(
+            TEST_CLUSTER_KUBECONFIG_PATH,
+            &self.config,
+            &self.results_dir,
+        )
+        .await
+    }
+
+    async fn rerun_failed(&mut self, _prev_results: &TestResults) -> Result<TestResults, Self::E> {
+        // Set up the aws credentials if they were provided.
+        if let Some(aws_secret_name) = &self.aws_secret_name {
+            setup_test_env(self, aws_secret_name).await?;
+        }
+
+        if let Some(wireguard_secret_name) = &self.wireguard_secret_name {
+            // If a wireguard secret is specified, try to set up an wireguard connection with the
+            // wireguard configuration stored in the secret.
+            let wireguard_secret = self
+                .get_secret(wireguard_secret_name)
+                .context(error::SecretMissingSnafu)?;
+            setup_wireguard(&wireguard_secret).await?;
+        }
+
+        delete_sonobuoy(TEST_CLUSTER_KUBECONFIG_PATH).await?;
+
+        decode_write_kubeconfig(&self.config.kubeconfig_base64, TEST_CLUSTER_KUBECONFIG_PATH)
+            .await?;
+        rerun_failed_sonobuoy(
             TEST_CLUSTER_KUBECONFIG_PATH,
             &self.config,
             &self.results_dir,

--- a/controller/src/test_controller/action.rs
+++ b/controller/src/test_controller/action.rs
@@ -174,7 +174,7 @@ async fn dependency_wait_action(t: &TestInterface) -> Result<Option<Action>> {
         if needed_test
             .agent_status()
             .results
-            .as_ref()
+            .last()
             .map(|results| results.outcome != Outcome::Pass)
             .unwrap_or(true)
         {

--- a/model/src/clients/test_client.rs
+++ b/model/src/clients/test_client.rs
@@ -70,12 +70,24 @@ impl TestClient {
         .await
     }
 
+    pub async fn send_test_results(&self, name: &str, results: TestResults) -> Result<Test> {
+        self.patch_status(
+            name,
+            vec![JsonPatch::new_add_operation(
+                "/status/agent/results/-",
+                results,
+            )],
+            "send test results",
+        )
+        .await
+    }
+
     pub async fn send_test_completed(&self, name: &str, results: TestResults) -> Result<Test> {
         self.patch_status(
             name,
             vec![
                 JsonPatch::new_add_operation("/status/agent/taskState", TaskState::Completed),
-                JsonPatch::new_add_operation("/status/agent/results", results),
+                JsonPatch::new_add_operation("/status/agent/results/-", results),
             ],
             "send test completion results",
         )

--- a/model/src/test.rs
+++ b/model/src/test.rs
@@ -32,6 +32,8 @@ pub struct TestSpec {
     pub depends_on: Option<Vec<String>>,
     /// Information about the test agent.
     pub agent: Agent,
+    /// The number of retries the agent is allowed to perform after a failed test.
+    pub retries: Option<u32>,
 }
 
 /// The status field of the TestSys Test CRD. This is where the controller and agents will write
@@ -87,7 +89,7 @@ pub struct AgentStatus {
     /// *may* be an error message here. If there is an error message here and the `run_state` is
     /// *not* `Error`, the this is a bad state and the `error_message` should be ignored.
     pub error: Option<String>,
-    pub results: Option<TestResults>,
+    pub results: Vec<TestResults>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Eq, PartialEq, Clone, JsonSchema)]
@@ -171,7 +173,7 @@ impl Test {
             }
             TaskState::Running => TestUserState::Running,
             TaskState::Completed => {
-                if let Some(results) = &agent_status.results {
+                if let Some(results) = agent_status.results.last() {
                     match results.outcome {
                         Outcome::Pass => TestUserState::Passed,
                         Outcome::Fail => TestUserState::Failed,

--- a/testsys/src/run_aws_ecs.rs
+++ b/testsys/src/run_aws_ecs.rs
@@ -407,6 +407,7 @@ impl RunAwsEcs {
                     cluster_resource_name.to_owned(),
                 ],
                 depends_on,
+                retries: None,
                 agent: Agent {
                     name: "ecs-test-agent".to_string(),
                     image: self.test_agent_image.clone(),
@@ -473,6 +474,7 @@ impl RunAwsEcs {
                     cluster_resource_name.to_owned(),
                 ],
                 depends_on,
+                retries: None,
                 agent: Agent {
                     name: "ecs-test-agent".to_string(),
                     image: migration_agent_image.to_string(),

--- a/testsys/src/run_aws_k8s.rs
+++ b/testsys/src/run_aws_k8s.rs
@@ -129,6 +129,10 @@ pub(crate) struct RunAwsK8s {
     #[structopt(long)]
     keep_instance_provider_running: bool,
 
+    /// Allow the sonobuoy test agent to rerun failed test.
+    #[structopt(long)]
+    allow_retries: Option<u32>,
+
     /// Perform an upgrade downgrade test.
     #[structopt(long, requires_all(&["starting-version", "upgrade-version", "migration-agent-image"]))]
     upgrade_downgrade: bool,
@@ -431,7 +435,7 @@ impl RunAwsK8s {
                     cluster_resource_name.to_string(),
                 ],
                 depends_on,
-                retries: None,
+                retries: self.allow_retries,
                 agent: Agent {
                     name: "sonobuoy-test-agent".to_string(),
                     image: self.test_agent_image.clone(),

--- a/testsys/src/run_aws_k8s.rs
+++ b/testsys/src/run_aws_k8s.rs
@@ -431,6 +431,7 @@ impl RunAwsK8s {
                     cluster_resource_name.to_string(),
                 ],
                 depends_on,
+                retries: None,
                 agent: Agent {
                     name: "sonobuoy-test-agent".to_string(),
                     image: self.test_agent_image.clone(),
@@ -499,6 +500,7 @@ impl RunAwsK8s {
                     cluster_resource_name.to_owned(),
                 ],
                 depends_on,
+                retries: None,
                 agent: Agent {
                     name: "eks-test-agent".to_string(),
                     image: migration_agent_image.to_string(),

--- a/testsys/src/run_aws_k8s.rs
+++ b/testsys/src/run_aws_k8s.rs
@@ -131,7 +131,7 @@ pub(crate) struct RunAwsK8s {
 
     /// Allow the sonobuoy test agent to rerun failed test.
     #[structopt(long)]
-    allow_retries: Option<u32>,
+    retry_failed_attempts: Option<u32>,
 
     /// Perform an upgrade downgrade test.
     #[structopt(long, requires_all(&["starting-version", "upgrade-version", "migration-agent-image"]))]
@@ -435,7 +435,7 @@ impl RunAwsK8s {
                     cluster_resource_name.to_string(),
                 ],
                 depends_on,
-                retries: self.allow_retries,
+                retries: self.retry_failed_attempts,
                 agent: Agent {
                     name: "sonobuoy-test-agent".to_string(),
                     image: self.test_agent_image.clone(),

--- a/testsys/src/run_sonobuoy.rs
+++ b/testsys/src/run_sonobuoy.rs
@@ -90,6 +90,7 @@ impl RunSonobuoy {
             spec: TestSpec {
                 resources: self.resource.clone(),
                 depends_on: Default::default(),
+                retries: None,
                 agent: Agent {
                     name: "sonobuoy-test-agent".to_string(),
                     image: self.image.clone(),

--- a/testsys/src/run_vmware.rs
+++ b/testsys/src/run_vmware.rs
@@ -378,6 +378,7 @@ impl RunVmware {
             spec: TestSpec {
                 resources: vec![vm_resource_name.to_string()],
                 depends_on,
+                retries: None,
                 agent: Agent {
                     name: "vmware-sonobuoy-test-agent".to_string(),
                     image: self.test_agent_image.clone(),
@@ -438,6 +439,7 @@ impl RunVmware {
             spec: TestSpec {
                 resources: vec![vm_resource_name.to_owned()],
                 depends_on,
+                retries: None,
                 agent: Agent {
                     name: "vmware-migration-test-agent".to_string(),
                     image: migration_agent_image.to_string(),

--- a/testsys/src/run_vmware.rs
+++ b/testsys/src/run_vmware.rs
@@ -142,6 +142,10 @@ pub(crate) struct RunVmware {
     #[structopt(long)]
     keep_instance_provider_running: bool,
 
+    /// Allow the sonobuoy test agent to rerun failed test.
+    #[structopt(long)]
+    allow_retries: Option<u32>,
+
     /// Perform an upgrade downgrade test.
     #[structopt(long, requires_all(&["starting-version", "upgrade-version"]))]
     upgrade_downgrade: bool,
@@ -378,7 +382,7 @@ impl RunVmware {
             spec: TestSpec {
                 resources: vec![vm_resource_name.to_string()],
                 depends_on,
-                retries: None,
+                retries: self.allow_retries,
                 agent: Agent {
                     name: "vmware-sonobuoy-test-agent".to_string(),
                     image: self.test_agent_image.clone(),

--- a/testsys/src/run_vmware.rs
+++ b/testsys/src/run_vmware.rs
@@ -144,7 +144,7 @@ pub(crate) struct RunVmware {
 
     /// Allow the sonobuoy test agent to rerun failed test.
     #[structopt(long)]
-    allow_retries: Option<u32>,
+    retry_failed_attempts: Option<u32>,
 
     /// Perform an upgrade downgrade test.
     #[structopt(long, requires_all(&["starting-version", "upgrade-version"]))]
@@ -382,7 +382,7 @@ impl RunVmware {
             spec: TestSpec {
                 resources: vec![vm_resource_name.to_string()],
                 depends_on,
-                retries: self.allow_retries,
+                retries: self.retry_failed_attempts,
                 agent: Agent {
                     name: "vmware-sonobuoy-test-agent".to_string(),
                     image: self.test_agent_image.clone(),

--- a/testsys/src/status.rs
+++ b/testsys/src/status.rs
@@ -6,11 +6,9 @@ use kube::core::object::HasStatus;
 use kube::{Api, Client, ResourceExt};
 use model::clients::{CrdClient, ResourceClient, TestClient};
 use model::constants::{LABEL_COMPONENT, NAMESPACE};
-use model::{Resource, TaskState, Test, TestUserState};
-use serde::{Deserialize, Serialize};
+use model::{Resource, TaskState, Test};
+use serde::Serialize;
 use snafu::ResultExt;
-use std::collections::HashMap;
-use std::fmt::Display;
 use structopt::StructOpt;
 use tabled::{Alignment, Column, Full, MaxWidth, Modify, Style, Table, Tabled};
 use termion::terminal_size;
@@ -36,24 +34,23 @@ impl Status {
         let tests_api = TestClient::new_from_k8s_client(k8s_client.clone());
         let resources_api = ResourceClient::new_from_k8s_client(k8s_client.clone());
         let pod_api = Api::<Pod>::namespaced(k8s_client, NAMESPACE);
-        let mut status_results = StatusResults::new();
+        let mut status_results = Results::default();
         if self.controller {
-            status_results.controller_is_running = Some(is_controller_running(&pod_api).await?);
+            status_results.add_controller(is_controller_running(&pod_api).await?);
         }
         let tests = self.tests(&tests_api).await?;
         let resources = self.resources(&resources_api).await?;
         for test in tests {
-            let test_result = TestResult::from_test(&test);
-            status_results.add_test_result(test_result)
+            status_results.add_test(&test)
         }
         for resource in resources {
-            let resource_result = ResourceResult::from_resource(&resource);
-            status_results.add_resource_result(resource_result)
+            status_results.add_resource(&resource)
         }
 
         if !self.json {
             let (width, _) = terminal_size().ok().unwrap_or((120, 0));
-            status_results.draw(width);
+            status_results.width = width;
+            status_results.draw();
         } else {
             println!(
                 "{}",
@@ -126,203 +123,22 @@ async fn is_controller_running(pod_api: &Api<Pod>) -> Result<bool> {
     Ok(true)
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
-struct StatusResults {
-    tests: HashMap<String, TestResult>,
-    resources: HashMap<String, ResourceResult>,
-    controller_is_running: Option<bool>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct TestResult {
-    name: String,
-    state: TestUserState,
-    passed: Option<u64>,
-    failed: Option<u64>,
-    skipped: Option<u64>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct ResourceResult {
-    name: String,
-    create_state: TaskState,
-    delete_state: TaskState,
-}
-
-impl StatusResults {
-    fn new() -> Self {
-        Self {
-            tests: HashMap::new(),
-            resources: HashMap::new(),
-            controller_is_running: None,
-        }
-    }
-
-    fn add_test_result(&mut self, test_result: TestResult) {
-        self.tests.insert(test_result.name.clone(), test_result);
-    }
-
-    fn add_resource_result(&mut self, resource_result: ResourceResult) {
-        self.resources
-            .insert(resource_result.name.clone(), resource_result);
-    }
-
-    fn draw(&self, width: u16) {
-        let mut results = Vec::new();
-        if let Some(controller_running) = self.controller_is_running {
-            results.push(ResultRow {
-                name: "Controller".to_string(),
-                object_type: "Controller".to_string(),
-                state: if controller_running { "Running" } else { "" }.to_string(),
-                ..Default::default()
-            })
-        }
-        for resource_result in self.resources.values() {
-            results.push(resource_result.into());
-        }
-        for test_result in self.tests.values() {
-            results.push(test_result.into());
-        }
-        let results_table = Results {
-            width,
-            results,
-            ..Default::default()
-        };
-
-        results_table.draw();
-    }
-}
-
-impl Display for StatusResults {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for result in self.tests.values() {
-            write!(f, "{}\n\n", result)?;
-        }
-
-        for result in self.resources.values() {
-            write!(f, "{}\n\n", result)?;
-        }
-
-        if let Some(running) = self.controller_is_running {
-            write!(f, "Controller Running: {}", running)?;
-        }
-
-        Ok(())
-    }
-}
-
-impl TestResult {
-    fn from_test(test: &Test) -> Self {
-        let name = test.metadata.name.clone().unwrap_or_else(|| "".to_string());
-        let mut passed = None;
-        let mut failed = None;
-        let mut skipped = None;
-        let test_user_state = test.test_user_state();
-        if let Some(results) = test.agent_status().results.last() {
-            passed = Some(results.num_passed);
-            failed = Some(results.num_failed);
-            skipped = Some(results.num_skipped);
-        }
-
-        Self {
-            name,
-            state: test_user_state,
-            passed,
-            failed,
-            skipped,
-        }
-    }
-}
-
-impl Display for TestResult {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Test Name: {}", self.name)?;
-        writeln!(f, "Test State: {}", self.state)?;
-        writeln!(
-            f,
-            "Passed: {}",
-            self.passed.map_or("".to_string(), |x| x.to_string())
-        )?;
-        writeln!(
-            f,
-            "Failed: {}",
-            self.failed.map_or("".to_string(), |x| x.to_string())
-        )?;
-        writeln!(
-            f,
-            "Skipped: {}",
-            self.skipped.map_or("".to_string(), |x| x.to_string())
-        )?;
-
-        Ok(())
-    }
-}
-
-impl From<&TestResult> for ResultRow {
-    fn from(test_result: &TestResult) -> ResultRow {
-        ResultRow {
-            name: test_result.name.clone(),
-            object_type: "Test".to_string(),
-            state: test_result.state.to_string(),
-            passed: test_result.passed,
-            skipped: test_result.skipped,
-            failed: test_result.failed,
-        }
-    }
-}
-
-impl ResourceResult {
-    fn from_resource(resource: &Resource) -> Self {
-        let name = resource.name();
-        let mut create_state = TaskState::Unknown;
-        let mut delete_state = TaskState::Unknown;
-        if let Some(status) = resource.status() {
-            create_state = status.creation.task_state;
-            delete_state = status.destruction.task_state;
-        }
-
-        Self {
-            name,
-            create_state,
-            delete_state,
-        }
-    }
-}
-
-impl Display for ResourceResult {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Resource Name: {}", self.name)?;
-        writeln!(f, "Resource Creation State: {:?}", self.create_state)?;
-        writeln!(f, "Resource Deletion State: {:?}", self.delete_state)?;
-        Ok(())
-    }
-}
-
-impl From<&ResourceResult> for ResultRow {
-    fn from(resource_result: &ResourceResult) -> ResultRow {
-        let state = match resource_result.delete_state {
-            TaskState::Unknown => resource_result.create_state,
-            _ => resource_result.delete_state,
-        };
-        ResultRow {
-            name: resource_result.name.clone(),
-            object_type: "Resource".to_string(),
-            state: state.to_string(),
-            passed: None,
-            skipped: None,
-            failed: None,
-        }
-    }
-}
-
+#[derive(Serialize)]
 struct Results {
+    #[serde(skip_serializing)]
     width: u16,
     results: Vec<ResultRow>,
+    #[serde(skip_serializing)]
     min_name_width: u16,
+    #[serde(skip_serializing)]
     min_object_width: u16,
+    #[serde(skip_serializing)]
     min_state_width: u16,
+    #[serde(skip_serializing)]
     min_passed_width: u16,
+    #[serde(skip_serializing)]
     min_skipped_width: u16,
+    #[serde(skip_serializing)]
     min_failed_width: u16,
 }
 
@@ -342,6 +158,73 @@ impl Default for Results {
 }
 
 impl Results {
+    /// Adds a new `ResultRow` for each `TestResults` in test, or a single row if no `TestsResults` are available.
+    fn add_test(&mut self, test: &Test) {
+        let name = test.metadata.name.clone().unwrap_or_else(|| "".to_string());
+        let state = test.test_user_state().to_string();
+        let results = &test.agent_status().results;
+        if results.is_empty() {
+            self.results.push(ResultRow {
+                name,
+                object_type: "Test".to_string(),
+                state,
+                passed: None,
+                skipped: None,
+                failed: None,
+            })
+        } else {
+            for (test_count, result) in results.iter().enumerate() {
+                let retry_name = if test_count == 0 {
+                    name.clone()
+                } else {
+                    format!("{}-retry-{}", name, test_count)
+                };
+                self.results.push(ResultRow {
+                    name: retry_name,
+                    object_type: "Test".to_string(),
+                    state: state.clone(),
+                    passed: Some(result.num_passed),
+                    skipped: Some(result.num_skipped),
+                    failed: Some(result.num_failed),
+                });
+            }
+        }
+    }
+
+    fn add_resource(&mut self, resource: &Resource) {
+        let name = resource.name();
+        let mut create_state = TaskState::Unknown;
+        let mut delete_state = TaskState::Unknown;
+        if let Some(status) = resource.status() {
+            create_state = status.creation.task_state;
+            delete_state = status.destruction.task_state;
+        }
+        let state = match delete_state {
+            TaskState::Unknown => create_state,
+            _ => delete_state,
+        };
+
+        self.results.push(ResultRow {
+            name,
+            object_type: "Resource".to_string(),
+            state: state.to_string(),
+            passed: None,
+            skipped: None,
+            failed: None,
+        });
+    }
+
+    fn add_controller(&mut self, running: bool) {
+        self.results.push(ResultRow {
+            name: "Controller".to_string(),
+            object_type: "Controller".to_string(),
+            state: if running { "Running" } else { "" }.to_string(),
+            passed: None,
+            skipped: None,
+            failed: None,
+        });
+    }
+
     fn draw(&self) {
         if self.width
             < self.min_name_width
@@ -396,7 +279,7 @@ impl Results {
     }
 }
 
-#[derive(Tabled, Default, Clone)]
+#[derive(Tabled, Default, Clone, Serialize)]
 struct ResultRow {
     #[header("NAME")]
     name: String,

--- a/testsys/src/status.rs
+++ b/testsys/src/status.rs
@@ -218,7 +218,7 @@ impl TestResult {
         let mut failed = None;
         let mut skipped = None;
         let test_user_state = test.test_user_state();
-        if let Some(results) = &test.agent_status().results {
+        if let Some(results) = test.agent_status().results.last() {
             passed = Some(results.num_passed);
             failed = Some(results.num_failed);
             skipped = Some(results.num_skipped);

--- a/yamlgen/deploy/testsys-crd.yaml
+++ b/yamlgen/deploy/testsys-crd.yaml
@@ -90,6 +90,12 @@ spec:
                   items:
                     type: string
                   type: array
+                retries:
+                  description: The number of retries the agent is allowed to perform after a failed test.
+                  format: uint32
+                  minimum: 0.0
+                  nullable: true
+                  type: integer
               required:
                 - agent
                 - resources
@@ -106,37 +112,38 @@ spec:
                       nullable: true
                       type: string
                     results:
-                      nullable: true
-                      properties:
-                        numFailed:
-                          format: uint64
-                          minimum: 0.0
-                          type: integer
-                        numPassed:
-                          format: uint64
-                          minimum: 0.0
-                          type: integer
-                        numSkipped:
-                          format: uint64
-                          minimum: 0.0
-                          type: integer
-                        otherInfo:
-                          nullable: true
-                          type: string
-                        outcome:
-                          description: "The `Outcome` of a test run, reported by the test agent."
-                          enum:
-                            - pass
-                            - fail
-                            - timeout
-                            - unknown
-                          type: string
-                      required:
-                        - numFailed
-                        - numPassed
-                        - numSkipped
-                        - outcome
-                      type: object
+                      items:
+                        properties:
+                          numFailed:
+                            format: uint64
+                            minimum: 0.0
+                            type: integer
+                          numPassed:
+                            format: uint64
+                            minimum: 0.0
+                            type: integer
+                          numSkipped:
+                            format: uint64
+                            minimum: 0.0
+                            type: integer
+                          otherInfo:
+                            nullable: true
+                            type: string
+                          outcome:
+                            description: "The `Outcome` of a test run, reported by the test agent."
+                            enum:
+                              - pass
+                              - fail
+                              - timeout
+                              - unknown
+                            type: string
+                        required:
+                          - numFailed
+                          - numPassed
+                          - numSkipped
+                          - outcome
+                        type: object
+                      type: array
                     taskState:
                       description: The states that an agent declares about its task (e.g. running tests or creating/destroying resources).
                       enum:
@@ -146,6 +153,7 @@ spec:
                         - error
                       type: string
                   required:
+                    - results
                     - taskState
                   type: object
                 controller:


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #181 

**Description of changes:**

Adds a function `rerun_failed` to the `Runner` trait. After `run` is called, `rerun_failed` will be called up to `retries` times or `Outcome::Pass` is returned.

**Testing done:**

Forced a sonobuoy test to fail and the test was properly rerun.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
