### PR TITLE
build: align crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "agent-common"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "model",
  "snafu",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-agents"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "agent-common",
  "async-trait",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-types"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "model",
  "serde",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "cli"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "model"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "resource-agent"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "agent-common",
  "async-trait",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "selftest"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "envy",
@@ -2657,7 +2657,7 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "test-agent"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "agent-common",
  "async-trait",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "testsys"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "yamlgen"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "kube",
  "model",

--- a/agent/agent-common/Cargo.toml
+++ b/agent/agent-common/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "agent-common"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-model = { version = "0.1.0", path = "../../model" }
+model = { version = "0.0.1", path = "../../model" }
 snafu = "0.7"
 
 [dev-dependencies]
 tempfile = "3"
 
 [build-dependencies]
-yamlgen = { version = "0.1.0", path = "../../yamlgen" }
+yamlgen = { version = "0.0.1", path = "../../yamlgen" }

--- a/agent/resource-agent/Cargo.toml
+++ b/agent/resource-agent/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "resource-agent"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-agent-common = { version = "0.1.0", path = "../agent-common" }
+agent-common = { version = "0.0.1", path = "../agent-common" }
 async-trait = "0.1"
 log = "0.4"
-model = { version = "0.1.0", path = "../../model" }
+model = { version = "0.0.1", path = "../../model" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu = "0.7"
@@ -21,4 +21,4 @@ nonzero_ext = "0.3"
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
-yamlgen = { version = "0.1.0", path = "../../yamlgen" }
+yamlgen = { version = "0.0.1", path = "../../yamlgen" }

--- a/agent/test-agent/Cargo.toml
+++ b/agent/test-agent/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "test-agent"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-agent-common = { version = "0.1.0", path = "../agent-common" }
+agent-common = { version = "0.0.1", path = "../agent-common" }
 async-trait = "0.1"
 log = "0.4"
-model = { version = "0.1.0", path = "../../model" }
+model = { version = "0.0.1", path = "../../model" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu = "0.7"
@@ -21,4 +21,4 @@ tokio = { version = "1", default-features = false, features = ["time"] }
 tokio = { version = "1", default-features = false, features = ["macros", "process", "rt-multi-thread"] }
 
 [build-dependencies]
-yamlgen = { version = "0.1.0", path = "../../yamlgen" }
+yamlgen = { version = "0.0.1", path = "../../yamlgen" }

--- a/bottlerocket/agents/Cargo.toml
+++ b/bottlerocket/agents/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "bottlerocket-agents"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2018"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-agent-common = { version = "0.1.0", path = "../../agent/agent-common" }
-bottlerocket-types = { version = "0.1.0", path = "../types" }
+agent-common = { version = "0.0.1", path = "../../agent/agent-common" }
+bottlerocket-types = { version = "0.0.1", path = "../types" }
 async-trait = "0.1"
 aws-config = "0.15"
 aws-types = "0.15"
@@ -25,19 +25,19 @@ k8s-openapi = { version = "0.15", default-features = false, features = ["v1_20"]
 kube = { version = "0.73", default-features = false, features = ["config", "derive", "client"] }
 log = "0.4"
 maplit = "1.0.2"
-model = { version = "0.1.0", path = "../../model" }
+model = { version = "0.0.1", path = "../../model" }
 reqwest = { version = "0.11.1", default-features = false, features = ["rustls-tls", "blocking"] }
-resource-agent = { version = "0.1.0", path = "../../agent/resource-agent" }
+resource-agent = { version = "0.0.1", path = "../../agent/resource-agent" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1"
 sha2 = "0.10"
 snafu = "0.7"
-test-agent = { version = "0.1.0", path = "../../agent/test-agent" }
+test-agent = { version = "0.0.1", path = "../../agent/test-agent" }
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
 tough = { version = "0.12", features = ["http"] }
 url = "2.2"
 uuid = { version = "1.0", default-features = false, features = ["serde", "v4"] }
 
 [build-dependencies]
-yamlgen = { version = "0.1.0", path = "../../yamlgen" }
+yamlgen = { version = "0.0.1", path = "../../yamlgen" }

--- a/bottlerocket/testsys/Cargo.toml
+++ b/bottlerocket/testsys/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "testsys"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 base64 = "0.13.0"
-bottlerocket-types = { version = "0.1.0", path = "../types" }
+bottlerocket-types = { version = "0.0.1", path = "../types" }
 env_logger = "0.9"
 futures = "0.3.8"
 http = "0"
@@ -15,7 +15,7 @@ k8s-openapi = { version = "0.15", features = ["v1_20", "api"], default-features 
 kube = { version = "0.73", default-features = true, features = ["config", "derive", "ws"] }
 log = "0.4"
 maplit = "1"
-model = { version = "0.1.0", path = "../../model" }
+model = { version = "0.0.1", path = "../../model" }
 serde = "1.0.130"
 serde_plain = "1"
 serde_json = "1.0.61"
@@ -30,10 +30,10 @@ topological-sort = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2.0"
-selftest = { version = "0.1.0", path = "../../selftest" }
+selftest = { version = "0.0.1", path = "../../selftest" }
 
 [build-dependencies]
-yamlgen = { version = "0.1.0", path = "../../yamlgen" }
+yamlgen = { version = "0.0.1", path = "../../yamlgen" }
 
 [features]
 # The `integ` feature enables integration tests. These tests require docker and kind.

--- a/bottlerocket/types/Cargo.toml
+++ b/bottlerocket/types/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bottlerocket-types"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2018"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-model = { version = "0.1.0", path = "../../model" }
+model = { version = "0.0.1", path = "../../model" }
 serde = "1"
 serde_plain = "1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "controller"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ kube = { version = "0.73", default-features = true, features = ["derive"] }
 kube-runtime = "0.73"
 lazy_static = "1"
 log = "0.4"
-model = { version = "0.1.0", path = "../model" }
+model = { version = "0.0.1", path = "../model" }
 parse_duration = "2.1"
 schemars = "0"
 serde = { version = "1", features = ["derive"] }
@@ -24,4 +24,4 @@ snafu = "0.7"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
-yamlgen = { version = "0.1.0", path = "../yamlgen" }
+yamlgen = { version = "0.0.1", path = "../yamlgen" }

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "model"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
@@ -31,7 +31,7 @@ tokio-util = "0.7"
 topological-sort = "0.2"
 
 [dev-dependencies]
-selftest = { version = "0.1.0", path = "../selftest" }
+selftest = { version = "0.0.1", path = "../selftest" }
 tokio = { version = "1", features = ["macros"] }
 
 [features]

--- a/selftest/Cargo.toml
+++ b/selftest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "selftest"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
@@ -13,7 +13,7 @@ futures = "0.3.8"
 k8s-openapi = { version = "0.15", default-features = false, features = ["v1_20"] }
 kube = { version = "0.73", default-features = true }
 lazy_static = "1"
-model = { version = "0.1.0", path = "../model"}
+model = { version = "0.0.1", path = "../model"}
 serde = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["time"] }

--- a/yamlgen/Cargo.toml
+++ b/yamlgen/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "yamlgen"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [build-dependencies]
 kube = { version = "0.73", default-features = false }
-model = { version = "0.1.0", path = "../model" }
+model = { version = "0.0.1", path = "../model" }
 serde_yaml = "0"


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

We recently released container images with the tag v0.0.1. For the sake
of simplicity, we should align our crate version numbers to match the
published container version numbers.

**Testing done:**

It builds.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
