### PR TITLE
build: fix aws-iam-authenticator build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -191,7 +191,8 @@ RUN mkdir -p /usr/share/licenses/aws-iam-authenticator && \
     chown -R builder:builder /usr/share/licenses/aws-iam-authenticator
 
 ARG AWS_IAM_AUTHENTICATOR_VERSION=0.5.3
-ARG AWS_IAM_AUTHENTICATOR_SOURCE_URL="https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/refs/tags/v${AWS_IAM_AUTHENTICATOR_VERSION}.tar.gz"
+ARG AWS_IAM_AUTHENTICATOR_SHA512_SUM=430af9fd04b9a94205a485281fb668f5bc18cdac569de0232fa98e08ebb0e08a8d233537bd3373a5f1e53cf529bc2050aebc34a4a53c8b29a831070e34213210
+ARG AWS_IAM_AUTHENTICATOR_SOURCE_URL="https://cache.bottlerocket.aws/aws-iam-authenticator-${AWS_IAM_AUTHENTICATOR_VERSION}.tar.gz/${AWS_IAM_AUTHENTICATOR_SHA512_SUM}/aws-iam-authenticator-${AWS_IAM_AUTHENTICATOR_VERSION}.tar.gz"
 
 USER builder
 WORKDIR /home/builder/


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N.A

**Description of changes:**

Apparently, GitHub archive hashes are not stable. The sha sum for
aws-iam-authenticator changed and it broke our build. Now we pull it
from the Bottlerocket lookaside cache instead.

We probably need to do something like this with the rest of our GitHub archive sourcecode pulls as well, but for now this fixes our build.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
