### PR TITLE
cli: `status` report waiting

### DIFF
--- a/model/src/test.rs
+++ b/model/src/test.rs
@@ -108,7 +108,7 @@ pub enum TestUserState {
     /// The test state cannot be determined.
     Unknown,
     /// The test has not yet started its test agent, it might be waiting for resources.
-    Starting,
+    Waiting,
     /// The test agent container is running.
     Running,
     /// The test agent container finished successfully but reported no tests.
@@ -166,7 +166,7 @@ impl Test {
         match agent_status.task_state {
             TaskState::Unknown => {
                 if self.has_finalizer(FINALIZER_MAIN) {
-                    TestUserState::Starting
+                    TestUserState::Waiting
                 } else {
                     TestUserState::Unknown
                 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #298 

**Description of changes:**

If a test is waiting on a resource, `testsys status` will report the test as starting. By changing `TestUserState` a test's state is now displayed as `Waiting` if it has not started yet.

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
