### PR TITLE
Move legacy cli to develop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byteorder"
@@ -611,6 +620,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
 version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
@@ -621,9 +645,9 @@ dependencies = [
  "clap_lex",
  "indexmap",
  "lazy_static",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
- "textwrap",
+ "textwrap 0.15.0",
 ]
 
 [[package]]
@@ -632,7 +656,7 @@ version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -646,6 +670,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "clap 3.1.18",
+ "env_logger",
+ "futures",
+ "log",
+ "model",
+ "selftest",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "terminal_size",
+ "tokio",
+ "yamlgen",
 ]
 
 [[package]]
@@ -735,7 +779,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn",
 ]
 
@@ -1049,6 +1093,15 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
@@ -1308,9 +1361,12 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
+ "http",
+ "percent-encoding",
  "serde",
  "serde-value",
  "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -1525,7 +1581,7 @@ dependencies = [
  "serde_plain",
  "serde_yaml",
  "snafu",
- "tabled",
+ "tabled 0.6.1",
  "tokio",
  "tokio-util",
  "topological-sort",
@@ -1652,6 +1708,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
 name = "olpc-cjson"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,9 +1764,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.73"
+version = "0.9.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
+checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
 dependencies = [
  "autocfg",
  "cc",
@@ -1727,6 +1789,15 @@ name = "os_str_bytes"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+
+[[package]]
+name = "papergrid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c2b5b9ea36abb56e4f8a29889e67f878ebc4ab43c918abe32e85a012d27b819"
+dependencies = [
+ "unicode-width",
+]
 
 [[package]]
 name = "papergrid"
@@ -1954,6 +2025,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+dependencies = [
+ "redox_syscall",
 ]
 
 [[package]]
@@ -2399,7 +2479,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2423,9 +2503,39 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap 2.34.0",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -2440,12 +2550,33 @@ dependencies = [
 
 [[package]]
 name = "tabled"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0dca82254bf1031c194833992b10c8a8148a8f4966ae2d3b0afdabcb1bb4c8"
+dependencies = [
+ "papergrid 0.2.1",
+ "tabled_derive 0.2.0",
+]
+
+[[package]]
+name = "tabled"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d15827061abcf689257b1841c8e2732b1dfcc3ef825b24ce6c606e1e9e1a7bde"
 dependencies = [
- "papergrid",
- "tabled_derive",
+ "papergrid 0.3.0",
+ "tabled_derive 0.3.0",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a224735cbc8c30f06e52dc3891dc4b8eed07e5d4c8fb6f4cb6a839458e5a6465"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2504,6 +2635,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "termion"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall",
+ "redox_termios",
+]
+
+[[package]]
 name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,20 +2673,39 @@ dependencies = [
 name = "testsys"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "assert_cmd",
- "clap",
+ "base64",
+ "bottlerocket-types",
  "env_logger",
  "futures",
+ "http",
+ "k8s-openapi",
+ "kube",
  "log",
+ "maplit",
  "model",
  "selftest",
  "serde",
  "serde_json",
  "serde_plain",
- "terminal_size",
+ "serde_yaml",
+ "snafu",
+ "structopt",
+ "tabled 0.4.2",
+ "termion",
  "tokio",
+ "tokio-util",
+ "topological-sort",
  "yamlgen",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -2906,6 +3068,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2956,6 +3124,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "bottlerocket/agents",
     "cli",
     "bottlerocket/types",
+    "bottlerocket/testsys",
     "controller",
     "model",
     "selftest",

--- a/bottlerocket/testsys/Cargo.toml
+++ b/bottlerocket/testsys/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "testsys"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+base64 = "0.13.0"
+bottlerocket-types = { version = "0.1.0", path = "../types" }
+env_logger = "0.9"
+futures = "0.3.8"
+http = "0"
+k8s-openapi = { version = "0.15", features = ["v1_20", "api"], default-features = false }
+kube = { version = "0.73", default-features = true, features = ["config", "derive", "ws"] }
+log = "0.4"
+maplit = "1"
+model = { version = "0.1.0", path = "../../model" }
+serde = "1.0.130"
+serde_plain = "1"
+serde_json = "1.0.61"
+serde_yaml = "0.8"
+snafu = "0.7"
+structopt = "0.3"
+tabled = "0.4"
+termion = "1.5"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
+tokio-util = "0.7"
+topological-sort = "0.1"
+
+[dev-dependencies]
+assert_cmd = "2.0"
+selftest = { version = "0.1.0", path = "../../selftest" }
+
+[build-dependencies]
+yamlgen = { version = "0.1.0", path = "../../yamlgen" }
+
+[features]
+# The `integ` feature enables integration tests. These tests require docker and kind.
+integ = []

--- a/bottlerocket/testsys/src/add.rs
+++ b/bottlerocket/testsys/src/add.rs
@@ -1,0 +1,29 @@
+use crate::error::Result;
+use crate::{add_aws_secret, add_secret};
+use kube::Client;
+use structopt::StructOpt;
+
+/// Add a resource provider to a testsys cluster.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Add {
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, StructOpt)]
+enum Command {
+    /// Add a secret to the cluster.
+    Secret(add_secret::AddSecret),
+
+    /// Add AWS credentials as a secret.
+    AwsSecret(add_aws_secret::AddAwsSecret),
+}
+
+impl Add {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        match &self.command {
+            Command::Secret(add_secret) => add_secret.run(k8s_client).await,
+            Command::AwsSecret(add_aws_secret) => add_aws_secret.run(k8s_client).await,
+        }
+    }
+}

--- a/bottlerocket/testsys/src/add_aws_secret.rs
+++ b/bottlerocket/testsys/src/add_aws_secret.rs
@@ -1,0 +1,59 @@
+use crate::error::Result;
+use crate::k8s::create_or_update;
+use k8s_openapi::api::core::v1::Secret;
+use kube::{Api, Client};
+use model::constants::NAMESPACE;
+use model::SecretName;
+use std::collections::BTreeMap;
+use structopt::StructOpt;
+
+/// Add a `Secret` with key value pairs.
+#[derive(Debug, StructOpt)]
+pub(crate) struct AddAwsSecret {
+    /// Name of the secret
+    #[structopt(short, long)]
+    name: SecretName,
+
+    /// Aws access key id.
+    #[structopt(short = "u", long)]
+    aws_access_key_id: String,
+
+    /// Aws secret access key.
+    #[structopt(short = "p", long)]
+    secret_access_key: String,
+}
+
+impl AddAwsSecret {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        let args: BTreeMap<String, String> = vec![
+            ("access-key-id".to_string(), self.aws_access_key_id.clone()),
+            (
+                "secret-access-key".to_string(),
+                self.secret_access_key.clone(),
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        let secrets: Api<k8s_openapi::api::core::v1::Secret> =
+            Api::namespaced(k8s_client.clone(), NAMESPACE);
+
+        let object_meta = kube::api::ObjectMeta {
+            name: Some(self.name.as_str().to_owned()),
+            ..Default::default()
+        };
+
+        // Create the secret we are going to add.
+        let secret = Secret {
+            data: None,
+            immutable: None,
+            metadata: object_meta,
+            string_data: Some(args),
+            type_: None,
+        };
+
+        create_or_update(&secrets, secret, "Secret").await?;
+        println!("Successfully added '{}' to secrets.", self.name);
+        Ok(())
+    }
+}

--- a/bottlerocket/testsys/src/add_secret.rs
+++ b/bottlerocket/testsys/src/add_secret.rs
@@ -1,0 +1,25 @@
+use crate::add_secret_map;
+use crate::error::Result;
+use kube::Client;
+use structopt::StructOpt;
+
+/// Add a `Secret` to a testsys cluster.
+#[derive(Debug, StructOpt)]
+pub(crate) struct AddSecret {
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, StructOpt)]
+enum Command {
+    /// Add a `Secret` to the cluster using key value pairs.
+    Map(add_secret_map::AddSecretMap),
+}
+
+impl AddSecret {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        match &self.command {
+            Command::Map(add_secret_map) => add_secret_map.run(k8s_client).await,
+        }
+    }
+}

--- a/bottlerocket/testsys/src/add_secret_map.rs
+++ b/bottlerocket/testsys/src/add_secret_map.rs
@@ -1,0 +1,59 @@
+use crate::error::{self, Result};
+use crate::k8s::create_or_update;
+use k8s_openapi::api::core::v1::Secret;
+use kube::{Api, Client};
+use model::constants::NAMESPACE;
+use model::SecretName;
+use snafu::OptionExt;
+use std::collections::BTreeMap;
+use structopt::StructOpt;
+
+/// Add a `Secret` with key value pairs.
+#[derive(Debug, StructOpt)]
+pub(crate) struct AddSecretMap {
+    /// Name of the secret
+    #[structopt(short, long)]
+    name: SecretName,
+
+    /// Key value pairs for secrets. (Key=value)
+    #[structopt(parse(try_from_str = parse_key_val))]
+    args: Vec<(String, String)>,
+}
+
+impl AddSecretMap {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        let args: BTreeMap<String, String> = self.args.clone().into_iter().collect();
+
+        let secrets: Api<k8s_openapi::api::core::v1::Secret> =
+            Api::namespaced(k8s_client.clone(), NAMESPACE);
+
+        let object_meta = kube::api::ObjectMeta {
+            name: Some(self.name.as_str().to_owned()),
+            ..Default::default()
+        };
+
+        // Create the secret we are going to add.
+        let secret = Secret {
+            data: None,
+            immutable: None,
+            metadata: object_meta,
+            string_data: Some(args),
+            type_: None,
+        };
+
+        create_or_update(&secrets, secret, "Secret").await?;
+        println!("Successfully added '{}' to secrets.", self.name);
+        Ok(())
+    }
+}
+
+fn parse_key_val(s: &str) -> Result<(String, String)> {
+    let mut iter = s.splitn(2, '=');
+    let key = iter
+        .next()
+        .context(error::ArgumentMissingSnafu { arg: s.to_string() })?;
+    let value = iter
+        .next()
+        .context(error::ArgumentMissingSnafu { arg: s.to_string() })?;
+    Ok((key.to_string(), value.to_string()))
+}

--- a/bottlerocket/testsys/src/delete.rs
+++ b/bottlerocket/testsys/src/delete.rs
@@ -1,0 +1,341 @@
+use crate::error::{self, Result};
+use http::StatusCode;
+use kube::{core::object::HasStatus, Client, ResourceExt};
+use model::{
+    clients::{AllowNotFound, CrdClient, HttpStatusCode, ResourceClient, TestClient},
+    TaskState,
+};
+use serde::Deserialize;
+use serde_plain::derive_fromstr_from_deserialize;
+use snafu::ResultExt;
+use std::{collections::HashSet, time::Duration};
+use structopt::StructOpt;
+use topological_sort::TopologicalSort;
+
+/// Delete an object from a testsys cluster.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Delete {
+    /// Delete all tests and resources from a testsys cluster.
+    #[structopt(
+        long,
+        conflicts_with_all(&["object-type", "object-name", "include-resources", "force"])
+    )]
+    all: bool,
+
+    /// Delete the resource object after a failed deletion attempt.
+    /// Warning: the resources created must be manually removed.
+    #[structopt(
+        long,
+        conflicts_with = "include-resources",
+        requires_if("object-type", "resource")
+    )]
+    force: bool,
+
+    /// The type of object that is being delete must be either `test` or `resource`.
+    #[structopt(required_unless = "all")]
+    object_type: Option<ObjectType>,
+
+    /// The name of the test/resource that should be deleted.
+    #[structopt(required_unless = "all")]
+    object_name: Option<String>,
+
+    /// Include this flag if all resources this object depends on should be deleted as well.
+    #[structopt(long)]
+    include_resources: bool,
+}
+
+#[derive(Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+enum ObjectType {
+    Test,
+    Resource,
+}
+
+derive_fromstr_from_deserialize!(ObjectType);
+
+impl Delete {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        match (
+            self.all,
+            self.force,
+            self.object_type,
+            self.object_name.as_ref(),
+        ) {
+            (true, _, _, _) => delete_all(k8s_client).await,
+            (false, false, Some(ObjectType::Test), Some(object_name)) => {
+                delete_test(k8s_client, object_name, self.include_resources).await
+            }
+            (false, false, Some(ObjectType::Resource), Some(object_name)) => {
+                delete_resource(k8s_client, object_name, self.include_resources).await
+            }
+            (false, true, Some(ObjectType::Resource), Some(object_name)) => {
+                force_delete_resource(k8s_client, object_name).await
+            }
+            (_, _, _, _) => Err(error::Error::InvalidArguments {
+                why: "Either `all` must be set, or both of `object-type` and `object-name`"
+                    .to_string(),
+            }),
+        }
+    }
+}
+
+async fn delete_all(k8s_client: Client) -> Result<()> {
+    let mut failures = 0;
+    let test_client = TestClient::new_from_k8s_client(k8s_client.clone());
+    let resource_client = ResourceClient::new_from_k8s_client(k8s_client.clone());
+
+    // Start by deleting all tests and waiting for their completion.
+    println!("Deleting all tests...");
+    test_client.delete_all().await.context(error::DeleteSnafu {
+        what: "all tests".to_string(),
+    })?;
+    while !test_client
+        .get_all()
+        .await
+        .context(error::GetSnafu { what: "all tests" })?
+        .is_empty()
+    {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+    println!("Test deletion complete.");
+    // Build a topological sort with all resources in the cluster
+    let mut deletion_order = all_resources_deletion_order(&k8s_client).await?;
+    let mut awaiting_deletion = Vec::<String>::new();
+    println!("Deleting all resources following dependencies...");
+    while !deletion_order.is_empty() || !awaiting_deletion.is_empty() {
+        // Check for all resources that have been deleted for completion.
+        let mut still_awaiting = Vec::new();
+        for resource_name in &awaiting_deletion {
+            if let Some(resource) = resource_client
+                .get(resource_name)
+                .await
+                .allow_not_found(|_| ())
+                .context(error::GetSnafu {
+                    what: resource_name,
+                })?
+            {
+                // If the resource errored during deletion alert the user that a problem occured
+                if resource
+                    .status()
+                    .map(|status| status.destruction.task_state == TaskState::Error)
+                    .unwrap_or_default()
+                {
+                    failures += 1;
+                    eprintln!("Resource '{}' failed to delete.", resource_name);
+                    println!("Use `testsys delete resource {} --force` to manually clean up the resource.", resource_name);
+                } else {
+                    still_awaiting.push(resource_name.to_string());
+                }
+            } else {
+                println!("Resource '{}' has been deleted", resource_name);
+            }
+        }
+        awaiting_deletion = still_awaiting;
+
+        // If all resources awaiting deletion have been deleted we can get a new
+        // set of resources to delete.
+        if awaiting_deletion.is_empty() {
+            awaiting_deletion = deletion_order.pop_all();
+            for resource in &awaiting_deletion {
+                println!("Deleting resource '{}' ...", resource);
+                resource_client
+                    .delete(resource)
+                    .await
+                    .allow_not_found(|_| println!("The resource '{}' was not found", resource))
+                    .context(error::DeleteSnafu {
+                        what: resource.to_string(),
+                    })?;
+            }
+        }
+    }
+    if failures == 0 {
+        println!("All resources have been deleted.");
+        Ok(())
+    } else {
+        eprintln!("Some resources failed to be deleted.");
+        Err(error::Error::DeleteCommand { count: failures })
+    }
+}
+
+/// Delete a testsys resource. If `include_resources`, all resources that this resource
+/// depended on will also be deleted.
+async fn delete_resource(
+    k8s_client: Client,
+    resource_name: &str,
+    include_resources: bool,
+) -> Result<()> {
+    let delete_order = if include_resources {
+        resource_dependency_delete_order(&k8s_client, vec![resource_name.to_string()]).await?
+    } else {
+        let mut topo_sort = TopologicalSort::new();
+        topo_sort.insert(resource_name);
+        topo_sort
+    };
+    delete_resources_in_order(&k8s_client, delete_order).await
+}
+
+/// Delete a testsys test. If `include_resources`, all resources that this test
+/// depended on will also be deleted.
+async fn delete_test(k8s_client: Client, test_name: &str, include_resources: bool) -> Result<()> {
+    let test_client = TestClient::new_from_k8s_client(k8s_client.clone());
+    let delete_order = if include_resources {
+        Some(resource_deletion_order_for_test(k8s_client.clone(), test_name).await?)
+    } else {
+        None
+    };
+
+    if test_client
+        .delete(test_name)
+        .await
+        .allow_not_found(|_| println!("The test '{}' was not found", test_name))
+        .context(error::DeleteSnafu {
+            what: test_name.to_string(),
+        })?
+        .is_some()
+    {
+        println!("Deleting test '{}'", test_name);
+        test_client.wait_for_deletion(test_name).await;
+        println!("Test '{}' has been deleted", test_name);
+        if let Some(delete_order) = delete_order {
+            return delete_resources_in_order(&k8s_client, delete_order).await;
+        }
+    }
+    Ok(())
+}
+
+/// Delete all resources in a `TopologicalSort` in order. The function will wait
+/// for each resource to finish before starting to delete the next resource.
+async fn delete_resources_in_order(
+    k8s_client: &Client,
+    mut topo_sort: TopologicalSort<String>,
+) -> Result<()> {
+    let mut failures = 0;
+    let resource_client = ResourceClient::new_from_k8s_client(k8s_client.clone());
+    while !topo_sort.is_empty() {
+        if let Some(independent_resource) = topo_sort.pop() {
+            if resource_client
+                .delete(&independent_resource)
+                .await
+                .allow_not_found(|_| {
+                    println!("The resource '{}' was not found", independent_resource)
+                })
+                .context(error::DeleteSnafu {
+                    what: independent_resource.to_string(),
+                })?
+                .is_some()
+            {
+                println!("Deleting resource '{}'", independent_resource);
+                if resource_client
+                    .wait_for_deletion(&independent_resource)
+                    .await
+                    .is_err()
+                {
+                    failures += 1;
+                    eprintln!("Resource '{}' failed to delete.", independent_resource);
+                    println!("Use `testsys delete resource {} --force` to manually clean up the resource.", independent_resource);
+                } else {
+                    println!("Resource '{}' has been deleted", independent_resource);
+                }
+            }
+        }
+    }
+    if failures == 0 {
+        Ok(())
+    } else {
+        eprintln!("Some resources failed to be deleted.");
+        Err(error::Error::DeleteCommand { count: failures })
+    }
+}
+
+/// Creates a `TopologicalSort` containing all resources that `test_name` depends on
+/// which provides an order for deletion.
+async fn resource_deletion_order_for_test(
+    k8s_client: Client,
+    test_name: &str,
+) -> Result<TopologicalSort<String>> {
+    let test_client = TestClient::new_from_k8s_client(k8s_client.clone());
+    let get_test_result = test_client.get(test_name).await;
+
+    if get_test_result.is_status_code(StatusCode::NOT_FOUND) {
+        println!("Test '{}' does not exist, nothing to do.", test_name);
+        return Ok(TopologicalSort::new());
+    }
+
+    let test = get_test_result.context(error::GetSnafu {
+        what: test_name.to_string(),
+    })?;
+
+    resource_dependency_delete_order(&k8s_client, test.spec.resources).await
+}
+
+/// Creates a `TopologicalSort` containing all resources including `initial_resources` that
+/// `initial_resources` depends on.
+async fn resource_dependency_delete_order(
+    k8s_client: &Client,
+    initial_resources: Vec<String>,
+) -> Result<TopologicalSort<String>> {
+    let resource_client = ResourceClient::new_from_k8s_client(k8s_client.clone());
+    let mut visited_resources = HashSet::<String>::from_iter(initial_resources.clone());
+    let mut to_be_visited = initial_resources.clone();
+
+    let mut topo_sort = TopologicalSort::new();
+
+    while let Some(resource_name) = to_be_visited.pop() {
+        let get_resource_result = resource_client.get(&resource_name).await;
+        if get_resource_result.is_status_code(StatusCode::NOT_FOUND) {
+            println!("Resource '{}' does not exist. Skipping.", resource_name);
+            continue;
+        }
+
+        let resource = get_resource_result.context(error::GetSnafu {
+            what: resource_name.to_string(),
+        })?;
+
+        if let Some(depended_resources) = resource.spec.depends_on {
+            for depended_resource in depended_resources {
+                topo_sort.add_dependency(resource_name.clone(), depended_resource.clone());
+
+                visited_resources.insert(depended_resource.clone());
+                to_be_visited.push(depended_resource);
+            }
+        } else {
+            topo_sort.insert(resource_name);
+        }
+    }
+
+    Ok(topo_sort)
+}
+
+/// Creates a `TopologicalSort` containing all resources in a testsys cluster.
+async fn all_resources_deletion_order(k8s_client: &Client) -> Result<TopologicalSort<String>> {
+    let mut topo_sort = TopologicalSort::new();
+    let resource_client = ResourceClient::new_from_k8s_client(k8s_client.clone());
+    let resources = resource_client.get_all().await.context(error::GetSnafu {
+        what: "all resources",
+    })?;
+    for resource in resources {
+        if let Some(depended_resources) = &resource.spec.depends_on {
+            for depended_resource in depended_resources {
+                topo_sort.add_dependency(resource.name(), depended_resource.clone());
+            }
+        } else {
+            topo_sort.insert(resource.name());
+        }
+    }
+    Ok(topo_sort)
+}
+
+/// Delete a resource from a testsys cluster by force.
+/// The finalizers will be removed from the resource and the resource will be deleted.
+/// The job for resource deletion will also be deleted.
+/// This should only be used if a resource has already failed to delete.
+async fn force_delete_resource(k8s_client: Client, resource_name: &str) -> Result<()> {
+    let resource_client = ResourceClient::new_from_k8s_client(k8s_client.clone());
+    resource_client
+        .force_delete(resource_name)
+        .await
+        .context(error::DeleteSnafu {
+            what: resource_name,
+        })?;
+    Ok(())
+}

--- a/bottlerocket/testsys/src/error.rs
+++ b/bottlerocket/testsys/src/error.rs
@@ -1,0 +1,136 @@
+use crate::PathBuf;
+use snafu::Snafu;
+
+/// The crate-wide result type.
+pub(crate) type Result<T> = std::result::Result<T, Error>;
+
+/// The crate-wide error type.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub(crate) enum Error {
+    #[snafu(display(
+        "Unable to parse argument '{}' as key value pair, expected key=value syntax",
+        arg
+    ))]
+    ArgumentMissing { arg: String },
+
+    #[snafu(display("Unable to create client: {}", source))]
+    ClientCreate { source: kube::Error },
+
+    #[snafu(display("Unable to create client: {}", source))]
+    ClientCreateKubeconfig {
+        source: kube::config::KubeconfigError,
+    },
+
+    #[snafu(display("Unable to read kubeconfig: {}", source))]
+    ConfigRead {
+        source: kube::config::KubeconfigError,
+    },
+
+    #[snafu(display("Error Creating {}: {}", what, source))]
+    Creation { what: String, source: kube::Error },
+
+    #[snafu(display("Error creating test: {}", source))]
+    CreateTest { source: model::clients::Error },
+
+    #[snafu(display("Error creating resource: {}", source))]
+    CreateResource { source: model::clients::Error },
+
+    #[snafu(display("Unable to delete '{}': {}", what, source))]
+    Delete {
+        what: String,
+        source: model::clients::Error,
+    },
+
+    #[snafu(display("{} objects failed to be deleted.", count))]
+    DeleteCommand { count: i32 },
+
+    #[snafu(display("Error deleting {} '{}': {}", what, name, source))]
+    DeleteObject {
+        what: String,
+        name: String,
+        source: kube::Error,
+    },
+
+    #[snafu(display("The following tests failed to run '{:?}'", tests))]
+    FailedTest { tests: Vec<String> },
+
+    #[snafu(display("Unable to open file '{}': {}", path.display(), source))]
+    File {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Unable to get pod for '{}': {}", test_name, source))]
+    GetPod {
+        test_name: String,
+        source: kube::Error,
+    },
+
+    #[snafu(display("Unable to get logs for '{}': {}", pod, source))]
+    Logs { pod: String, source: kube::Error },
+
+    #[snafu(display("Unable to get next log from stream: {}", source))]
+    LogsStream { source: kube::Error },
+
+    #[snafu(display("Unable to get '{}': {}", what, source))]
+    Get {
+        what: String,
+        source: model::clients::Error,
+    },
+
+    #[snafu(display("The arguments given were invalid: {}", why))]
+    InvalidArguments { why: String },
+
+    #[snafu(display("Could not serialize object: {}", source))]
+    JsonSerialize { source: serde_json::Error },
+
+    #[snafu(display("Could not create map: {}", source))]
+    ConfigMap { source: model::Error },
+
+    #[snafu(display("Could not extract registry url from '{}'", uri))]
+    MissingRegistry { uri: String },
+
+    #[snafu(display("{}: {}", message, source))]
+    ModelClient {
+        message: String,
+        source: model::clients::Error,
+    },
+
+    #[snafu(display("No stdout from request"))]
+    NoOut,
+
+    #[snafu(display("Error patching {}: {}", what, source))]
+    Patch { what: String, source: kube::Error },
+
+    #[snafu(display("Error getting data from reader: {}", source))]
+    Read { source: std::io::Error },
+
+    #[snafu(display("Unable to create ResourceProvider CRD from '{}': {}", path.display(), source))]
+    ResourceProviderFileParse {
+        path: PathBuf,
+        source: serde_yaml::Error,
+    },
+
+    #[snafu(display("Unable to set {} field of '{}': {}", what, name, source))]
+    Set {
+        name: String,
+        what: String,
+        source: model::clients::Error,
+    },
+
+    #[snafu(display("Unable to create client: {}", source))]
+    TestClientNew { source: model::clients::Error },
+
+    #[snafu(display("Unable to create Test CRD from '{}': {}", path.display(), source))]
+    TestFileParse {
+        path: PathBuf,
+        source: serde_yaml::Error,
+    },
+
+    #[snafu(display("Could not retrieve test '{}'", test_name))]
+    TestMissing { test_name: String },
+
+    #[snafu(display("Unable to write data: {}", source))]
+    Write { source: std::io::Error },
+}

--- a/bottlerocket/testsys/src/install.rs
+++ b/bottlerocket/testsys/src/install.rs
@@ -1,0 +1,238 @@
+use crate::error::{self, Result};
+use crate::k8s::{create_or_update, DockerConfigJson};
+use apiexts::CustomResourceDefinition;
+use k8s_openapi::{
+    api::core::v1::Secret, apiextensions_apiserver::pkg::apis::apiextensions::v1 as apiexts,
+};
+use kube::{Api, Client, CustomResourceExt};
+use model::constants::NAMESPACE;
+use model::system::{
+    agent_cluster_role, agent_cluster_role_binding, agent_service_account, controller_cluster_role,
+    controller_cluster_role_binding, controller_deployment, controller_service_account,
+    testsys_namespace, AgentType,
+};
+use model::{Resource, Test};
+use snafu::ResultExt;
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use structopt::StructOpt;
+
+const CONTROLLER_SECRET: &str = "testsys-controller-pull-cred";
+
+const DEFAULT_TESTSYS_CONTROLLER_IMAGE: &str =
+    "334716814390.dkr.ecr.us-west-2.amazonaws.com/controller:2";
+
+/// The install subcommand is responsible for putting all of the necessary components for testsys in
+/// a k8s cluster.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Install {
+    /// Controller image pull username
+    #[structopt(
+        long = "controller-pull-username",
+        short = "u",
+        requires("pull-password")
+    )]
+    pull_username: Option<String>,
+
+    /// Controller image pull password
+    #[structopt(
+        long = "controller-pull-password",
+        short = "p",
+        requires("pull-username")
+    )]
+    pull_password: Option<String>,
+
+    /// Controller image uri
+    #[structopt(long = "controller-uri", default_value = DEFAULT_TESTSYS_CONTROLLER_IMAGE)]
+    controller_uri: String,
+}
+
+impl Install {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        create_namespace(&k8s_client).await?;
+        create_crd(&k8s_client).await?;
+        create_roles(&k8s_client, AgentType::Test).await?;
+        create_roles(&k8s_client, AgentType::Resource).await?;
+        create_service_accts(&k8s_client, AgentType::Test).await?;
+        create_service_accts(&k8s_client, AgentType::Resource).await?;
+        create_controller_service_acct(&k8s_client).await?;
+
+        let mut controller_image_pull_secret = None;
+
+        // Create the secret.
+        if let (Some(username), Some(password)) =
+            (self.pull_username.as_ref(), self.pull_password.as_ref())
+        {
+            create_secret(
+                &k8s_client,
+                username,
+                password,
+                self.controller_uri
+                    .split('/')
+                    .next()
+                    .ok_or(error::Error::MissingRegistry {
+                        uri: self.controller_uri.clone(),
+                    })?,
+            )
+            .await?;
+            // Use the secret we just created.
+            controller_image_pull_secret = Some(CONTROLLER_SECRET.to_string());
+        }
+
+        create_deployment(
+            &k8s_client,
+            self.controller_uri.clone(),
+            controller_image_pull_secret,
+        )
+        .await?;
+
+        println!("testsys components were successfully installed.");
+
+        Ok(())
+    }
+}
+
+async fn create_namespace(client: &Client) -> Result<()> {
+    // Add the namespace to the cluster.
+    let api: Api<k8s_openapi::api::core::v1::Namespace> = Api::all(client.clone());
+    let ns = testsys_namespace();
+
+    create_or_update(&api, ns, "namespace").await?;
+
+    // Give the object enough time to settle.
+    let mut sleep_count = 0;
+    while api.get(NAMESPACE).await.is_err() && sleep_count < 20 {
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        sleep_count += 1;
+    }
+
+    api.get(NAMESPACE)
+        .await
+        .context(error::CreationSnafu { what: "namespace" })?;
+
+    Ok(())
+}
+
+async fn create_crd(client: &Client) -> Result<()> {
+    // Manage the cluster crds.
+    let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+    // Create the `Test` crd.
+    let testcrd = Test::crd();
+    // Create the `Resource` crd.
+    let resourcecrd = Resource::crd();
+
+    create_or_update(&crds, testcrd, "Test CRD").await?;
+    create_or_update(&crds, resourcecrd, "Resource Provider CRD").await
+}
+
+async fn create_roles(client: &Client, agent_type: AgentType) -> Result<()> {
+    let roles: Api<k8s_openapi::api::rbac::v1::ClusterRole> = Api::all(client.clone());
+
+    // If the role exists merge the new role, if not create the role.
+    let test_agent_cluster_role = agent_cluster_role(agent_type);
+    create_or_update(&roles, test_agent_cluster_role, "Agent Cluster Role").await?;
+
+    // If the role already exists, update it with the new one using Patch. If not create a new role.
+    let controller_cluster_role = controller_cluster_role();
+    create_or_update(&roles, controller_cluster_role, "Controller Cluster Role").await?;
+
+    let rolesbinding: Api<k8s_openapi::api::rbac::v1::ClusterRoleBinding> =
+        Api::all(client.clone());
+
+    // If the cluster role binding already exists, update it with the new one using Patch. If not
+    // create a new cluster role binding.
+    let agent_cluster_role_binding = agent_cluster_role_binding(agent_type);
+    create_or_update(
+        &rolesbinding,
+        agent_cluster_role_binding,
+        "Agent Cluster Role Binding",
+    )
+    .await?;
+
+    // If the cluster role binding already exists, update it with the new one using Patch. If not
+    // create a new cluster role binding.
+    let controller_cluster_role_binding = controller_cluster_role_binding();
+    create_or_update(
+        &rolesbinding,
+        controller_cluster_role_binding,
+        "Controller Cluster Role Binding",
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn create_service_accts(client: &Client, agent_type: AgentType) -> Result<()> {
+    let service_accts: Api<k8s_openapi::api::core::v1::ServiceAccount> =
+        Api::namespaced(client.clone(), NAMESPACE);
+
+    // If the service accounts already exist, update them with the new ones using Patch.
+    // If not create new service accounts.
+    let agent_service_account = agent_service_account(agent_type);
+    create_or_update(
+        &service_accts,
+        agent_service_account,
+        "Agent Service Account",
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn create_controller_service_acct(client: &Client) -> Result<()> {
+    let service_accts: Api<k8s_openapi::api::core::v1::ServiceAccount> =
+        Api::namespaced(client.clone(), NAMESPACE);
+    let controller_service_account = controller_service_account();
+    create_or_update(
+        &service_accts,
+        controller_service_account,
+        "Controller Service Accout",
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn create_secret(
+    client: &Client,
+    username: &str,
+    password: &str,
+    registry_url: &str,
+) -> Result<()> {
+    // Create secret for controller image pull.
+    let sec_str =
+        serde_json::to_string_pretty(&DockerConfigJson::new(username, password, registry_url))
+            .context(error::JsonSerializeSnafu)?;
+    let mut secret_tree = BTreeMap::new();
+    secret_tree.insert(".dockerconfigjson".to_string(), sec_str);
+
+    let secrets: Api<k8s_openapi::api::core::v1::Secret> =
+        Api::namespaced(client.clone(), NAMESPACE);
+
+    let object_meta = kube::api::ObjectMeta {
+        name: Some(CONTROLLER_SECRET.to_string()),
+        ..Default::default()
+    };
+
+    // Create the secret we are going to add.
+    let secret = Secret {
+        data: None,
+        immutable: None,
+        metadata: object_meta,
+        string_data: Some(secret_tree),
+        type_: Some("kubernetes.io/dockerconfigjson".to_string()),
+    };
+
+    create_or_update(&secrets, secret, "Secret").await
+}
+
+async fn create_deployment(client: &Client, uri: String, secret: Option<String>) -> Result<()> {
+    let deps: Api<k8s_openapi::api::apps::v1::Deployment> =
+        Api::namespaced(client.clone(), NAMESPACE);
+
+    let controller_deployment = controller_deployment(uri, secret);
+
+    // If the controller deployment already exists, update it with the new one using Patch.
+    // If not create a new controller deployment.
+    create_or_update(&deps, controller_deployment, "namespace").await
+}

--- a/bottlerocket/testsys/src/k8s.rs
+++ b/bottlerocket/testsys/src/k8s.rs
@@ -1,0 +1,93 @@
+use crate::error::{self, Result};
+use kube::{
+    api::{Api, Patch, PatchParams, PostParams, ResourceExt},
+    config::{KubeConfigOptions, Kubeconfig},
+    Client, Config,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use snafu::ResultExt;
+use std::collections::HashMap;
+use std::convert::TryInto;
+use std::fmt::Debug;
+use std::path::PathBuf;
+
+/// Create the k8s client. If the `kubeconfig` path is given then we use it. If not, then we
+/// construct use the `Client`'s default construction which attempts to use environment variables
+/// (e.g. `KUBECONFIG`).
+pub(crate) async fn k8s_client(kubeconfig: &Option<PathBuf>) -> Result<Client> {
+    match kubeconfig {
+        None => Ok(Client::try_default()
+            .await
+            .context(error::ClientCreateSnafu)?),
+        Some(config_path) => {
+            let kubeconfig = Kubeconfig::read_from(config_path).context(error::ConfigReadSnafu)?;
+            let config = Config::from_custom_kubeconfig(kubeconfig, &KubeConfigOptions::default())
+                .await
+                .context(error::ClientCreateKubeconfigSnafu)?;
+            Ok(config.try_into().context(error::ClientCreateSnafu)?)
+        }
+    }
+}
+
+const MAX_RETRIES: i32 = 3;
+const BACKOFF_MS: u64 = 500;
+
+/// Create or update an object in `api` with `data`'s name
+pub(crate) async fn create_or_update<T>(api: &Api<T>, data: T, what: &str) -> Result<()>
+where
+    T: Clone + DeserializeOwned + Debug + kube::Resource + Serialize,
+{
+    let mut error = None;
+
+    for _ in 0..MAX_RETRIES {
+        match create_or_update_internal(api, data.clone(), what).await {
+            Ok(()) => return Ok(()),
+            Err(e) => error = Some(e),
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(BACKOFF_MS)).await;
+    }
+    match error {
+        None => Ok(()),
+        Some(error) => Err(error),
+    }
+}
+
+async fn create_or_update_internal<T>(api: &Api<T>, data: T, what: &str) -> Result<()>
+where
+    T: Clone + DeserializeOwned + Debug + kube::Resource + Serialize,
+{
+    // If the data already exists, update it with the new one using a `Patch`. If not create a new one.
+    match api.get(&data.name()).await {
+        Ok(deployment) => {
+            api.patch(
+                &deployment.name(),
+                &PatchParams::default(),
+                &Patch::Merge(data),
+            )
+            .await
+        }
+        Err(_err) => api.create(&PostParams::default(), &data).await,
+    }
+    .context(error::CreationSnafu { what })?;
+
+    Ok(())
+}
+
+#[derive(Serialize)]
+pub(crate) struct DockerConfigJson {
+    auths: HashMap<String, DockerConfigAuth>,
+}
+
+#[derive(Serialize)]
+struct DockerConfigAuth {
+    auth: String,
+}
+
+impl DockerConfigJson {
+    pub(crate) fn new(username: &str, password: &str, registry: &str) -> DockerConfigJson {
+        let mut auths = HashMap::new();
+        let auth = base64::encode(format!("{}:{}", username, password));
+        auths.insert(registry.to_string(), DockerConfigAuth { auth });
+        DockerConfigJson { auths }
+    }
+}

--- a/bottlerocket/testsys/src/logs.rs
+++ b/bottlerocket/testsys/src/logs.rs
@@ -1,0 +1,119 @@
+use crate::error::{self, Result};
+use futures::{stream::select_all, TryStreamExt};
+use k8s_openapi::api::core::v1::Pod;
+use kube::{
+    api::{ListParams, LogParams},
+    Api, Client, ResourceExt,
+};
+use model::{
+    clients::{CrdClient, TestClient},
+    constants::NAMESPACE,
+};
+use snafu::ResultExt;
+use structopt::StructOpt;
+
+/// Retrieve the logs for a testsys test and all resources it depends on.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Logs {
+    /// The name of the test.
+    #[structopt()]
+    test_name: String,
+
+    /// Include logs for the resource this test depends on.
+    #[structopt(long)]
+    include_resources: bool,
+
+    /// Keep and updated stream of logs.
+    #[structopt(long)]
+    follow: bool,
+}
+
+impl Logs {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        let test_client = TestClient::new_from_k8s_client(k8s_client.clone());
+        let test = test_client
+            .get(&self.test_name)
+            .await
+            .context(error::GetSnafu {
+                what: self.test_name.clone(),
+            })?;
+        let resources = test.spec.resources;
+
+        let pod_api = Api::<Pod>::namespaced(k8s_client, NAMESPACE);
+        let test_pods = pod_api
+            .list(&ListParams {
+                label_selector: Some(format!("job-name={}", &self.test_name)),
+                ..Default::default()
+            })
+            .await
+            .context(error::GetPodSnafu {
+                test_name: self.test_name.clone(),
+            })?;
+
+        let log_params = LogParams {
+            follow: self.follow,
+            pretty: true,
+            ..Default::default()
+        };
+
+        let mut streams = Vec::new();
+
+        if self.include_resources {
+            let mut pods = Vec::new();
+            for resource in resources {
+                pods.append(
+                    &mut pod_api
+                        .list(&ListParams {
+                            label_selector: Some(format!("job-name={}-creation", resource)),
+                            ..Default::default()
+                        })
+                        .await
+                        .context(error::GetPodSnafu {
+                            test_name: resource.clone(),
+                        })?
+                        .items,
+                );
+                pods.append(
+                    &mut pod_api
+                        .list(&ListParams {
+                            label_selector: Some(format!("job-name={}-destruction", resource)),
+                            ..Default::default()
+                        })
+                        .await
+                        .context(error::GetPodSnafu {
+                            test_name: resource.clone(),
+                        })?
+                        .items,
+                );
+            }
+            for pod in pods {
+                streams.push(
+                    pod_api
+                        .log_stream(&pod.name(), &log_params)
+                        .await
+                        .context(error::LogsSnafu { pod: pod.name() })?,
+                );
+            }
+        }
+        for pod in test_pods {
+            streams.push(
+                pod_api
+                    .log_stream(&pod.name(), &log_params)
+                    .await
+                    .context(error::LogsSnafu { pod: pod.name() })?,
+            );
+        }
+
+        let mut single_stream = select_all(streams);
+
+        while let Some(line) = single_stream
+            .try_next()
+            .await
+            .context(error::LogsStreamSnafu)?
+        {
+            println!("{:?}", String::from_utf8_lossy(&line));
+        }
+
+        Ok(())
+    }
+}

--- a/bottlerocket/testsys/src/main.rs
+++ b/bottlerocket/testsys/src/main.rs
@@ -1,0 +1,116 @@
+/*!
+
+DEPRECATED: We are using this command line interface for setting up and running Bottlerocket tests.
+It is in the process of being moved to https://github.com/bottlerocket-os/bottlerocket
+Once the functionality has been moved over, this CLI will be removed.
+
+!*/
+
+mod add;
+mod add_aws_secret;
+mod add_secret;
+mod add_secret_map;
+mod delete;
+mod error;
+mod install;
+mod k8s;
+mod logs;
+mod restart;
+mod restart_test;
+mod results;
+mod run;
+mod run_aws_ecs;
+mod run_aws_k8s;
+mod run_file;
+mod run_sonobuoy;
+mod run_vmware;
+mod set;
+mod status;
+
+use crate::k8s::k8s_client;
+use env_logger::Builder;
+use error::Result;
+use log::LevelFilter;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+/// DEPRECATED: We are using this command line interface for setting up and running Bottlerocket
+/// tests. It is in the process of being moved to https://github.com/bottlerocket-os/bottlerocket
+/// Once the functionality has been moved over, this CLI will be removed.
+#[derive(Debug, StructOpt)]
+struct Args {
+    /// Set logging verbosity [trace|debug|info|warn|error]. If the environment variable `RUST_LOG`
+    /// is present, it overrides the default logging behavior. See https://docs.rs/env_logger/latest
+    #[structopt(long = "log-level", default_value = "info")]
+    log_level: LevelFilter,
+    /// Path to the kubeconfig file. Also can be passed with the KUBECONFIG environment variable.
+    #[structopt(long = "kubeconfig")]
+    kubeconfig: Option<PathBuf>,
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, StructOpt)]
+enum Command {
+    /// Install TestSys components into the cluster.
+    Install(install::Install),
+    /// Run a TestSys test.
+    Run(run::Run),
+    /// Check the status of a TestSys test.
+    Status(status::Status),
+    /// Add various components to the cluster.
+    Add(add::Add),
+    /// Set a field of a TestSys test.
+    Set(set::Set),
+    /// Retrieve the results tar from the test.
+    Results(results::Results),
+    /// Retrieve the logs for a test pod.
+    Logs(logs::Logs),
+    /// Delete a testsys object.
+    Delete(delete::Delete),
+    /// Restart a testsys test.
+    Restart(restart::Restart),
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::from_args();
+    init_logger(args.log_level);
+    if let Err(e) = run(args).await {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    }
+}
+
+async fn run(args: Args) -> Result<()> {
+    let k8s_client = k8s_client(&args.kubeconfig).await?;
+    match args.command {
+        Command::Install(install) => install.run(k8s_client).await,
+        Command::Run(run) => run.run(k8s_client).await,
+        Command::Status(status) => status.run(k8s_client).await,
+        Command::Add(add) => add.run(k8s_client).await,
+        Command::Set(set) => set.run(k8s_client).await,
+        Command::Results(results) => results.run(k8s_client).await,
+        Command::Logs(logs) => logs.run(k8s_client).await,
+        Command::Delete(delete) => delete.run(k8s_client).await,
+        Command::Restart(restart) => restart.run(k8s_client).await,
+    }
+}
+
+/// Initialize the logger with the value passed by `--log-level` (or its default) when the
+/// `RUST_LOG` environment variable is not present. If present, the `RUST_LOG` environment variable
+/// overrides `--log-level`/`level`.
+fn init_logger(level: LevelFilter) {
+    match std::env::var(env_logger::DEFAULT_FILTER_ENV).ok() {
+        Some(_) => {
+            // RUST_LOG exists; env_logger will use it.
+            Builder::from_default_env().init();
+        }
+        None => {
+            // RUST_LOG does not exist; use default log level for this crate only.
+            Builder::new()
+                .filter(Some(env!("CARGO_CRATE_NAME")), level)
+                .init();
+        }
+    }
+}

--- a/bottlerocket/testsys/src/restart.rs
+++ b/bottlerocket/testsys/src/restart.rs
@@ -1,0 +1,25 @@
+use crate::error::Result;
+use crate::restart_test;
+use kube::Client;
+use structopt::StructOpt;
+
+/// Restart testsys tests.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Restart {
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, StructOpt)]
+enum Command {
+    /// Restart a testsys test.
+    Test(restart_test::RestartTest),
+}
+
+impl Restart {
+    pub(crate) async fn run(self, k8s_client: Client) -> Result<()> {
+        match self.command {
+            Command::Test(restart_test) => restart_test.run(k8s_client).await,
+        }
+    }
+}

--- a/bottlerocket/testsys/src/restart_test.rs
+++ b/bottlerocket/testsys/src/restart_test.rs
@@ -1,0 +1,40 @@
+use crate::error::{self, Result};
+use kube::Client;
+use model::clients::{CrdClient, TestClient};
+use snafu::ResultExt;
+use structopt::StructOpt;
+
+/// Restart an object from a testsys cluster.
+#[derive(Debug, StructOpt)]
+pub(crate) struct RestartTest {
+    /// The name of the test to be restarted.
+    #[structopt()]
+    test_name: String,
+}
+
+impl RestartTest {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        let test_client = TestClient::new_from_k8s_client(k8s_client.clone());
+        let mut test = test_client
+            .get(&self.test_name)
+            .await
+            .context(error::GetSnafu {
+                what: self.test_name.clone(),
+            })?;
+        // Created objects are not allowed to have `resource_version` set.
+        test.metadata.resource_version = None;
+        test.status = None;
+        test_client
+            .delete(&self.test_name)
+            .await
+            .context(error::DeleteSnafu {
+                what: self.test_name.clone(),
+            })?;
+        test_client.wait_for_deletion(&self.test_name).await;
+        test_client
+            .create(test)
+            .await
+            .context(error::CreateTestSnafu)?;
+        Ok(())
+    }
+}

--- a/bottlerocket/testsys/src/results.rs
+++ b/bottlerocket/testsys/src/results.rs
@@ -1,0 +1,70 @@
+use crate::error::{self, Result};
+use futures::StreamExt;
+use k8s_openapi::api::core::v1::Pod;
+use kube::{
+    api::{AttachParams, ListParams},
+    Api, Client, ResourceExt,
+};
+use model::constants::{NAMESPACE, TESTSYS_RESULTS_FILE};
+use snafu::ResultExt;
+use std::path::PathBuf;
+use structopt::StructOpt;
+use tokio::io::AsyncWriteExt;
+
+/// Retrieve the results of a test.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Results {
+    /// Name of the sonobuoy test.
+    #[structopt(short = "n", long)]
+    test_name: String,
+    /// The place the test results should be written
+    #[structopt(long, parse(from_os_str))]
+    destination: PathBuf,
+}
+
+impl Results {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        let pods: Api<Pod> = Api::namespaced(k8s_client.clone(), NAMESPACE);
+        let pod_name = pods
+            .list(&ListParams {
+                label_selector: Some(format!("job-name={}", &self.test_name)),
+                ..Default::default()
+            })
+            .await
+            .context(error::GetPodSnafu {
+                test_name: self.test_name.clone(),
+            })?
+            .iter()
+            .next()
+            .ok_or(error::Error::TestMissing {
+                test_name: self.test_name.clone(),
+            })?
+            .name();
+
+        let ap = AttachParams::default();
+        let mut cat = pods
+            .exec(&pod_name, vec!["cat", TESTSYS_RESULTS_FILE], &ap)
+            .await
+            .context(error::CreationSnafu {
+                what: "sonobuoy results file",
+            })?;
+        let mut cat_out =
+            tokio_util::io::ReaderStream::new(cat.stdout().ok_or(error::Error::NoOut)?);
+
+        let mut out_file =
+            tokio::fs::File::create(&self.destination)
+                .await
+                .context(error::FileSnafu {
+                    path: &self.destination,
+                })?;
+        while let Some(data) = cat_out.next().await {
+            out_file
+                .write(&data.context(error::ReadSnafu)?)
+                .await
+                .context(error::WriteSnafu)?;
+        }
+        out_file.flush().await.context(error::WriteSnafu)?;
+
+        Ok(())
+    }
+}

--- a/bottlerocket/testsys/src/run.rs
+++ b/bottlerocket/testsys/src/run.rs
@@ -1,0 +1,40 @@
+use crate::error::Result;
+use crate::{run_aws_ecs, run_aws_k8s, run_file, run_sonobuoy, run_vmware};
+use kube::Client;
+use structopt::StructOpt;
+
+/// Run testsys tests.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Run {
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, StructOpt)]
+enum Command {
+    /// Run a test from a YAML file.
+    File(run_file::RunFile),
+    /// Run a Sonobuoy test;.
+    Sonobuoy(Box<run_sonobuoy::RunSonobuoy>),
+    /// Create an EKS resource, an EC2 resource, and run a Sonobuoy test. This test mode is useful
+    /// for the `aws-k8s` variants of Bottlerocket.
+    AwsK8s(Box<run_aws_k8s::RunAwsK8s>),
+    /// Create an ECS resource, an EC2 resource, and run an ECS task. This test mode is useful
+    /// for the `aws-ecs` variants of Bottlerocket.
+    AwsEcs(Box<run_aws_ecs::RunAwsEcs>),
+    /// Create VM nodes on a cluster running in vSphere and run a sonobuoy test. This test mode is
+    /// useful for the `vmware` variants of Bottlerocket.
+    Vmware(Box<run_vmware::RunVmware>),
+}
+
+impl Run {
+    pub(crate) async fn run(self, k8s_client: Client) -> Result<()> {
+        match self.command {
+            Command::File(run_file) => run_file.run(k8s_client).await,
+            Command::Sonobuoy(run_sonobuoy) => run_sonobuoy.run(k8s_client).await,
+            Command::AwsK8s(run_aws_k8s) => run_aws_k8s.run(k8s_client).await,
+            Command::AwsEcs(run_aws_ecs) => run_aws_ecs.run(k8s_client).await,
+            Command::Vmware(run_vmware) => run_vmware.run(k8s_client).await,
+        }
+    }
+}

--- a/bottlerocket/testsys/src/run_aws_ecs.rs
+++ b/bottlerocket/testsys/src/run_aws_ecs.rs
@@ -1,0 +1,492 @@
+use crate::error::{self, Result};
+use bottlerocket_types::agent_config::{
+    ClusterType, Ec2Config, EcsClusterConfig, EcsTestConfig, MigrationConfig, TufRepoConfig,
+    AWS_CREDENTIALS_SECRET_NAME,
+};
+use kube::ResourceExt;
+use kube::{api::ObjectMeta, Client};
+use maplit::btreemap;
+use model::clients::{CrdClient, ResourceClient, TestClient};
+use model::constants::NAMESPACE;
+use model::{
+    Agent, Configuration, DestructionPolicy, Resource, ResourceSpec, SecretName, Test, TestSpec,
+};
+use serde_json::Value;
+use snafu::ResultExt;
+use std::collections::BTreeMap;
+use structopt::StructOpt;
+
+/// Create an EKS resource, EC2 resource and run Sonobuoy.
+#[derive(Debug, StructOpt)]
+pub(crate) struct RunAwsEcs {
+    /// Name of the ecs test agent.
+    #[structopt(long, short)]
+    name: String,
+
+    /// Location of the ecs test agent image.
+    // TODO - default to an ECR public repository image
+    #[structopt(long, short)]
+    test_agent_image: String,
+
+    /// Name of the pull secret for the ecs test image (if needed).
+    #[structopt(long)]
+    test_agent_pull_secret: Option<String>,
+
+    /// Keep the test agent running after completion.
+    #[structopt(long)]
+    keep_running: bool,
+
+    /// A specific task definition that the ecs test agent will use. If one isn't provided,
+    /// a simple default task will be created and used.
+    #[structopt(long)]
+    task_definition_name_and_revision: Option<String>,
+
+    /// The number of tasks that should be run (default value is 1).
+    #[structopt(long, default_value = "1")]
+    task_count: i32,
+
+    /// The vpc that will be used for the ecs cluster (defaults to the default vpc).
+    #[structopt(long)]
+    vpc: Option<String>,
+
+    /// The name of the secret containing aws credentials.
+    #[structopt(long)]
+    aws_secret: Option<SecretName>,
+
+    /// The AWS region.
+    #[structopt(long, default_value = "us-west-2")]
+    region: String,
+
+    /// The name of the EKS cluster that will be used (whether it is being created or already
+    /// exists).
+    #[structopt(long)]
+    cluster_name: String,
+
+    /// The name of the TestSys resource that will represent this cluster. If you do not specify a
+    /// value, one will be created matching the `cluster-name`. Unless there is a name conflict or
+    /// you desire a specific resource name, then you do not need to supply a resource name here.
+    #[structopt(long)]
+    cluster_resource_name: Option<String>,
+
+    /// The aws arn for the instace profile that the ec2 instances should be launched using. If
+    /// no arn is provided, a testsys provided iam instance profile will be used.
+    #[structopt(long)]
+    iam_instance_profile_arn: Option<String>,
+
+    /// The container image of the ECS resource provider.
+    // TODO - provide a default on ECR Public
+    #[structopt(long)]
+    cluster_provider_image: String,
+
+    /// Name of the pull secret for the cluster provider image.
+    #[structopt(long)]
+    cluster_provider_pull_secret: Option<String>,
+
+    /// Keep the ECS cluster provider agent running after cluster creation.
+    #[structopt(long)]
+    keep_cluster_provider_running: bool,
+
+    /// The EC2 AMI ID to use for cluster nodes.
+    #[structopt(long)]
+    ami: String,
+
+    /// The EC2 instance type to use for cluster nodes. For example `m5.large`. If you do not
+    /// provide an instance type, an appropriate instance type will be used based on the AMI's
+    /// architecture.
+    #[structopt(long)]
+    instance_type: Option<String>,
+
+    /// The name of the TestSys resource that will represent EC2 instances serving as cluster nodes.
+    /// Defaults to `cluster-name-instances`.
+    #[structopt(long)]
+    ec2_resource_name: Option<String>,
+
+    /// The container image of the EC2 resource provider.
+    // TODO - provide a default on ECR Public
+    #[structopt(long)]
+    ec2_provider_image: String,
+
+    /// Name of the pull secret for the EC2 provider image.
+    #[structopt(long)]
+    ec2_provider_pull_secret: Option<String>,
+
+    /// Keep the EC2 instance provider running after instances are created.
+    #[structopt(long)]
+    keep_instance_provider_running: bool,
+
+    /// Perform an upgrade downgrade test.
+    #[structopt(long, requires_all(&["starting-version", "upgrade-version"]))]
+    upgrade_downgrade: bool,
+
+    /// Starting version for an upgrade/downgrade test.
+    #[structopt(long, requires("upgrade-downgrade"))]
+    starting_version: Option<String>,
+
+    /// Version the ec2 instances should be upgraded to in an upgrade/downgrade test.
+    #[structopt(long, requires("upgrade-downgrade"))]
+    upgrade_version: Option<String>,
+
+    /// Location of the tuf repo metadata.
+    #[structopt(long, requires_all(&["tuf-repo-targets-url", "upgrade-downgrade"]))]
+    tuf_repo_metadata_url: Option<String>,
+
+    /// Location of the tuf repo targets.
+    #[structopt(long, requires_all(&["tuf-repo-metadata-url", "upgrade-downgrade"]))]
+    tuf_repo_targets_url: Option<String>,
+
+    /// Location of the migration agent image.
+    // TODO - default to an ECR public repository image
+    #[structopt(long)]
+    migration_agent_image: Option<String>,
+
+    /// Name of the pull secret for the ecs migration image (if needed).
+    #[structopt(long)]
+    migration_agent_pull_secret: Option<String>,
+
+    /// The arn for the role that should be assumed by the agents.
+    #[structopt(long)]
+    assume_role: Option<String>,
+}
+
+impl RunAwsEcs {
+    pub(crate) async fn run(self, k8s_client: Client) -> Result<()> {
+        let cluster_resource_name = self
+            .cluster_resource_name
+            .as_ref()
+            .unwrap_or(&self.cluster_name);
+        let ec2_resource_name = self
+            .ec2_resource_name
+            .clone()
+            .unwrap_or(format!("{}-instances", self.cluster_name));
+        let aws_secret_map = self.aws_secret.as_ref().map(|secret_name| {
+            btreemap! [ AWS_CREDENTIALS_SECRET_NAME.to_string() => secret_name.clone()]
+        });
+
+        let ecs_resource = self.ecs_resource(cluster_resource_name, aws_secret_map.clone())?;
+
+        let ec2_resource = self.ec2_resource(
+            &ec2_resource_name,
+            aws_secret_map.clone(),
+            cluster_resource_name,
+        )?;
+
+        let tests = if self.upgrade_downgrade {
+            if let (Some(starting_version), Some(upgrade_version), Some(migration_agent_image)) = (
+                self.starting_version.as_ref(),
+                self.upgrade_version.as_ref(),
+                self.migration_agent_image.as_ref(),
+            ) {
+                let tuf_repo = if let (Some(tuf_repo_metadata_url), Some(tuf_repo_targets_url)) = (
+                    self.tuf_repo_metadata_url.as_ref(),
+                    self.tuf_repo_targets_url.as_ref(),
+                ) {
+                    Some(TufRepoConfig {
+                        metadata_url: tuf_repo_metadata_url.to_string(),
+                        targets_url: tuf_repo_targets_url.to_string(),
+                    })
+                } else {
+                    None
+                };
+                let init_test_name = format!("{}-1-initial", self.name);
+                let upgrade_test_name = format!("{}-2-migrate", self.name);
+                let upgraded_test_name = format!("{}-3-migrated", self.name);
+                let downgrade_test_name = format!("{}-4-migrate", self.name);
+                let final_test_name = format!("{}-5-final", self.name);
+                let init_ecs_test = self.ecs_test(
+                    &init_test_name,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    None,
+                )?;
+                let upgrade_test = self.migration_test(
+                    &upgrade_test_name,
+                    upgrade_version,
+                    tuf_repo.clone(),
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![init_test_name.clone()]),
+                    migration_agent_image,
+                    &self.migration_agent_pull_secret,
+                )?;
+                let upgraded_ecs_test = self.ecs_test(
+                    &upgraded_test_name,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![init_test_name.clone(), upgrade_test_name.clone()]),
+                )?;
+                let downgrade_test = self.migration_test(
+                    &downgrade_test_name,
+                    starting_version,
+                    tuf_repo,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![
+                        init_test_name.clone(),
+                        upgrade_test_name.clone(),
+                        upgraded_test_name.clone(),
+                    ]),
+                    migration_agent_image,
+                    &self.migration_agent_pull_secret,
+                )?;
+                let final_ecs_test = self.ecs_test(
+                    &final_test_name,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![
+                        init_test_name,
+                        upgrade_test_name,
+                        upgraded_test_name,
+                        downgrade_test_name,
+                    ]),
+                )?;
+                vec![
+                    init_ecs_test,
+                    upgrade_test,
+                    upgraded_ecs_test,
+                    downgrade_test,
+                    final_ecs_test,
+                ]
+            } else {
+                return Err(error::Error::InvalidArguments {
+                    why: "If performing an upgrade/downgrade test, \
+                        `starting-version`, `upgrade-version` must be provided."
+                        .to_string(),
+                });
+            }
+        } else {
+            vec![self.ecs_test(
+                &self.name,
+                aws_secret_map.clone(),
+                &ec2_resource_name,
+                cluster_resource_name,
+                None,
+            )?]
+        };
+
+        let resource_client = ResourceClient::new_from_k8s_client(k8s_client.clone());
+        let test_client = TestClient::new_from_k8s_client(k8s_client);
+
+        let _ = resource_client
+            .create(ecs_resource)
+            .await
+            .context(error::ModelClientSnafu {
+                message: "Unable to create ECS cluster resource object",
+            })?;
+        println!("Created resource object '{}'", cluster_resource_name);
+
+        let _ = resource_client
+            .create(ec2_resource)
+            .await
+            .context(error::ModelClientSnafu {
+                message: "Unable to create EC2 instances resource object",
+            })?;
+        println!("Created resource object '{}'", ec2_resource_name);
+
+        for test in tests {
+            let name = test.name();
+            let _ = test_client
+                .create(test)
+                .await
+                .context(error::ModelClientSnafu {
+                    message: "Unable to create test object",
+                })?;
+            println!("Created test object '{}'", name);
+        }
+        Ok(())
+    }
+
+    fn ecs_resource(
+        &self,
+        name: &str,
+        secrets: Option<BTreeMap<String, SecretName>>,
+    ) -> Result<Resource> {
+        Ok(Resource {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: ResourceSpec {
+                depends_on: None,
+                agent: Agent {
+                    name: "ecs-provider".to_string(),
+                    image: self.cluster_provider_image.clone(),
+                    pull_secret: self.cluster_provider_pull_secret.clone(),
+                    keep_running: self.keep_cluster_provider_running,
+                    timeout: None,
+                    configuration: Some(
+                        EcsClusterConfig {
+                            cluster_name: self.cluster_name.to_owned(),
+                            region: Some(self.region.clone()),
+                            vpc: self.vpc.clone(),
+                            assume_role: self.assume_role.clone(),
+                        }
+                        .into_map()
+                        .context(error::ConfigMapSnafu)?,
+                    ),
+                    secrets,
+                    capabilities: None,
+                },
+                ..Default::default()
+            },
+            status: None,
+        })
+    }
+
+    fn ec2_resource(
+        &self,
+        name: &str,
+        secrets: Option<BTreeMap<String, SecretName>>,
+        cluster_resource_name: &str,
+    ) -> Result<Resource> {
+        let ec2_config = Ec2Config {
+            node_ami: self.ami.clone(),
+            // TODO - configurable
+            instance_count: Some(2),
+            instance_type: self.instance_type.clone(),
+            cluster_name: self.cluster_name.clone(),
+            region: self.region.clone(),
+            instance_profile_arn: self
+                .iam_instance_profile_arn
+                .clone()
+                .unwrap_or_else(|| format!("${{{}.iamInstanceProfileArn}}", cluster_resource_name)),
+            subnet_id: format!("${{{}.publicSubnetId}}", cluster_resource_name),
+            cluster_type: ClusterType::Ecs,
+            assume_role: self.assume_role.clone(),
+            ..Default::default()
+        }
+        .into_map()
+        .context(error::ConfigMapSnafu)?;
+
+        Ok(Resource {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: ResourceSpec {
+                depends_on: Some(vec![cluster_resource_name.to_owned()]),
+                agent: Agent {
+                    name: "ec2-provider".to_string(),
+                    image: self.ec2_provider_image.clone(),
+                    pull_secret: self.ec2_provider_pull_secret.clone(),
+                    keep_running: self.keep_instance_provider_running,
+                    timeout: None,
+                    configuration: Some(ec2_config),
+                    secrets,
+                    capabilities: None,
+                },
+                destruction_policy: DestructionPolicy::OnDeletion,
+            },
+            status: None,
+        })
+    }
+
+    fn ecs_test(
+        &self,
+        name: &str,
+        secrets: Option<BTreeMap<String, SecretName>>,
+        ec2_resource_name: &str,
+        cluster_resource_name: &str,
+        depends_on: Option<Vec<String>>,
+    ) -> Result<Test> {
+        Ok(Test {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: TestSpec {
+                resources: vec![
+                    ec2_resource_name.to_owned(),
+                    cluster_resource_name.to_owned(),
+                ],
+                depends_on,
+                retries: None,
+                agent: Agent {
+                    name: "ecs-test-agent".to_string(),
+                    image: self.test_agent_image.clone(),
+                    pull_secret: self.test_agent_pull_secret.clone(),
+                    keep_running: self.keep_running,
+                    timeout: None,
+                    configuration: Some(
+                        EcsTestConfig {
+                            region: Some(format!("${{{}.region}}", cluster_resource_name)),
+                            cluster_name: format!("${{{}.clusterName}}", cluster_resource_name),
+                            task_count: self.task_count,
+                            subnet: format!("${{{}.publicSubnetId}}", cluster_resource_name),
+                            task_definition_name_and_revision: self
+                                .task_definition_name_and_revision
+                                .clone(),
+                            assume_role: self.assume_role.clone(),
+                        }
+                        .into_map()
+                        .context(error::ConfigMapSnafu)?,
+                    ),
+                    secrets,
+                    capabilities: None,
+                },
+            },
+            status: None,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn migration_test(
+        &self,
+        name: &str,
+        version: &str,
+        tuf_repo: Option<TufRepoConfig>,
+        secrets: Option<BTreeMap<String, SecretName>>,
+        ec2_resource_name: &str,
+        cluster_resource_name: &str,
+        depends_on: Option<Vec<String>>,
+        migration_agent_image: &str,
+        migration_agent_pull_secret: &Option<String>,
+    ) -> Result<Test> {
+        let mut migration_config = MigrationConfig {
+            aws_region: format!("${{{}.region}}", cluster_resource_name),
+            instance_ids: Default::default(),
+            migrate_to_version: version.to_string(),
+            tuf_repo,
+            assume_role: self.assume_role.clone(),
+        }
+        .into_map()
+        .context(error::ConfigMapSnafu)?;
+        migration_config.insert(
+            "instanceIds".to_string(),
+            Value::String(format!("${{{}.ids}}", ec2_resource_name)),
+        );
+        Ok(Test {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: TestSpec {
+                resources: vec![
+                    ec2_resource_name.to_owned(),
+                    cluster_resource_name.to_owned(),
+                ],
+                depends_on,
+                retries: None,
+                agent: Agent {
+                    name: "ecs-test-agent".to_string(),
+                    image: migration_agent_image.to_string(),
+                    pull_secret: migration_agent_pull_secret.clone(),
+                    keep_running: self.keep_running,
+                    timeout: None,
+                    configuration: Some(migration_config),
+                    secrets,
+                    capabilities: None,
+                },
+            },
+            status: None,
+        })
+    }
+}

--- a/bottlerocket/testsys/src/run_aws_k8s.rs
+++ b/bottlerocket/testsys/src/run_aws_k8s.rs
@@ -1,0 +1,522 @@
+use crate::error::{self, Result};
+use bottlerocket_types::agent_config::{
+    ClusterType, CreationPolicy, Ec2Config, EksClusterConfig, K8sVersion, MigrationConfig,
+    SonobuoyConfig, SonobuoyMode, TufRepoConfig, AWS_CREDENTIALS_SECRET_NAME,
+};
+use kube::ResourceExt;
+use kube::{api::ObjectMeta, Client};
+use maplit::btreemap;
+use model::clients::{CrdClient, ResourceClient, TestClient};
+use model::constants::NAMESPACE;
+use model::{
+    Agent, Configuration, DestructionPolicy, Resource, ResourceSpec, SecretName, Test, TestSpec,
+};
+use serde_json::Value;
+use snafu::ResultExt;
+use std::collections::BTreeMap;
+use structopt::StructOpt;
+
+/// Create an EKS resource, EC2 resource and run Sonobuoy.
+#[derive(Debug, StructOpt)]
+pub(crate) struct RunAwsK8s {
+    /// Name of the sonobuoy test.
+    #[structopt(long, short)]
+    name: String,
+
+    /// Location of the sonobuoy test agent image.
+    // TODO - default to an ECR public repository image
+    #[structopt(long, short)]
+    test_agent_image: String,
+
+    /// Name of the pull secret for the sonobuoy test image (if needed).
+    #[structopt(long)]
+    test_agent_pull_secret: Option<String>,
+
+    /// Keep the test agent running after completion.
+    #[structopt(long)]
+    keep_running: bool,
+
+    /// The plugin used for the sonobuoy test. Normally this is `e2e` (the default).
+    #[structopt(long, default_value = "e2e")]
+    sonobuoy_plugin: String,
+
+    /// The mode used for the sonobuoy test. One of `non-disruptive-conformance`,
+    /// `certified-conformance`, `quick`. Although the Sonobuoy binary defaults to
+    /// `non-disruptive-conformance`, we default to `quick` to make a quick test the most ergonomic.
+    #[structopt(long, default_value = "quick")]
+    sonobuoy_mode: SonobuoyMode,
+
+    /// The kubernetes conformance image used for the sonobuoy test.
+    #[structopt(long)]
+    kubernetes_conformance_image: Option<String>,
+
+    /// The name of the secret containing aws credentials.
+    #[structopt(long)]
+    aws_secret: Option<SecretName>,
+
+    /// The AWS region.
+    #[structopt(long, default_value = "us-west-2")]
+    region: String,
+
+    /// The name of the EKS cluster that will be used (whether it is being created or already
+    /// exists).
+    #[structopt(long)]
+    cluster_name: String,
+
+    /// The name of the TestSys resource that will represent this cluster. If you do not specify a
+    /// value, one will be created matching the `cluster-name`. Unless there is a name conflict or
+    /// you desire a specific resource name, then you do not need to supply a resource name here.
+    #[structopt(long)]
+    cluster_resource_name: Option<String>,
+
+    /// The version of the EKS cluster that is to be created (with or without the 'v', e.g. 1.20 or
+    /// v1.21, etc.) *This only affects EKS cluster creation!* If the cluster already exists, this
+    /// option will have no affect.
+    #[structopt(long)]
+    cluster_version: Option<K8sVersion>,
+
+    /// Whether or not we want the EKS cluster to be created. The possible values are:
+    /// - `create`: the cluster will be created, it is an error for the cluster to pre-exist
+    /// - `ifNotExists`: the cluster will be created if it does not already exist
+    /// - `never`: the cluster must pre-exist or else it is an error
+    #[structopt(long, default_value = "ifNotExists")]
+    cluster_creation_policy: CreationPolicy,
+
+    /// Whether or not we want the EKS cluster to be destroyed. The possible values are:
+    /// - `onDeletion`: the cluster will be destroyed when its TestSys resource is deleted.
+    /// - `never`: the cluster will not be destroyed.
+    #[structopt(long, default_value = "never")]
+    cluster_destruction_policy: DestructionPolicy,
+
+    /// The container image of the EKS resource provider.
+    // TODO - provide a default on ECR Public
+    #[structopt(long)]
+    cluster_provider_image: String,
+
+    /// Name of the pull secret for the cluster provider image.
+    #[structopt(long)]
+    cluster_provider_pull_secret: Option<String>,
+
+    /// Keep the EKS provider agent running after cluster creation.
+    #[structopt(long)]
+    keep_cluster_provider_running: bool,
+
+    /// The EC2 AMI ID to use for cluster nodes.
+    #[structopt(long)]
+    ami: String,
+
+    /// The EC2 instance type to use for cluster nodes. For example `m5.large`. If you do not
+    /// provide an instance type, an appropriate instance type will be used based on the AMI's
+    /// architecture.
+    #[structopt(long)]
+    instance_type: Option<String>,
+
+    /// The name of the TestSys resource that will represent EC2 instances serving as cluster nodes.
+    /// Defaults to `cluster-name-instances`.
+    #[structopt(long)]
+    ec2_resource_name: Option<String>,
+
+    /// The container image of the EC2 resource provider.
+    // TODO - provide a default on ECR Public
+    #[structopt(long)]
+    ec2_provider_image: String,
+
+    /// Name of the pull secret for the EC2 provider image.
+    #[structopt(long)]
+    ec2_provider_pull_secret: Option<String>,
+
+    /// Keep the EC2 instance provider running after instances are created.
+    #[structopt(long)]
+    keep_instance_provider_running: bool,
+
+    /// Allow the sonobuoy test agent to rerun failed test.
+    #[structopt(long)]
+    retry_failed_attempts: Option<u32>,
+
+    /// Perform an upgrade downgrade test.
+    #[structopt(long, requires_all(&["starting-version", "upgrade-version", "migration-agent-image"]))]
+    upgrade_downgrade: bool,
+
+    /// Starting version for an upgrade/downgrade test.
+    #[structopt(long, requires("upgrade-downgrade"))]
+    starting_version: Option<String>,
+
+    /// Version the ec2 instances should be upgraded to in an upgrade/downgrade test.
+    #[structopt(long, requires("upgrade-downgrade"))]
+    upgrade_version: Option<String>,
+
+    /// Location of the tuf repo metadata.
+    #[structopt(long, requires_all(&["tuf-repo-targets-url", "upgrade-downgrade"]))]
+    tuf_repo_metadata_url: Option<String>,
+
+    /// Location of the tuf repo targets.
+    #[structopt(long, requires_all(&["tuf-repo-metadata-url", "upgrade-downgrade"]))]
+    tuf_repo_targets_url: Option<String>,
+
+    /// Location of the migration agent image.
+    // TODO - default to an ECR public repository image
+    #[structopt(long, short)]
+    migration_agent_image: Option<String>,
+
+    /// Name of the pull secret for the eks migration image (if needed).
+    #[structopt(long)]
+    migration_agent_pull_secret: Option<String>,
+
+    /// The arn for the role that should be assumed by the agents.
+    #[structopt(long)]
+    assume_role: Option<String>,
+}
+
+impl RunAwsK8s {
+    pub(crate) async fn run(self, k8s_client: Client) -> Result<()> {
+        let cluster_resource_name = self
+            .cluster_resource_name
+            .as_ref()
+            .unwrap_or(&self.cluster_name);
+        let ec2_resource_name = self
+            .ec2_resource_name
+            .clone()
+            .unwrap_or(format!("{}-instances", self.cluster_name));
+        let aws_secret_map = self.aws_secret.as_ref().map(|secret_name| {
+            btreemap! [ AWS_CREDENTIALS_SECRET_NAME.to_string() => secret_name.clone()]
+        });
+
+        let eks_resource = self.eks_resource(cluster_resource_name, aws_secret_map.clone())?;
+        let ec2_resource = self.ec2_resource(
+            &ec2_resource_name,
+            aws_secret_map.clone(),
+            cluster_resource_name,
+        )?;
+
+        let tests = if self.upgrade_downgrade {
+            if let (Some(starting_version), Some(upgrade_version), Some(migration_agent_image)) = (
+                self.starting_version.as_ref(),
+                self.upgrade_version.as_ref(),
+                self.migration_agent_image.as_ref(),
+            ) {
+                let tuf_repo = if let (Some(tuf_repo_metadata_url), Some(tuf_repo_targets_url)) = (
+                    self.tuf_repo_metadata_url.as_ref(),
+                    self.tuf_repo_targets_url.as_ref(),
+                ) {
+                    Some(TufRepoConfig {
+                        metadata_url: tuf_repo_metadata_url.to_string(),
+                        targets_url: tuf_repo_targets_url.to_string(),
+                    })
+                } else {
+                    None
+                };
+                let init_test_name = format!("{}-1-initial", self.name);
+                let upgrade_test_name = format!("{}-2-migrate", self.name);
+                let upgraded_test_name = format!("{}-3-migrated", self.name);
+                let downgrade_test_name = format!("{}-4-migrate", self.name);
+                let final_test_name = format!("{}-5-final", self.name);
+                let init_eks_test = self.sonobuoy_test(
+                    &init_test_name,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    None,
+                )?;
+                let upgrade_test = self.migration_test(
+                    &upgrade_test_name,
+                    upgrade_version,
+                    tuf_repo.clone(),
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![init_test_name.clone()]),
+                    migration_agent_image,
+                    &self.migration_agent_pull_secret,
+                )?;
+                let upgraded_eks_test = self.sonobuoy_test(
+                    &upgraded_test_name,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![init_test_name.clone(), upgrade_test_name.clone()]),
+                )?;
+                let downgrade_test = self.migration_test(
+                    &downgrade_test_name,
+                    starting_version,
+                    tuf_repo,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![
+                        init_test_name.clone(),
+                        upgrade_test_name.clone(),
+                        upgraded_test_name.clone(),
+                    ]),
+                    migration_agent_image,
+                    &self.migration_agent_pull_secret,
+                )?;
+                let final_eks_test = self.sonobuoy_test(
+                    &final_test_name,
+                    aws_secret_map.clone(),
+                    &ec2_resource_name,
+                    cluster_resource_name,
+                    Some(vec![
+                        init_test_name,
+                        upgrade_test_name,
+                        upgraded_test_name,
+                        downgrade_test_name,
+                    ]),
+                )?;
+                vec![
+                    init_eks_test,
+                    upgrade_test,
+                    upgraded_eks_test,
+                    downgrade_test,
+                    final_eks_test,
+                ]
+            } else {
+                return Err(error::Error::InvalidArguments {
+                    why: "If performing an upgrade/downgrade test,\
+                        `starting-version`, `upgrade-version` must be provided."
+                        .to_string(),
+                });
+            }
+        } else {
+            vec![self.sonobuoy_test(
+                &self.name,
+                aws_secret_map.clone(),
+                &ec2_resource_name,
+                cluster_resource_name,
+                None,
+            )?]
+        };
+        let resource_client = ResourceClient::new_from_k8s_client(k8s_client.clone());
+        let test_client = TestClient::new_from_k8s_client(k8s_client);
+
+        let _ = resource_client
+            .create(eks_resource)
+            .await
+            .context(error::ModelClientSnafu {
+                message: "Unable to create EKS cluster resource object",
+            })?;
+        println!("Created resource object '{}'", cluster_resource_name);
+
+        let _ = resource_client
+            .create(ec2_resource)
+            .await
+            .context(error::ModelClientSnafu {
+                message: "Unable to create EC2 instances resource object",
+            })?;
+        println!("Created resource object '{}'", ec2_resource_name);
+
+        for test in tests {
+            let name = test.name();
+            let _ = test_client
+                .create(test)
+                .await
+                .context(error::ModelClientSnafu {
+                    message: "Unable to create test object",
+                })?;
+            println!("Created test object '{}'", name);
+        }
+        Ok(())
+    }
+
+    fn eks_resource(
+        &self,
+        name: &str,
+        secrets: Option<BTreeMap<String, SecretName>>,
+    ) -> Result<Resource> {
+        Ok(Resource {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: ResourceSpec {
+                depends_on: None,
+                agent: Agent {
+                    name: "eks-provider".to_string(),
+                    image: self.cluster_provider_image.clone(),
+                    pull_secret: self.cluster_provider_pull_secret.clone(),
+                    keep_running: self.keep_cluster_provider_running,
+                    timeout: None,
+                    configuration: Some(
+                        EksClusterConfig {
+                            cluster_name: self.cluster_name.clone(),
+                            creation_policy: Some(self.cluster_creation_policy),
+                            region: Some(self.region.clone()),
+                            zones: None,
+                            version: self.cluster_version,
+                            assume_role: self.assume_role.clone(),
+                        }
+                        .into_map()
+                        .context(error::ConfigMapSnafu)?,
+                    ),
+                    secrets,
+                    capabilities: None,
+                },
+                destruction_policy: self.cluster_destruction_policy,
+            },
+            status: None,
+        })
+    }
+
+    fn ec2_resource(
+        &self,
+        name: &str,
+        secrets: Option<BTreeMap<String, SecretName>>,
+        cluster_resource_name: &str,
+    ) -> Result<Resource> {
+        let mut ec2_config = Ec2Config {
+            node_ami: self.ami.clone(),
+            // TODO - configurable
+            instance_count: Some(2),
+            instance_type: self.instance_type.clone(),
+            cluster_name: self.cluster_name.clone(),
+            region: self.region.clone(),
+            instance_profile_arn: format!("${{{}.iamInstanceProfileArn}}", cluster_resource_name),
+            subnet_id: format!("${{{}.privateSubnetId}}", cluster_resource_name),
+            cluster_type: ClusterType::Eks,
+            endpoint: Some(format!("${{{}.endpoint}}", cluster_resource_name)),
+            certificate: Some(format!("${{{}.certificate}}", cluster_resource_name)),
+            cluster_dns_ip: Some(format!("${{{}.clusterDnsIp}}", cluster_resource_name)),
+            security_groups: vec![],
+            assume_role: self.assume_role.clone(),
+        }
+        .into_map()
+        .context(error::ConfigMapSnafu)?;
+
+        // TODO - we have change the raw map to reference/template a non string field.
+        let previous_value = ec2_config.insert(
+            "securityGroups".to_owned(),
+            Value::String(format!("${{{}.securityGroups}}", cluster_resource_name)),
+        );
+        if previous_value.is_none() {
+            todo!("This is an error: fields in the Ec2Config struct have changed")
+        }
+
+        Ok(Resource {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: ResourceSpec {
+                depends_on: Some(vec![cluster_resource_name.to_owned()]),
+                agent: Agent {
+                    name: "ec2-provider".to_string(),
+                    image: self.ec2_provider_image.clone(),
+                    pull_secret: self.ec2_provider_pull_secret.clone(),
+                    keep_running: self.keep_instance_provider_running,
+                    timeout: None,
+                    configuration: Some(ec2_config),
+                    secrets,
+                    capabilities: None,
+                },
+                destruction_policy: DestructionPolicy::OnDeletion,
+            },
+            status: None,
+        })
+    }
+
+    fn sonobuoy_test(
+        &self,
+        name: &str,
+        secrets: Option<BTreeMap<String, SecretName>>,
+        ec2_resource_name: &str,
+        cluster_resource_name: &str,
+        depends_on: Option<Vec<String>>,
+    ) -> Result<Test> {
+        Ok(Test {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: TestSpec {
+                resources: vec![
+                    ec2_resource_name.to_string(),
+                    cluster_resource_name.to_string(),
+                ],
+                depends_on,
+                retries: self.retry_failed_attempts,
+                agent: Agent {
+                    name: "sonobuoy-test-agent".to_string(),
+                    image: self.test_agent_image.clone(),
+                    pull_secret: self.test_agent_pull_secret.clone(),
+                    keep_running: self.keep_running,
+                    timeout: None,
+                    configuration: Some(
+                        SonobuoyConfig {
+                            kubeconfig_base64: format!(
+                                "${{{}.encodedKubeconfig}}",
+                                cluster_resource_name
+                            ),
+                            plugin: self.sonobuoy_plugin.clone(),
+                            mode: self.sonobuoy_mode,
+                            kubernetes_version: None,
+                            kube_conformance_image: self.kubernetes_conformance_image.clone(),
+                            assume_role: self.assume_role.clone(),
+                        }
+                        .into_map()
+                        .context(error::ConfigMapSnafu)?,
+                    ),
+                    secrets,
+                    // FIXME: Add CLI option for setting this
+                    capabilities: None,
+                },
+            },
+            status: None,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn migration_test(
+        &self,
+        name: &str,
+        version: &str,
+        tuf_repo: Option<TufRepoConfig>,
+        secrets: Option<BTreeMap<String, SecretName>>,
+        ec2_resource_name: &str,
+        cluster_resource_name: &str,
+        depends_on: Option<Vec<String>>,
+        migration_agent_image: &str,
+        migration_agent_pull_secret: &Option<String>,
+    ) -> Result<Test> {
+        let mut migration_config = MigrationConfig {
+            aws_region: format!("${{{}.region}}", cluster_resource_name),
+            instance_ids: Default::default(),
+            migrate_to_version: version.to_string(),
+            tuf_repo,
+            assume_role: self.assume_role.clone(),
+        }
+        .into_map()
+        .context(error::ConfigMapSnafu)?;
+        migration_config.insert(
+            "instanceIds".to_string(),
+            Value::String(format!("${{{}.ids}}", ec2_resource_name)),
+        );
+        Ok(Test {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: TestSpec {
+                resources: vec![
+                    ec2_resource_name.to_owned(),
+                    cluster_resource_name.to_owned(),
+                ],
+                depends_on,
+                retries: None,
+                agent: Agent {
+                    name: "eks-test-agent".to_string(),
+                    image: migration_agent_image.to_string(),
+                    pull_secret: migration_agent_pull_secret.clone(),
+                    keep_running: self.keep_running,
+                    timeout: None,
+                    configuration: Some(migration_config),
+                    secrets,
+                    capabilities: None,
+                },
+            },
+            status: None,
+        })
+    }
+}

--- a/bottlerocket/testsys/src/run_file.rs
+++ b/bottlerocket/testsys/src/run_file.rs
@@ -1,0 +1,66 @@
+use crate::error::{self, Result};
+use kube::Client;
+use model::{
+    clients::{CrdClient, ResourceClient, TestClient},
+    Resource, Test,
+};
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+/// Run a test stored in a YAML file at `path`.
+#[derive(Debug, StructOpt)]
+pub(crate) struct RunFile {
+    /// Path to test crd YAML file.
+    #[structopt(parse(from_os_str))]
+    path: PathBuf,
+}
+
+impl RunFile {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        // Create the resource objects from its path.
+        let manifest_string =
+            std::fs::read_to_string(&self.path).context(error::FileSnafu { path: &self.path })?;
+        let tests = TestClient::new_from_k8s_client(k8s_client.clone());
+        let resources = ResourceClient::new_from_k8s_client(k8s_client);
+        for crd_doc in serde_yaml::Deserializer::from_str(&manifest_string) {
+            let value = serde_yaml::Value::deserialize(crd_doc)
+                .context(error::ResourceProviderFileParseSnafu { path: &self.path })?;
+            let crd: Crd = serde_yaml::from_value(value)
+                .context(error::ResourceProviderFileParseSnafu { path: &self.path })?;
+            let name = crd.name();
+            match crd {
+                Crd::Test(test) => {
+                    Crd::Test(tests.create(test).await.context(error::CreateTestSnafu)?)
+                }
+                Crd::Resource(resource) => Crd::Resource(
+                    resources
+                        .create(resource)
+                        .await
+                        .context(error::CreateResourceSnafu)?,
+                ),
+            };
+            if let Some(name) = name {
+                println!("Successfully added '{}'.", name);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+enum Crd {
+    Test(Test),
+    Resource(Resource),
+}
+
+impl Crd {
+    fn name(&self) -> Option<String> {
+        match self {
+            Self::Test(test) => test.metadata.name.to_owned(),
+            Self::Resource(resource) => resource.metadata.name.to_owned(),
+        }
+    }
+}

--- a/bottlerocket/testsys/src/run_sonobuoy.rs
+++ b/bottlerocket/testsys/src/run_sonobuoy.rs
@@ -1,0 +1,131 @@
+use crate::error::{self, Result};
+use bottlerocket_types::agent_config::{SonobuoyConfig, SonobuoyMode, AWS_CREDENTIALS_SECRET_NAME};
+use kube::{api::ObjectMeta, Client};
+use model::clients::CrdClient;
+use model::constants::NAMESPACE;
+use model::{clients::TestClient, Agent, Configuration, SecretName, Test, TestSpec};
+use snafu::ResultExt;
+use std::{collections::BTreeMap, fs::read_to_string, path::PathBuf};
+use structopt::StructOpt;
+
+/// Run a test stored in a YAML file at `path`.
+#[derive(Debug, StructOpt)]
+pub(crate) struct RunSonobuoy {
+    /// Path to test cluster's kubeconfig file.
+    #[structopt(
+        long,
+        parse(from_os_str),
+        required_if("target-cluster-kubeconfig", "None"),
+        conflicts_with("target-cluster-kubeconfig")
+    )]
+    target_cluster_kubeconfig_path: Option<PathBuf>,
+
+    /// The base64 encoded kubeconfig file for the target cluster, or a template such as
+    /// `${mycluster.kubeconfig}`.
+    #[structopt(long, required_if("target-cluster-kubeconfig-path", "None"))]
+    target_cluster_kubeconfig: Option<String>,
+
+    /// Name of the sonobuoy test.
+    #[structopt(long, short)]
+    name: String,
+
+    /// Location of the sonobuoy test agent image.
+    // TODO - default to an ECR public repository image
+    #[structopt(long, short)]
+    image: String,
+
+    /// Name of the pull secret for the sonobuoy test image (if needed).
+    #[structopt(long)]
+    pull_secret: Option<String>,
+
+    /// Keep the test running after completion.
+    #[structopt(long)]
+    keep_running: bool,
+
+    /// The plugin used for the sonobuoy test. Normally this is `e2e` (the default).
+    #[structopt(long, default_value = "e2e")]
+    plugin: String,
+
+    /// The mode used for the sonobuoy test. One of `non-disruptive-conformance`,
+    /// `certified-conformance`, `quick`. Although the Sonobuoy binary defaults to
+    /// `non-disruptive-conformance`, we default to `quick` to make a quick test the most ergonomic.
+    #[structopt(long, default_value = "quick")]
+    mode: SonobuoyMode,
+
+    /// The kubernetes conformance image used for the sonobuoy test.
+    #[structopt(long)]
+    kubernetes_conformance_image: Option<String>,
+
+    /// The name of the secret containing aws credentials.
+    #[structopt(long)]
+    aws_secret: Option<SecretName>,
+
+    /// The resources required by the sonobuoy test.
+    #[structopt(long)]
+    resource: Vec<String>,
+
+    /// The arn for the role that should be assumed by the agent.
+    #[structopt(long)]
+    assume_role: Option<String>,
+}
+
+impl RunSonobuoy {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        let kubeconfig_string = match (&self.target_cluster_kubeconfig_path, &self.target_cluster_kubeconfig) {
+            (Some(kubeconfig_path), None) => base64::encode(
+                read_to_string(kubeconfig_path).context(error::FileSnafu {
+                    path: kubeconfig_path,
+                })?,
+            ),
+            (None, Some(template_value)) => template_value.to_string(),
+            (_, _) => return Err(error::Error::InvalidArguments { why: "Exactly 1 of 'target-cluster-kubeconfig' and 'target-cluster-kubeconfig-path' must be provided".to_string() })
+        };
+
+        let test = Test {
+            metadata: ObjectMeta {
+                name: Some(self.name.clone()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: TestSpec {
+                resources: self.resource.clone(),
+                depends_on: Default::default(),
+                retries: None,
+                agent: Agent {
+                    name: "sonobuoy-test-agent".to_string(),
+                    image: self.image.clone(),
+                    pull_secret: self.pull_secret.clone(),
+                    keep_running: self.keep_running,
+                    timeout: None,
+                    configuration: Some(
+                        SonobuoyConfig {
+                            kubeconfig_base64: kubeconfig_string,
+                            plugin: self.plugin.clone(),
+                            mode: self.mode,
+                            kubernetes_version: None,
+                            kube_conformance_image: self.kubernetes_conformance_image.clone(),
+                            assume_role: self.assume_role.clone(),
+                        }
+                        .into_map()
+                        .context(error::ConfigMapSnafu)?,
+                    ),
+                    secrets: self.aws_secret.as_ref().map(|secret_name| {
+                        let mut secrets_map = BTreeMap::new();
+                        secrets_map
+                            .insert(AWS_CREDENTIALS_SECRET_NAME.to_string(), secret_name.clone());
+                        secrets_map
+                    }),
+                    // FIXME: Add CLI option for setting this
+                    capabilities: None,
+                },
+            },
+            status: None,
+        };
+
+        let tests = TestClient::new_from_k8s_client(k8s_client);
+
+        tests.create(test).await.context(error::CreateTestSnafu)?;
+
+        Ok(())
+    }
+}

--- a/bottlerocket/testsys/src/run_vmware.rs
+++ b/bottlerocket/testsys/src/run_vmware.rs
@@ -1,0 +1,461 @@
+use crate::error::{self, Result};
+use bottlerocket_types::agent_config::{
+    MigrationConfig, SonobuoyConfig, SonobuoyMode, TufRepoConfig, VSphereClusterInfo,
+    VSphereVmConfig, AWS_CREDENTIALS_SECRET_NAME, VSPHERE_CREDENTIALS_SECRET_NAME,
+    WIREGUARD_SECRET_NAME,
+};
+use kube::ResourceExt;
+use kube::{api::ObjectMeta, Client};
+use maplit::btreemap;
+use model::clients::{CrdClient, ResourceClient, TestClient};
+use model::constants::NAMESPACE;
+use model::{
+    Agent, Configuration, DestructionPolicy, Resource, ResourceSpec, SecretName, Test, TestSpec,
+};
+use serde_json::Value;
+use snafu::ResultExt;
+use std::collections::BTreeMap;
+use std::fs::read_to_string;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+/// Create vmware nodes and run Sonobuoy.
+#[derive(Debug, StructOpt)]
+pub(crate) struct RunVmware {
+    /// Name of the sonobuoy test.
+    #[structopt(long, short)]
+    name: String,
+
+    /// Location of the sonobuoy test agent image.
+    // TODO - default to an ECR public repository image
+    #[structopt(long, short)]
+    test_agent_image: String,
+
+    /// Name of the pull secret for the sonobuoy test image (if needed).
+    #[structopt(long)]
+    test_agent_pull_secret: Option<String>,
+
+    /// Keep the test agent running after completion.
+    #[structopt(long)]
+    keep_running: bool,
+
+    /// The plugin used for the sonobuoy test. Normally this is `e2e` (the default).
+    #[structopt(long, default_value = "e2e")]
+    sonobuoy_plugin: String,
+
+    /// The mode used for the sonobuoy test. One of `non-disruptive-conformance`,
+    /// `certified-conformance`, `quick`. Although the Sonobuoy binary defaults to
+    /// `non-disruptive-conformance`, we default to `quick` to make a quick test the most ergonomic.
+    #[structopt(long, default_value = "quick")]
+    sonobuoy_mode: SonobuoyMode,
+
+    /// The kubernetes conformance image used for the sonobuoy test.
+    #[structopt(long)]
+    kubernetes_conformance_image: Option<String>,
+
+    /// The name of the secret containing aws credentials.
+    #[structopt(long)]
+    aws_secret: SecretName,
+
+    /// The name of the secret containing vsphere credentials.
+    #[structopt(long)]
+    vsphere_secret: SecretName,
+
+    /// The name of the secret containing wireguard configuration.
+    #[structopt(long)]
+    wireguard_secret: SecretName,
+
+    /// The name of the vsphere cluster that will be used.
+    #[structopt(long)]
+    cluster_name: String,
+
+    /// The ova name to use for cluster nodes.
+    #[structopt(long)]
+    ova_name: String,
+
+    /// The name of the TestSys resource that will represent the vms serving as cluster nodes.
+    /// Defaults to `cluster-name-vms`.
+    #[structopt(long)]
+    vm_resource_name: Option<String>,
+
+    /// The container image of the VMWare resource provider.
+    // TODO - provide a default on ECR Public
+    #[structopt(long)]
+    vm_provider_image: String,
+
+    /// Name of the pull secret for the VMWare VM provider image.
+    #[structopt(long)]
+    vm_provider_pull_secret: Option<String>,
+
+    /// The number of vm nodes to launch.
+    #[structopt(long)]
+    vm_count: Option<i32>,
+
+    /// Url for tuf repo metadata.
+    #[structopt(long)]
+    tuf_repo_metadata_url: String,
+
+    /// Url for tuf repo targets.
+    #[structopt(long)]
+    tuf_repo_targets_url: String,
+
+    /// URL of the vCenter instance to connect to
+    #[structopt(long)]
+    vcenter_url: String,
+
+    /// vCenter datacenter
+    #[structopt(long, default_value = "SDDC-Datacenter")]
+    datacenter: String,
+
+    /// vCenter datastore
+    #[structopt(long, default_value = "WorkloadDatastore")]
+    datastore: String,
+
+    /// vCenter network
+    #[structopt(long, default_value = "sddc-cgw-network-2")]
+    network: String,
+
+    /// vCenter resource pool
+    #[structopt(
+        long,
+        default_value = "/SDDC-Datacenter/host/Cluster-1/Resources/Compute-ResourcePool"
+    )]
+    resource_pool: String,
+
+    /// The workloads folder to create the VMWare resources in.
+    #[structopt(long, default_value = "testsys")]
+    workload_folder: String,
+
+    /// Path to test cluster's kubeconfig file.
+    #[structopt(long, parse(from_os_str))]
+    target_cluster_kubeconfig_path: PathBuf,
+
+    /// The ip for the cluster's control plane endpoint ip.
+    #[structopt(long)]
+    cluster_endpoint: String,
+
+    /// Capabilities that should be enabled in the resource provider and the test agent.
+    #[structopt(long)]
+    capabilities: Vec<String>,
+
+    /// Keep the VMWare instance provider running after instances are created.
+    #[structopt(long)]
+    keep_instance_provider_running: bool,
+
+    /// Allow the sonobuoy test agent to rerun failed test.
+    #[structopt(long)]
+    retry_failed_attempts: Option<u32>,
+
+    /// Perform an upgrade downgrade test.
+    #[structopt(long, requires_all(&["starting-version", "upgrade-version"]))]
+    upgrade_downgrade: bool,
+
+    /// Starting version for an upgrade/downgrade test.
+    #[structopt(long, requires("upgrade-downgrade"))]
+    starting_version: Option<String>,
+
+    /// Version the ec2 instances should be upgraded to in an upgrade/downgrade test.
+    #[structopt(long, requires("upgrade-downgrade"))]
+    upgrade_version: Option<String>,
+
+    /// The aws region for ssm on vm nodes
+    #[structopt(long, default_value = "us-west-2")]
+    region: String,
+
+    /// Location of the migration agent image.
+    // TODO - default to an ECR public repository image
+    #[structopt(long)]
+    migration_agent_image: Option<String>,
+
+    /// Name of the pull secret for the ecs migration image (if needed).
+    #[structopt(long)]
+    migration_agent_pull_secret: Option<String>,
+
+    /// The arn for the role that should be assumed by the agents.
+    #[structopt(long)]
+    assume_role: Option<String>,
+}
+
+impl RunVmware {
+    pub(crate) async fn run(self, k8s_client: Client) -> Result<()> {
+        let vm_resource_name = self
+            .vm_resource_name
+            .clone()
+            .unwrap_or(format!("{}-vms", self.cluster_name));
+        let secret_map = btreemap! [ AWS_CREDENTIALS_SECRET_NAME.to_string() => self.aws_secret.clone(),
+        VSPHERE_CREDENTIALS_SECRET_NAME.to_string() => self.vsphere_secret.clone(),
+        WIREGUARD_SECRET_NAME.to_string() => self.wireguard_secret.clone() ];
+
+        let encoded_kubeconfig = base64::encode(
+            read_to_string(&self.target_cluster_kubeconfig_path).context(error::FileSnafu {
+                path: self.target_cluster_kubeconfig_path.clone(),
+            })?,
+        );
+
+        let vm_resource = self.vm_resource(
+            &vm_resource_name,
+            Some(secret_map.clone()),
+            &encoded_kubeconfig,
+        )?;
+
+        let tests = if self.upgrade_downgrade {
+            if let (Some(starting_version), Some(upgrade_version), Some(migration_agent_image)) = (
+                self.starting_version.as_ref(),
+                self.upgrade_version.as_ref(),
+                self.migration_agent_image.as_ref(),
+            ) {
+                let tuf_repo = TufRepoConfig {
+                    metadata_url: self.tuf_repo_metadata_url.clone(),
+                    targets_url: self.tuf_repo_targets_url.clone(),
+                };
+                let init_test_name = format!("{}-1-initial", self.name);
+                let upgrade_test_name = format!("{}-2-migrate", self.name);
+                let upgraded_test_name = format!("{}-3-migrated", self.name);
+                let downgrade_test_name = format!("{}-4-migrate", self.name);
+                let final_test_name = format!("{}-5-final", self.name);
+                let init_sonobuoy_test = self.sonobuoy_test(
+                    &init_test_name,
+                    &encoded_kubeconfig,
+                    secret_map.clone(),
+                    &vm_resource_name,
+                    None,
+                )?;
+                let upgrade_test = self.migration_test(
+                    &upgrade_test_name,
+                    upgrade_version,
+                    Some(tuf_repo.clone()),
+                    secret_map.clone(),
+                    &vm_resource_name,
+                    Some(vec![init_test_name.clone()]),
+                    migration_agent_image,
+                    &self.migration_agent_pull_secret,
+                )?;
+                let upgraded_sonobuoy_test = self.sonobuoy_test(
+                    &upgraded_test_name,
+                    &encoded_kubeconfig,
+                    secret_map.clone(),
+                    &vm_resource_name,
+                    Some(vec![init_test_name.clone(), upgrade_test_name.clone()]),
+                )?;
+                let downgrade_test = self.migration_test(
+                    &downgrade_test_name,
+                    starting_version,
+                    Some(tuf_repo),
+                    secret_map.clone(),
+                    &vm_resource_name,
+                    Some(vec![
+                        init_test_name.clone(),
+                        upgrade_test_name.clone(),
+                        upgraded_test_name.clone(),
+                    ]),
+                    migration_agent_image,
+                    &self.migration_agent_pull_secret,
+                )?;
+                let final_sonobuoy_test = self.sonobuoy_test(
+                    &final_test_name,
+                    &encoded_kubeconfig,
+                    secret_map.clone(),
+                    &vm_resource_name,
+                    Some(vec![
+                        init_test_name,
+                        upgrade_test_name,
+                        upgraded_test_name,
+                        downgrade_test_name,
+                    ]),
+                )?;
+                vec![
+                    init_sonobuoy_test,
+                    upgrade_test,
+                    upgraded_sonobuoy_test,
+                    downgrade_test,
+                    final_sonobuoy_test,
+                ]
+            } else {
+                return Err(error::Error::InvalidArguments {
+                    why: "If performing an upgrade/downgrade test,\
+                         `starting-version`, `upgrade-version` must be provided."
+                        .to_string(),
+                });
+            }
+        } else {
+            vec![self.sonobuoy_test(
+                &self.name,
+                &encoded_kubeconfig,
+                secret_map.clone(),
+                &vm_resource_name,
+                None,
+            )?]
+        };
+
+        let resource_client = ResourceClient::new_from_k8s_client(k8s_client.clone());
+        let test_client = TestClient::new_from_k8s_client(k8s_client);
+
+        let _ = resource_client
+            .create(vm_resource)
+            .await
+            .context(error::ModelClientSnafu {
+                message: "Unable to create vm nodes resource object",
+            })?;
+        println!("Created resource object '{}'", vm_resource_name);
+
+        for test in tests {
+            let name = test.name();
+            let _ = test_client
+                .create(test)
+                .await
+                .context(error::ModelClientSnafu {
+                    message: "Unable to create test object",
+                })?;
+            println!("Created test object '{}'", name);
+        }
+
+        Ok(())
+    }
+
+    fn vm_resource(
+        &self,
+        name: &str,
+        secrets: Option<BTreeMap<String, SecretName>>,
+        encoded_kubeconfig: &str,
+    ) -> Result<Resource> {
+        let vm_config = VSphereVmConfig {
+            ova_name: self.ova_name.clone(),
+            vm_count: self.vm_count,
+            tuf_repo: TufRepoConfig {
+                metadata_url: self.tuf_repo_metadata_url.clone(),
+                targets_url: self.tuf_repo_targets_url.clone(),
+            },
+            vcenter_host_url: self.vcenter_url.clone(),
+            vcenter_datacenter: self.datacenter.clone(),
+            vcenter_datastore: self.datastore.clone(),
+            vcenter_network: self.network.clone(),
+            vcenter_resource_pool: self.resource_pool.clone(),
+            vcenter_workload_folder: self.workload_folder.clone(),
+            cluster: VSphereClusterInfo {
+                name: self.cluster_name.clone(),
+                control_plane_endpoint_ip: self.cluster_endpoint.clone(),
+                kubeconfig_base64: encoded_kubeconfig.to_string(),
+            },
+            assume_role: self.assume_role.clone(),
+        }
+        .into_map()
+        .context(error::ConfigMapSnafu)?;
+
+        Ok(Resource {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: ResourceSpec {
+                depends_on: None,
+                agent: Agent {
+                    name: "vsphere-vm-provider".to_string(),
+                    image: self.vm_provider_image.clone(),
+                    pull_secret: self.vm_provider_pull_secret.clone(),
+                    keep_running: self.keep_instance_provider_running,
+                    timeout: None,
+                    configuration: Some(vm_config),
+                    secrets,
+                    capabilities: Some(self.capabilities.clone()),
+                },
+                destruction_policy: DestructionPolicy::OnDeletion,
+            },
+            status: None,
+        })
+    }
+
+    fn sonobuoy_test(
+        &self,
+        name: &str,
+        encoded_kubeconfig: &str,
+        secrets: BTreeMap<String, SecretName>,
+        vm_resource_name: &str,
+        depends_on: Option<Vec<String>>,
+    ) -> Result<Test> {
+        Ok(Test {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: TestSpec {
+                resources: vec![vm_resource_name.to_string()],
+                depends_on,
+                retries: self.retry_failed_attempts,
+                agent: Agent {
+                    name: "vmware-sonobuoy-test-agent".to_string(),
+                    image: self.test_agent_image.clone(),
+                    pull_secret: self.test_agent_pull_secret.clone(),
+                    keep_running: self.keep_running,
+                    timeout: None,
+                    configuration: Some(
+                        SonobuoyConfig {
+                            kubeconfig_base64: encoded_kubeconfig.to_string(),
+                            plugin: self.sonobuoy_plugin.clone(),
+                            mode: self.sonobuoy_mode,
+                            kubernetes_version: None,
+                            kube_conformance_image: self.kubernetes_conformance_image.clone(),
+                            assume_role: self.assume_role.clone(),
+                        }
+                        .into_map()
+                        .context(error::ConfigMapSnafu)?,
+                    ),
+                    secrets: Some(secrets),
+                    capabilities: Some(self.capabilities.clone()),
+                },
+            },
+            status: None,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn migration_test(
+        &self,
+        name: &str,
+        version: &str,
+        tuf_repo: Option<TufRepoConfig>,
+        secrets: BTreeMap<String, SecretName>,
+        vm_resource_name: &str,
+        depends_on: Option<Vec<String>>,
+        migration_agent_image: &str,
+        migration_agent_pull_secret: &Option<String>,
+    ) -> Result<Test> {
+        let mut migration_config = MigrationConfig {
+            aws_region: self.region.to_string(),
+            instance_ids: Default::default(),
+            migrate_to_version: version.to_string(),
+            tuf_repo,
+            assume_role: self.assume_role.clone(),
+        }
+        .into_map()
+        .context(error::ConfigMapSnafu)?;
+        migration_config.insert(
+            "instanceIds".to_string(),
+            Value::String(format!("${{{}.instanceIds}}", vm_resource_name)),
+        );
+        Ok(Test {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(NAMESPACE.into()),
+                ..Default::default()
+            },
+            spec: TestSpec {
+                resources: vec![vm_resource_name.to_owned()],
+                depends_on,
+                retries: None,
+                agent: Agent {
+                    name: "vmware-migration-test-agent".to_string(),
+                    image: migration_agent_image.to_string(),
+                    pull_secret: migration_agent_pull_secret.clone(),
+                    keep_running: self.keep_running,
+                    timeout: None,
+                    configuration: Some(migration_config),
+                    secrets: Some(secrets),
+                    capabilities: Some(self.capabilities.clone()),
+                },
+            },
+            status: None,
+        })
+    }
+}

--- a/bottlerocket/testsys/src/set.rs
+++ b/bottlerocket/testsys/src/set.rs
@@ -1,0 +1,34 @@
+use crate::error::{self, Result};
+use kube::Client;
+use model::clients::{CrdClient, TestClient};
+use snafu::ResultExt;
+use structopt::StructOpt;
+
+/// Set the field of a testsys test.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Set {
+    /// The name of the test to change.
+    name: String,
+
+    /// Set the value of the `keep_running` field of a testsys test.
+    #[structopt(long)]
+    keep_running: Option<bool>,
+}
+
+impl Set {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        let tests = TestClient::new_from_k8s_client(k8s_client);
+
+        if let Some(keep_running) = &self.keep_running {
+            tests
+                .send_keep_running(&self.name, *keep_running)
+                .await
+                .context(error::SetSnafu {
+                    name: self.name.clone(),
+                    what: "keep_running",
+                })?;
+        }
+
+        Ok(())
+    }
+}

--- a/bottlerocket/testsys/src/status.rs
+++ b/bottlerocket/testsys/src/status.rs
@@ -1,0 +1,306 @@
+use crate::error::{self, Result};
+use futures::{stream, StreamExt};
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::ListParams;
+use kube::core::object::HasStatus;
+use kube::{Api, Client, ResourceExt};
+use model::clients::{CrdClient, ResourceClient, TestClient};
+use model::constants::{LABEL_COMPONENT, NAMESPACE};
+use model::{Resource, TaskState, Test};
+use serde::Serialize;
+use snafu::ResultExt;
+use structopt::StructOpt;
+use tabled::{Alignment, Column, Full, MaxWidth, Modify, Style, Table, Tabled};
+use termion::terminal_size;
+
+/// Check the status of a TestSys object.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Status {
+    /// Check the status of the `Resource`s provided, or all `Resource`s if no specific resource is provided.
+    #[structopt(long = "resources", short = "r")]
+    resources: Option<Vec<String>>,
+
+    /// Check the status of the testsys controller
+    #[structopt(long, short = "c")]
+    controller: bool,
+
+    /// Output the results in JSON format.
+    #[structopt(long = "json")]
+    json: bool,
+}
+
+impl Status {
+    pub(crate) async fn run(&self, k8s_client: Client) -> Result<()> {
+        let tests_api = TestClient::new_from_k8s_client(k8s_client.clone());
+        let resources_api = ResourceClient::new_from_k8s_client(k8s_client.clone());
+        let pod_api = Api::<Pod>::namespaced(k8s_client, NAMESPACE);
+        let mut status_results = Results::default();
+        if self.controller {
+            status_results.add_controller(is_controller_running(&pod_api).await?);
+        }
+        let tests = self.tests(&tests_api).await?;
+        let resources = self.resources(&resources_api).await?;
+        for test in tests {
+            status_results.add_test(&test)
+        }
+        for resource in resources {
+            status_results.add_resource(&resource)
+        }
+
+        if !self.json {
+            let (width, _) = terminal_size().ok().unwrap_or((120, 0));
+            status_results.width = width;
+            status_results.draw();
+        } else {
+            println!(
+                "{}",
+                serde_json::to_string(&status_results).context(error::JsonSerializeSnafu)?
+            )
+        }
+
+        Ok(())
+    }
+
+    async fn tests(&self, test_client: &TestClient) -> Result<Vec<Test>> {
+        test_client
+            .get_all()
+            .await
+            .context(error::GetSnafu { what: "all_tests" })
+    }
+
+    async fn resources(&self, resource_client: &ResourceClient) -> Result<Vec<Resource>> {
+        let resource_names = match &self.resources {
+            Some(resources) => resources,
+            None => return Ok(Vec::new()),
+        };
+        if resource_names.is_empty() {
+            resource_client.get_all().await.context(error::GetSnafu {
+                what: "all_resources",
+            })
+        } else {
+            stream::iter(resource_names)
+                .then(|resource_name| async move {
+                    resource_client
+                        .get(&resource_name)
+                        .await
+                        .context(error::GetSnafu {
+                            what: resource_name.clone(),
+                        })
+                })
+                .collect::<Vec<Result<Resource>>>()
+                .await
+                .into_iter()
+                .collect::<Result<Vec<Resource>>>()
+        }
+    }
+}
+
+async fn is_controller_running(pod_api: &Api<Pod>) -> Result<bool> {
+    let pods = pod_api
+        .list(&ListParams {
+            label_selector: Some(format!("{}={}", LABEL_COMPONENT, "controller")),
+            ..Default::default()
+        })
+        .await
+        .context(error::GetPodSnafu {
+            test_name: "controller",
+        })?
+        .items;
+    if pods.is_empty() {
+        return Ok(false);
+    }
+    for pod in pods {
+        if !pod
+            .status
+            .as_ref()
+            .and_then(|s| s.phase.as_ref().map(|s| s == "Running"))
+            .unwrap_or(false)
+        {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+#[derive(Serialize)]
+struct Results {
+    #[serde(skip_serializing)]
+    width: u16,
+    results: Vec<ResultRow>,
+    #[serde(skip_serializing)]
+    min_name_width: u16,
+    #[serde(skip_serializing)]
+    min_object_width: u16,
+    #[serde(skip_serializing)]
+    min_state_width: u16,
+    #[serde(skip_serializing)]
+    min_passed_width: u16,
+    #[serde(skip_serializing)]
+    min_skipped_width: u16,
+    #[serde(skip_serializing)]
+    min_failed_width: u16,
+}
+
+impl Default for Results {
+    fn default() -> Self {
+        Self {
+            width: 100,
+            results: Vec::new(),
+            min_name_width: 4,
+            min_object_width: 4,
+            min_state_width: 5,
+            min_passed_width: 6,
+            min_skipped_width: 7,
+            min_failed_width: 6,
+        }
+    }
+}
+
+impl Results {
+    /// Adds a new `ResultRow` for each `TestResults` in test, or a single row if no `TestsResults` are available.
+    fn add_test(&mut self, test: &Test) {
+        let name = test.metadata.name.clone().unwrap_or_else(|| "".to_string());
+        let state = test.test_user_state().to_string();
+        let results = &test.agent_status().results;
+        if results.is_empty() {
+            self.results.push(ResultRow {
+                name,
+                object_type: "Test".to_string(),
+                state,
+                passed: None,
+                skipped: None,
+                failed: None,
+            })
+        } else {
+            for (test_count, result) in results.iter().enumerate() {
+                let retry_name = if test_count == 0 {
+                    name.clone()
+                } else {
+                    format!("{}-retry-{}", name, test_count)
+                };
+                self.results.push(ResultRow {
+                    name: retry_name,
+                    object_type: "Test".to_string(),
+                    state: state.clone(),
+                    passed: Some(result.num_passed),
+                    skipped: Some(result.num_skipped),
+                    failed: Some(result.num_failed),
+                });
+            }
+        }
+    }
+
+    fn add_resource(&mut self, resource: &Resource) {
+        let name = resource.name();
+        let mut create_state = TaskState::Unknown;
+        let mut delete_state = TaskState::Unknown;
+        if let Some(status) = resource.status() {
+            create_state = status.creation.task_state;
+            delete_state = status.destruction.task_state;
+        }
+        let state = match delete_state {
+            TaskState::Unknown => create_state,
+            _ => delete_state,
+        };
+
+        self.results.push(ResultRow {
+            name,
+            object_type: "Resource".to_string(),
+            state: state.to_string(),
+            passed: None,
+            skipped: None,
+            failed: None,
+        });
+    }
+
+    fn add_controller(&mut self, running: bool) {
+        self.results.push(ResultRow {
+            name: "Controller".to_string(),
+            object_type: "Controller".to_string(),
+            state: if running { "Running" } else { "" }.to_string(),
+            passed: None,
+            skipped: None,
+            failed: None,
+        });
+    }
+
+    fn draw(&self) {
+        if self.width
+            < self.min_name_width
+                + self.min_object_width
+                + self.min_state_width
+                + self.min_passed_width
+                + self.min_skipped_width
+                + self.min_failed_width
+                + 25
+        {
+            println!("The screen is not wide enough.");
+            return;
+        }
+        let width_diff = self.width
+            - self.min_name_width
+            - self.min_object_width
+            - self.min_state_width
+            - self.min_passed_width
+            - self.min_skipped_width
+            - self.min_failed_width
+            - 25;
+        let mut name = self.min_name_width;
+        let mut object = self.min_object_width;
+        let mut state = self.min_state_width;
+        let passed = self.min_passed_width;
+        let skipped = self.min_skipped_width;
+        let failed = self.min_failed_width;
+        if width_diff < 18 {
+            let diff = width_diff / 3;
+            state += diff;
+            object += diff;
+            name += width_diff - 2 * diff;
+        } else {
+            name += width_diff - 12;
+            object += 6;
+            state += 6;
+        }
+
+        let mut sorted_results = self.results.clone();
+        sorted_results.sort_by(|a, b| a.name.cmp(&b.name));
+
+        let table = Table::new(sorted_results)
+            .with(Style::NO_BORDER)
+            .with(Modify::new(Full).with(Alignment::left()))
+            .with(Modify::new(Column(..1)).with(MaxWidth::truncating(name.into(), "..")))
+            .with(Modify::new(Column(1..2)).with(MaxWidth::truncating(object.into(), "..")))
+            .with(Modify::new(Column(2..3)).with(MaxWidth::truncating(state.into(), "..")))
+            .with(Modify::new(Column(3..4)).with(MaxWidth::truncating(passed.into(), "")))
+            .with(Modify::new(Column(4..5)).with(MaxWidth::truncating(skipped.into(), "")))
+            .with(Modify::new(Column(6..)).with(MaxWidth::truncating(failed.into(), "")));
+        print!("{}", table);
+    }
+}
+
+#[derive(Tabled, Default, Clone, Serialize)]
+struct ResultRow {
+    #[header("NAME")]
+    name: String,
+    #[header("TYPE")]
+    object_type: String,
+    #[header("STATE")]
+    state: String,
+    #[header("PASSED")]
+    #[field(display_with = "display_option")]
+    passed: Option<u64>,
+    #[header("SKIPPED")]
+    #[field(display_with = "display_option")]
+    skipped: Option<u64>,
+    #[header("FAILED")]
+    #[field(display_with = "display_option")]
+    failed: Option<u64>,
+}
+
+fn display_option(o: &Option<u64>) -> String {
+    match o {
+        Some(count) => format!("{}", count),
+        None => "".to_string(),
+    }
+}

--- a/bottlerocket/testsys/tests/cli_test.rs
+++ b/bottlerocket/testsys/tests/cli_test.rs
@@ -1,0 +1,138 @@
+#![cfg(feature = "integ")]
+mod data;
+use assert_cmd::Command;
+use model::{constants::NAMESPACE, Resource, Test};
+use selftest::Cluster;
+use tokio::time::Duration;
+
+/// The amount of time we will wait for the controller to run, a test-agent to run, etc. before we
+/// consider the selftest a failure. This can be a very long time on resource constrained or
+/// machines running a VM for docker.
+const POD_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// We will test:
+/// `testsys install`
+/// 'testsys run` (with a manifest)
+/// `testsys status`
+/// Ensure templating of resources and tests works
+/// Ensure depends on for resources and tests works
+
+#[tokio::test]
+async fn test_system() {
+    let cluster_name = "integ-test";
+    let cluster = Cluster::new(cluster_name).unwrap();
+    cluster.load_image_to_cluster("controller:integ").unwrap();
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "install",
+        "--controller-uri",
+        "controller:integ",
+    ]);
+    cmd.assert().success();
+    cluster.wait_for_controller(POD_TIMEOUT).await.unwrap();
+
+    cluster
+        .load_image_to_cluster("example-test-agent:integ")
+        .unwrap();
+    cluster
+        .load_image_to_cluster("duplicator-resource-agent:integ")
+        .unwrap();
+
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "run",
+        "file",
+        data::integ_test_dependent_path().to_str().unwrap(),
+    ]);
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "run",
+        "file",
+        data::integ_test_depended_on_path().to_str().unwrap(),
+    ]);
+    cmd.assert().success();
+
+    cluster
+        .wait_for_test_pod("hello-bones-1", POD_TIMEOUT)
+        .await
+        .unwrap();
+
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "set",
+        "hello-bones-1",
+        "--keep-running",
+        "false",
+    ]);
+    cmd.assert().success();
+
+    // Delete everything
+    cluster.delete_resource("dup-1").await.unwrap();
+    cluster
+        .wait_for_resource_destruction_pod("dup-1", POD_TIMEOUT)
+        .await
+        .unwrap();
+    cluster.delete_resource("dup-2").await.unwrap();
+    cluster
+        .wait_for_resource_destruction_pod("dup-2", POD_TIMEOUT)
+        .await
+        .unwrap();
+    cluster.delete_test("hello-bones-1").await.unwrap();
+    cluster.delete_test("hello-bones-2").await.unwrap();
+    cluster
+        .wait_for_deletion::<Resource>("dup-1", Some(NAMESPACE), POD_TIMEOUT)
+        .await
+        .unwrap();
+    cluster
+        .wait_for_deletion::<Resource>("dup-2", Some(NAMESPACE), POD_TIMEOUT)
+        .await
+        .unwrap();
+    cluster
+        .wait_for_deletion::<Test>("hello-bones-1", Some(NAMESPACE), POD_TIMEOUT)
+        .await
+        .unwrap();
+    cluster
+        .wait_for_deletion::<Test>("hello-bones-2", Some(NAMESPACE), POD_TIMEOUT)
+        .await
+        .unwrap();
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    // Create a resource with destructionPolicy: never and do a best-effort assertion that the
+    // destruction pod was not created.
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "run",
+        "file",
+        data::integ_test_resource_destruction_never_path()
+            .to_str()
+            .unwrap(),
+    ]);
+    cmd.assert().success();
+
+    // Watch for a bit and fail if we see the destruction pod.
+    for _ in 0..20 {
+        assert!(!cluster
+            .does_resource_destruction_pod_exist("never-destroy")
+            .await
+            .unwrap());
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await
+    }
+
+    cluster.delete_resource("never-destroy").await.unwrap();
+    cluster
+        .wait_for_deletion::<Resource>("never-destroy", Some(NAMESPACE), POD_TIMEOUT)
+        .await
+        .unwrap();
+}

--- a/bottlerocket/testsys/tests/data.rs
+++ b/bottlerocket/testsys/tests/data.rs
@@ -1,0 +1,21 @@
+#![allow(unused)]
+
+use std::path::PathBuf;
+
+pub fn integ_test_dependent_path() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.join("testsys/tests/data/integ-test-dependent.yaml")
+}
+
+pub fn integ_test_depended_on_path() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.join("testsys/tests/data/integ-test-depended-on.yaml")
+}
+
+pub fn integ_test_resource_destruction_never_path() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.join("testsys/tests/data/resource-destruction-never.yaml")
+}

--- a/bottlerocket/testsys/tests/data/example-resource-provider.yaml
+++ b/bottlerocket/testsys/tests/data/example-resource-provider.yaml
@@ -1,0 +1,14 @@
+apiVersion: testsys.bottlerocket.aws/v1
+kind: Resource
+metadata:
+  name: robot-provider
+  namespace: testsys-bottlerocket-aws
+spec:
+  dependsOn: []
+  agent:
+    name: robot-agent
+    image: "example-resource-agent:integ"
+    keepRunning: false
+    configuration:
+      color: "Purple"
+      numberOfRobots: 10

--- a/bottlerocket/testsys/tests/data/integ-test-depended-on.yaml
+++ b/bottlerocket/testsys/tests/data/integ-test-depended-on.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: testsys.bottlerocket.aws/v1
+kind: Resource
+metadata:
+  name: dup-2
+  namespace: testsys-bottlerocket-aws
+spec:
+  agent:
+    name: dup-2-agent
+    image: "duplicator-resource-agent:integ"
+    keepRunning: false
+    configuration:
+      info: 3
+  dependsOn: []
+---
+apiVersion: testsys.bottlerocket.aws/v1
+kind: Test
+metadata:
+  name: hello-bones-2
+  namespace: testsys-bottlerocket-aws
+spec:
+  agent:
+    name: hello-agent
+    image: "example-test-agent:integ"
+    keepRunning: false
+    configuration:
+      mode: Fast
+      person: Bones the Cat
+      helloCount: ${dup-1.info}
+      helloDurationMilliseconds: 500
+  resources: [dup-1]
+  dependsOn: []

--- a/bottlerocket/testsys/tests/data/integ-test-dependent.yaml
+++ b/bottlerocket/testsys/tests/data/integ-test-dependent.yaml
@@ -1,0 +1,31 @@
+apiVersion: testsys.bottlerocket.aws/v1
+kind: Test
+metadata:
+  name: hello-bones-1
+  namespace: testsys-bottlerocket-aws
+spec:
+  agent:
+    name: hello-agent
+    image: "example-test-agent:integ"
+    keepRunning: true
+    configuration:
+      mode: Fast
+      person: Bones the Cat
+      helloCount: 3
+      helloDurationMilliseconds: 500
+  resources: []
+  dependsOn: [hello-bones-2]
+---
+apiVersion: testsys.bottlerocket.aws/v1
+kind: Resource
+metadata:
+  name: dup-1
+  namespace: testsys-bottlerocket-aws
+spec:
+  agent:
+    name: dup-1-agent
+    image: "duplicator-resource-agent:integ"
+    keepRunning: false
+    configuration:
+      info: ${dup-2.info}
+  dependsOn: [dup-2]

--- a/bottlerocket/testsys/tests/data/resource-destruction-never.yaml
+++ b/bottlerocket/testsys/tests/data/resource-destruction-never.yaml
@@ -1,0 +1,14 @@
+apiVersion: testsys.bottlerocket.aws/v1
+kind: Resource
+metadata:
+  name: never-destroy
+  namespace: testsys-bottlerocket-aws
+spec:
+  dependsOn: []
+  destructionPolicy: never
+  agent:
+    name: robot-agent
+    image: "duplicator-resource-agent:integ"
+    keepRunning: false
+    configuration:
+      info: foo

--- a/bottlerocket/testsys/tests/data/resource-test.yaml
+++ b/bottlerocket/testsys/tests/data/resource-test.yaml
@@ -1,0 +1,17 @@
+apiVersion: testsys.bottlerocket.aws/v1
+kind: Test
+metadata:
+  name: hello-bones
+  namespace: testsys-bottlerocket-aws
+spec:
+  agent:
+    name: hello-agent
+    image: "example-test-agent:integ"
+    keepRunning: true
+    configuration:
+      mode: Fast
+      person: Bones the Cat
+      helloCount: 3
+      helloDurationMilliseconds: 500
+  resources: [eks]
+  dependsOn: []

--- a/bottlerocket/testsys/tests/data/template-test.yaml
+++ b/bottlerocket/testsys/tests/data/template-test.yaml
@@ -1,0 +1,20 @@
+apiVersion: testsys.bottlerocket.aws/v1
+kind: Test
+metadata:
+  name: hello-bones
+  namespace: testsys-bottlerocket-aws
+spec:
+  agent:
+    name: hello-agent
+    image: "example-test-agent:integ"
+    keepRunning: false
+    configuration:
+      mode: Fast
+      person: Bones the Cat
+      helloCount: ${dup1.info}
+      helloDurationMilliseconds: 500
+      nested:
+        data: 
+          inside: ${dup1.info}
+  resources: [dup1]
+  dependsOn: []

--- a/bottlerocket/testsys/tests/sonobuoy_test.rs
+++ b/bottlerocket/testsys/tests/sonobuoy_test.rs
@@ -1,0 +1,65 @@
+#![cfg(feature = "integ")]
+use assert_cmd::Command;
+use selftest::Cluster;
+use tokio::time::Duration;
+
+/// This test requires an external k8s cluster whose kubeconfig must be added to
+/// `test_kubeconfig`.
+#[tokio::test]
+// FIXME - remove assumptions about an existing cluster?
+#[ignore]
+async fn run_sonobuoy_test() {
+    tokio::time::timeout(Duration::from_secs(120), run_sonobuoy_test_impl())
+        .await
+        .expect("Timeout waiting for run_sonobuoy_test_impl");
+}
+
+async fn run_sonobuoy_test_impl() {
+    let test_cluster = Cluster::new("sono-test").unwrap();
+    let cluster = Cluster::new("sonobuoy-test").unwrap();
+    cluster.load_image_to_cluster("controller:integ").unwrap();
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "install",
+        "--controller-uri",
+        "controller:integ",
+    ]);
+    cmd.assert().success();
+    cluster
+        .load_image_to_cluster("sonobuoy-test-agent:integ")
+        .unwrap();
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "run",
+        "sonobuoy",
+        "--name",
+        "sono-test",
+        "--image",
+        "sonobuoy-test-agent:integ",
+        "--target-cluster-kubeconfig",
+        test_cluster
+            .get_internal_kubeconfig()
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "--plugin",
+        "e2e",
+        "--mode",
+        "quick",
+        "--kubernetes-version",
+        "v1.21.2",
+    ]);
+    cmd.assert().success();
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "status",
+        "--wait",
+    ]);
+    cmd.assert().success();
+}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "testsys"
+name = "cli"
 version = "0.1.0"
 edition = "2021"
 publish = false


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #368

**Description of changes:**

Moves the legacy cli onto develop to prevent development on 2 separate branches.

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
