### PR TITLE
Adds uninstall capabilities to the TestManager

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,6 +14,7 @@ mod results;
 mod run;
 mod run_file;
 mod status;
+mod uninstall;
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -41,6 +42,8 @@ struct Args {
 enum Command {
     /// Install testsys components into the cluster.
     Install(install::Install),
+    /// Uninstall all components from a testsys cluster.
+    Uninstall(uninstall::Uninstall),
     /// Restart a test.
     Restart(restart::Restart),
     /// Run a testsys test.
@@ -81,6 +84,7 @@ async fn run(args: Args) -> Result<()> {
     };
     match args.command {
         Command::Install(install) => install.run(client).await,
+        Command::Uninstall(uninstall) => uninstall.run(client).await,
         Command::Restart(restart) => restart.run(client).await,
         Command::Run(run) => run.run(client).await,
         Command::Logs(logs) => logs.run(client).await,

--- a/cli/src/uninstall.rs
+++ b/cli/src/uninstall.rs
@@ -1,0 +1,19 @@
+use anyhow::{Context, Result};
+use clap::Parser;
+use model::test_manager::TestManager;
+
+/// The uninstall subcommand is responsible for removing all testsys components from a k8s cluster.
+#[derive(Debug, Parser)]
+pub(crate) struct Uninstall {}
+
+impl Uninstall {
+    pub(crate) async fn run(self, client: TestManager) -> Result<()> {
+        client.uninstall().await.context(
+            "Unable to uninstall testsys from the cluster. (Some artifacts may be left behind)",
+        )?;
+
+        println!("testsys components were successfully uninstalled.");
+
+        Ok(())
+    }
+}

--- a/model/src/test_manager/install.rs
+++ b/model/src/test_manager/install.rs
@@ -8,7 +8,7 @@ use crate::system::{
 use crate::test_manager::TestManager;
 use crate::{Resource, Test};
 use k8s_openapi::api::core::v1::Namespace;
-use kube::CustomResourceExt;
+use kube::{Api, CustomResourceExt};
 use snafu::ResultExt;
 
 impl TestManager {
@@ -113,5 +113,16 @@ impl TestManager {
         // not create a new controller deployment.
         self.create_or_update(true, &controller_deployment, "namespace")
             .await
+    }
+
+    pub(super) async fn uninstall_testsys(&self) -> Result<()> {
+        let namespace_api: Api<Namespace> = self.api();
+        namespace_api
+            .delete(NAMESPACE, &Default::default())
+            .await
+            .context(error::KubeSnafu {
+                action: "delete testsys namespace",
+            })?;
+        Ok(())
     }
 }

--- a/model/src/test_manager/manager.rs
+++ b/model/src/test_manager/manager.rs
@@ -149,6 +149,11 @@ impl TestManager {
         Ok(())
     }
 
+    /// Uninstall testsys from a cluster.
+    pub async fn uninstall(&self) -> Result<()> {
+        self.uninstall_testsys().await
+    }
+
     /// Restart a crd object by deleting the crd from the cluster and adding a copy of it with its
     /// status cleared.
     pub async fn restart_test(&self, name: &str) -> Result<()> {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Allows users to uninstall the k8s components created by `install`.

**Testing done:**

Used `cli uninstall` to uninstall from a cluster and  everything was properly cleaned up.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
