### PR TITLE
test_manager: change `Status` to `StatusSnapshot` and add info

### DIFF
--- a/cli/src/status.rs
+++ b/cli/src/status.rs
@@ -31,7 +31,7 @@ impl Status {
         } else {
             let (terminal_size::Width(width), _) =
                 terminal_size::terminal_size().unwrap_or((Width(120), Height(0)));
-            println!("{}", status.to_string(width as usize));
+            println!("{:width$}", status, width = width as usize);
         }
         Ok(())
     }

--- a/model/src/test_manager/manager.rs
+++ b/model/src/test_manager/manager.rs
@@ -1,6 +1,6 @@
 use super::{
     error, DeleteEvent, DockerConfigJson, ImageConfig, ResourceState, Result, SelectionParams,
-    Status,
+    StatusSnapshot,
 };
 use crate::clients::{CrdClient, ResourceClient, TestClient};
 use crate::constants::{LABEL_COMPONENT, TESTSYS_RESULTS_FILE};
@@ -310,7 +310,7 @@ impl TestManager {
         &self,
         selection_params: &SelectionParams,
         include_controller: bool,
-    ) -> Result<Status> {
+    ) -> Result<StatusSnapshot> {
         let controller_status = if include_controller {
             let pod_api: Api<Pod> = self.namespaced_api();
             let pods = pod_api
@@ -333,7 +333,7 @@ impl TestManager {
         };
         let crds = self.list(selection_params).await?;
 
-        Ok(Status::new(controller_status, crds))
+        Ok(StatusSnapshot::new(controller_status, crds))
     }
 
     /// Retrieve the logs of a test.

--- a/model/src/test_manager/mod.rs
+++ b/model/src/test_manager/mod.rs
@@ -4,7 +4,7 @@ pub use error::{Error, Result};
 pub use manager::{read_manifest, TestManager};
 use serde::{Deserialize, Serialize};
 use serde_plain::derive_fromstr_from_deserialize;
-pub use status::Status;
+pub use status::StatusSnapshot;
 use std::collections::HashMap;
 
 mod delete;


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

`Status` is slightly ambiguous because once it is created all data remains permanent. `StatusSnapshot` helps iterate that data may become stale.
This pr also adds 3 additional fields to the `StatusSnapshot` struct: `passed`, `finished` and `failed_tests`. These will be useful for ci when calling `testsys status --json` as the test results and determining if tests are still running will not need to be calculated.

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
