### PR TITLE
build: specify workspace crate versions

### DIFF
--- a/agent/agent-common/Cargo.toml
+++ b/agent/agent-common/Cargo.toml
@@ -6,11 +6,11 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-model = { path = "../../model" }
+model = { version = "0.1.0", path = "../../model" }
 snafu = "0.7"
 
 [dev-dependencies]
 tempfile = "3"
 
 [build-dependencies]
-yamlgen = { path = "../../yamlgen" }
+yamlgen = { version = "0.1.0", path = "../../yamlgen" }

--- a/agent/resource-agent/Cargo.toml
+++ b/agent/resource-agent/Cargo.toml
@@ -6,10 +6,10 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-agent-common = { path = "../agent-common" }
+agent-common = { version = "0.1.0", path = "../agent-common" }
 async-trait = "0.1"
 log = "0.4"
-model = { path = "../../model" }
+model = { version = "0.1.0", path = "../../model" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu = "0.7"
@@ -21,4 +21,4 @@ nonzero_ext = "0.3"
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
-yamlgen = { path = "../../yamlgen" }
+yamlgen = { version = "0.1.0", path = "../../yamlgen" }

--- a/agent/test-agent/Cargo.toml
+++ b/agent/test-agent/Cargo.toml
@@ -6,10 +6,10 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-agent-common = { path = "../agent-common" }
+agent-common = { version = "0.1.0", path = "../agent-common" }
 async-trait = "0.1"
 log = "0.4"
-model = { path = "../../model" }
+model = { version = "0.1.0", path = "../../model" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu = "0.7"
@@ -21,4 +21,4 @@ tokio = { version = "1", default-features = false, features = ["time"] }
 tokio = { version = "1", default-features = false, features = ["macros", "process", "rt-multi-thread"] }
 
 [build-dependencies]
-yamlgen = { path = "../../yamlgen" }
+yamlgen = { version = "0.1.0", path = "../../yamlgen" }

--- a/bottlerocket/agents/Cargo.toml
+++ b/bottlerocket/agents/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-agent-common = { path = "../../agent/agent-common" }
-bottlerocket-types = { path = "../types" }
+agent-common = { version = "0.1.0", path = "../../agent/agent-common" }
+bottlerocket-types = { version = "0.1.0", path = "../types" }
 async-trait = "0.1"
 aws-config = "0.11"
 aws-types = "0.11"
@@ -25,19 +25,19 @@ k8s-openapi = { version = "0.14", default-features = false, features = ["v1_20"]
 kube = { version = "0.71", default-features = false, features = ["config", "derive", "client"] }
 log = "0.4"
 maplit = "1.0.2"
-model = { path = "../../model" }
+model = { version = "0.1.0", path = "../../model" }
 reqwest = { version = "0.11.1", default-features = false, features = ["rustls-tls", "blocking"] }
-resource-agent = { path = "../../agent/resource-agent" }
+resource-agent = { version = "0.1.0", path = "../../agent/resource-agent" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1"
 sha2 = "0.10"
 snafu = "0.7"
-test-agent = { path = "../../agent/test-agent" }
+test-agent = { version = "0.1.0", path = "../../agent/test-agent" }
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
 tough = { version = "0.12", features = ["http"] }
 url = "2.2"
 uuid = { version = "1.0", default-features = false, features = ["serde", "v4"] }
 
 [build-dependencies]
-yamlgen = { path = "../../yamlgen" }
+yamlgen = { version = "0.1.0", path = "../../yamlgen" }

--- a/bottlerocket/testsys/Cargo.toml
+++ b/bottlerocket/testsys/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 base64 = "0.13.0"
-bottlerocket-types = { path = "../types" }
+bottlerocket-types = { version = "0.1.0", path = "../types" }
 env_logger = "0.9"
 futures = "0.3.8"
 http = "0"
@@ -15,7 +15,7 @@ k8s-openapi = { version = "0.14", features = ["v1_20", "api"], default-features 
 kube = { version = "0.71", default-features = true, features = ["config", "derive", "ws"] }
 log = "0.4"
 maplit = "1"
-model = { path = "../../model" }
+model = { version = "0.1.0", path = "../../model" }
 serde = "1.0.130"
 serde_plain = "1"
 serde_json = "1.0.61"
@@ -30,10 +30,10 @@ topological-sort = "0.1"
 
 [dev-dependencies]
 assert_cmd = "2.0"
-selftest = { path = "../../selftest" }
+selftest = { version = "0.1.0", path = "../../selftest" }
 
 [build-dependencies]
-yamlgen = { path = "../../yamlgen" }
+yamlgen = { version = "0.1.0", path = "../../yamlgen" }
 
 [features]
 # The `integ` feature enables integration tests. These tests require docker and kind.

--- a/bottlerocket/types/Cargo.toml
+++ b/bottlerocket/types/Cargo.toml
@@ -6,6 +6,6 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-model = { path = "../../model" }
+model = { version = "0.1.0", path = "../../model" }
 serde = "1"
 serde_plain = "1"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -15,7 +15,7 @@ kube = { version = "0.71", default-features = true, features = ["derive"] }
 kube-runtime = "0.71"
 lazy_static = "1"
 log = "0.4"
-model = { path = "../model" }
+model = { version = "0.1.0", path = "../model" }
 parse_duration = "2.1"
 schemars = "0"
 serde = { version = "1", features = ["derive"] }
@@ -24,4 +24,4 @@ snafu = "0.7"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
-yamlgen = { path = "../yamlgen" }
+yamlgen = { version = "0.1.0", path = "../yamlgen" }

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -25,7 +25,7 @@ snafu = "0.7"
 tokio =  { version = "1", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
-selftest = { path = "../selftest" }
+selftest = { version = "0.1.0", path = "../selftest" }
 tokio = { version = "1", features = ["macros"] }
 
 [features]

--- a/selftest/Cargo.toml
+++ b/selftest/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3.8"
 k8s-openapi = { version = "0.14", default-features = false, features = ["v1_20"] }
 kube = { version = "0.71", default-features = true }
 lazy_static = "1"
-model = { path = "../model"}
+model = { version = "0.1.0", path = "../model"}
 serde = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["time"] }

--- a/yamlgen/Cargo.toml
+++ b/yamlgen/Cargo.toml
@@ -7,5 +7,5 @@ license = "MIT OR Apache-2.0"
 
 [build-dependencies]
 kube = { version = "0.71", default-features = false }
-model = { path = "../model" }
+model = { version = "0.1.0", path = "../model" }
 serde_yaml = "0"


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

When a crate in the Bottlerocket repo references a crate in this repo,
cargo-deny gets angry that we have not specified versions.

**Testing done:**

Compile-only

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
