### PR TITLE
Refactor docker images build in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,5 @@
 TOP := $(dir $(firstword $(MAKEFILE_LIST)))
 
-.PHONY: build sdk-openssl example-test-agent example-resource-agent \
-	controller images sonobuoy-test-agent integ-test ec2-resource-agent \
-	eks-resource-agent ecs-resource-agent show-variables migration-test-agent \
-	vsphere-vm-resource-agent ecs-test-agent cargo-deny
-
 TESTSYS_BUILD_HOST_UNAME_ARCH=$(shell uname -m)
 TESTSYS_BUILD_HOST_GOARCH ?= $(lastword $(subst :, ,$(filter $(TESTSYS_BUILD_HOST_UNAME_ARCH):%,x86_64:amd64 aarch64:arm64)))
 TESTSYS_BUILD_HOST_PLATFORM=$(shell uname | tr '[:upper:]' '[:lower:]')
@@ -15,6 +10,12 @@ BOTTLEROCKET_SDK_VERSION = v0.25.1
 BOTTLEROCKET_SDK_ARCH = $(TESTSYS_BUILD_HOST_UNAME_ARCH)
 
 BUILDER_IMAGE = public.ecr.aws/bottlerocket/bottlerocket-sdk-$(BOTTLEROCKET_SDK_ARCH):$(BOTTLEROCKET_SDK_VERSION)
+
+IMAGES = controller sonobuoy-test-agent ec2-resource-agent eks-resource-agent ecs-resource-agent \
+	migration-test-agent vsphere-vm-resource-agent ecs-test-agent
+
+.PHONY: build sdk-openssl example-test-agent example-resource-agent \
+	images fetch integ-test show-variables cargo-deny $(IMAGES)
 
 export DOCKER_BUILDKIT=1
 export CARGO_HOME = $(TOP)/.cargo
@@ -30,8 +31,7 @@ show-variables:
 fetch:
 	cargo fetch --locked
 
-images: fetch controller sonobuoy-test-agent ec2-resource-agent eks-resource-agent ecs-resource-agent \
-	migration-test-agent vsphere-vm-resource-agent
+images: fetch $(IMAGES)
 
 # Builds, Lints and Tests the Rust workspace
 build: fetch


### PR DESCRIPTION
**Issue number:**
N / A


**Description of changes:**
```
Now images should be added in the IMAGES variable so that only one place
is updated to add images. This prevents out-of-sync problems when new
images are added.

As part of this commit, I added the `ecs-test-agent` image to the list
of images to be build.
```


**Testing done:**
- I built the images with `make images -j` and I confirmed that all of them were built `docker images | grep ecs-test-agent`:

```
ecs-test-agent                                                       latest                     0daecce63e3a   23 seconds ago   211MB
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
