### PR TITLE
Allow eksctl config in eks resource provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
+ "serde_yaml",
  "sha2",
  "snafu",
  "test-agent",
@@ -613,6 +614,7 @@ dependencies = [
  "model",
  "serde",
  "serde_plain",
+ "serde_yaml",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ ENTRYPOINT ["./vsphere-vm-resource-agent"]
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Builds the EKS resource agent image
-FROM scratch as eks-resource-agent
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 as eks-resource-agent
 
 # Copy eksctl
 COPY --from=tools /eksctl /usr/bin/eksctl

--- a/bottlerocket/agents/Cargo.toml
+++ b/bottlerocket/agents/Cargo.toml
@@ -32,6 +32,7 @@ resource-agent = { version = "0.0.2", path = "../../agent/resource-agent" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1"
+serde_yaml = "0.8"
 sha2 = "0.10"
 snafu = "0.7"
 test-agent = { version = "0.0.2", path = "../../agent/test-agent" }

--- a/bottlerocket/testsys/src/run_aws_k8s.rs
+++ b/bottlerocket/testsys/src/run_aws_k8s.rs
@@ -1,7 +1,7 @@
 use crate::error::{self, Result};
 use bottlerocket_types::agent_config::{
-    ClusterType, CreationPolicy, Ec2Config, EksClusterConfig, K8sVersion, MigrationConfig,
-    SonobuoyConfig, SonobuoyMode, TufRepoConfig, AWS_CREDENTIALS_SECRET_NAME,
+    ClusterType, CreationPolicy, Ec2Config, EksClusterConfig, EksctlConfig, K8sVersion,
+    MigrationConfig, SonobuoyConfig, SonobuoyMode, TufRepoConfig, AWS_CREDENTIALS_SECRET_NAME,
 };
 use kube::ResourceExt;
 use kube::{api::ObjectMeta, Client};
@@ -12,7 +12,7 @@ use model::{
     Agent, Configuration, DestructionPolicy, Resource, ResourceSpec, SecretName, Test, TestSpec,
 };
 use serde_json::Value;
-use snafu::ResultExt;
+use snafu::{OptionExt, ResultExt};
 use std::collections::BTreeMap;
 use std::fs::read_to_string;
 use structopt::StructOpt;
@@ -66,7 +66,7 @@ pub(crate) struct RunAwsK8s {
     /// The name of the EKS cluster that will be used (whether it is being created or already
     /// exists).
     #[structopt(long)]
-    cluster_name: String,
+    cluster_name: Option<String>,
 
     /// The name of the TestSys resource that will represent this cluster. If you do not specify a
     /// value, one will be created matching the `cluster-name`. Unless there is a name conflict or
@@ -101,6 +101,10 @@ pub(crate) struct RunAwsK8s {
     /// Name of the pull secret for the cluster provider image.
     #[structopt(long)]
     cluster_provider_pull_secret: Option<String>,
+
+    /// Path to eksctl config file.
+    #[structopt(long)]
+    cluster_config: Option<String>,
 
     /// Keep the EKS provider agent running after cluster creation.
     #[structopt(long)]
@@ -177,20 +181,21 @@ impl RunAwsK8s {
         let cluster_resource_name = self
             .cluster_resource_name
             .as_ref()
-            .unwrap_or(&self.cluster_name);
+            .cloned()
+            .or_else(|| self.cluster_name.as_ref().cloned())
+            .unwrap_or_else(|| "cluster".to_string());
         let ec2_resource_name = self
             .ec2_resource_name
             .clone()
-            .unwrap_or(format!("{}-instances", self.cluster_name));
+            .unwrap_or(format!("{}-instances", cluster_resource_name));
         let aws_secret_map = self.aws_secret.as_ref().map(|secret_name| {
             btreemap! [ AWS_CREDENTIALS_SECRET_NAME.to_string() => secret_name.clone()]
         });
-
-        let eks_resource = self.eks_resource(cluster_resource_name, aws_secret_map.clone())?;
+        let eks_resource = self.eks_resource(&cluster_resource_name, aws_secret_map.clone())?;
         let ec2_resource = self.ec2_resource(
             &ec2_resource_name,
             aws_secret_map.clone(),
-            cluster_resource_name,
+            &cluster_resource_name,
         )?;
 
         let tests = if self.upgrade_downgrade {
@@ -219,7 +224,7 @@ impl RunAwsK8s {
                     &init_test_name,
                     aws_secret_map.clone(),
                     &ec2_resource_name,
-                    cluster_resource_name,
+                    &cluster_resource_name,
                     None,
                 )?;
                 let upgrade_test = self.migration_test(
@@ -228,7 +233,7 @@ impl RunAwsK8s {
                     tuf_repo.clone(),
                     aws_secret_map.clone(),
                     &ec2_resource_name,
-                    cluster_resource_name,
+                    &cluster_resource_name,
                     Some(vec![init_test_name.clone()]),
                     migration_agent_image,
                     &self.migration_agent_pull_secret,
@@ -237,7 +242,7 @@ impl RunAwsK8s {
                     &upgraded_test_name,
                     aws_secret_map.clone(),
                     &ec2_resource_name,
-                    cluster_resource_name,
+                    &cluster_resource_name,
                     Some(vec![init_test_name.clone(), upgrade_test_name.clone()]),
                 )?;
                 let downgrade_test = self.migration_test(
@@ -246,7 +251,7 @@ impl RunAwsK8s {
                     tuf_repo,
                     aws_secret_map.clone(),
                     &ec2_resource_name,
-                    cluster_resource_name,
+                    &cluster_resource_name,
                     Some(vec![
                         init_test_name.clone(),
                         upgrade_test_name.clone(),
@@ -259,7 +264,7 @@ impl RunAwsK8s {
                     &final_test_name,
                     aws_secret_map.clone(),
                     &ec2_resource_name,
-                    cluster_resource_name,
+                    &cluster_resource_name,
                     Some(vec![
                         init_test_name,
                         upgrade_test_name,
@@ -286,7 +291,7 @@ impl RunAwsK8s {
                 &self.name,
                 aws_secret_map.clone(),
                 &ec2_resource_name,
-                cluster_resource_name,
+                &cluster_resource_name,
                 None,
             )?]
         };
@@ -327,6 +332,26 @@ impl RunAwsK8s {
         name: &str,
         secrets: Option<BTreeMap<String, SecretName>>,
     ) -> Result<Resource> {
+        let eksctl_config = if let Some(eksctl_config) = &self.cluster_config {
+            EksctlConfig::File {
+                encoded_config: base64::encode(read_to_string(eksctl_config).context(
+                    error::FileSnafu {
+                        path: eksctl_config,
+                    },
+                )?),
+            }
+        } else {
+            EksctlConfig::Args {
+                cluster_name: self.cluster_name.to_owned().context(
+                    error::InvalidArgumentsSnafu {
+                        why: "One of `cluster-name` or `cluster-config` must be provided.",
+                    },
+                )?,
+                region: Some(self.region.clone()),
+                zones: None,
+                version: self.cluster_version,
+            }
+        };
         Ok(Resource {
             metadata: ObjectMeta {
                 name: Some(name.to_string()),
@@ -343,11 +368,8 @@ impl RunAwsK8s {
                     keep_running: self.keep_cluster_provider_running,
                     configuration: Some(
                         EksClusterConfig {
-                            cluster_name: self.cluster_name.clone(),
+                            config: eksctl_config,
                             creation_policy: Some(self.cluster_creation_policy),
-                            region: Some(self.region.clone()),
-                            zones: None,
-                            version: self.cluster_version,
                             assume_role: self.assume_role.clone(),
                         }
                         .into_map()
@@ -377,7 +399,7 @@ impl RunAwsK8s {
                 .clone()
                 .map(|instance_type| vec![instance_type])
                 .unwrap_or_default(),
-            cluster_name: self.cluster_name.clone(),
+            cluster_name: format!("${{{}.clusterName}}", cluster_resource_name),
             region: self.region.clone(),
             instance_profile_arn: format!("${{{}.iamInstanceProfileArn}}", cluster_resource_name),
             subnet_ids: vec![],

--- a/bottlerocket/types/Cargo.toml
+++ b/bottlerocket/types/Cargo.toml
@@ -9,3 +9,4 @@ license = "MIT OR Apache-2.0"
 model = { version = "0.0.2", path = "../../model" }
 serde = "1"
 serde_plain = "1"
+serde_yaml = "0.8"

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -91,24 +91,40 @@ impl Configuration for MigrationConfig {}
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct EksClusterConfig {
-    /// The name of the eks cluster to create or an existing cluster.
-    pub cluster_name: String,
-
     /// Whether this agent will create the cluster or not.
     pub creation_policy: Option<CreationPolicy>,
 
-    /// The AWS region to create the cluster. If no value is provided `us-west-2` will be used.
-    pub region: Option<String>,
-
-    /// The availability zones. (e.g. us-west-2a,us-west-2b)
-    pub zones: Option<Vec<String>>,
-
-    /// The eks version of the the cluster (e.g. "1.14", "1.15", "1.16"). Make sure this is
-    /// quoted so that it is interpreted as a JSON/YAML string (not a number).
-    pub version: Option<K8sVersion>,
-
     /// The role that should be assumed when creating the cluster.
     pub assume_role: Option<String>,
+
+    #[serde(flatten)]
+    pub config: EksctlConfig,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum EksctlConfig {
+    File {
+        encoded_config: String,
+    },
+    Args {
+        cluster_name: String,
+        region: Option<String>,
+        /// The availability zones. (e.g. us-west-2a,us-west-2b)
+        zones: Option<Vec<String>>,
+
+        /// The eks version of the the cluster (e.g. "1.14", "1.15", "1.16"). Make sure this is
+        /// quoted so that it is interpreted as a JSON/YAML string (not a number).
+        version: Option<K8sVersion>,
+    },
+}
+
+impl Default for EksctlConfig {
+    fn default() -> Self {
+        Self::File {
+            encoded_config: "".to_string(),
+        }
+    }
 }
 
 impl Configuration for EksClusterConfig {}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #252 
Closes #416 

**Description of changes:**

Allows the user to provide and encoded eksctl config file for cluster creation.
I chose to keep the config flat (instead of creating an enum for cluster config vs zones and version) so that the work is compatible with #537 .

**Testing done:**

Tested using existing roles from another cluster with the following config: (Note: this config is probably not minimal but it works)
```yaml
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
metadata:
  name:  eksctl-test
  region: us-west-2
  version: "1.22"
kubernetesNetworkConfig:
  ipFamily: IPv4
iam:
  serviceRoleARN: arn:aws:iam::<ACCOUNT-ID>:role/eksctl-x86-64-aws-k8s-121-cluster-ServiceRole-...
iamIdentityMappings:
  - arn: arn:aws:iam::<ACCOUNT-ID>:role/Ecs
    groups:
      - system:masters
    username: admin
    noDuplicateARNs: true
nodeGroups:
  - name: empty
    desiredCapacity: 0
    iam:
      withAddonPolicies:
        albIngress: false
        appMesh: false
        appMeshPreview: false
        autoScaler: false
        awsLoadBalancerController: false
        certManager: false
        cloudWatch: false
        ebs: false
        efs: false
        externalDNS: false
        fsx: false
        imageBuilder: false
        xRay: false
      instanceRoleARN: "arn:aws:iam::<ACCOUNT-ID>:role/eksctl-x86-64-aws-k8s-121-nodegro-NodeInstanceRole-..."
      instanceProfileARN: "arn:aws:iam::<ACCOUNT-ID>:instance-profile/eksctl-x86-64-aws-k8s-121-nodegroup-ng-..."
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
