### PR TITLE
agent-config: support sonobuoy e2e test mode 'conformance-lite'

### DIFF
--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -31,7 +31,10 @@ pub enum SonobuoyMode {
     /// This is the default mode and will run all the tests in the e2e plugin which are marked
     /// `Conformance` which are known to not be disruptive to other workloads in your cluster.
     NonDisruptiveConformance,
-    //// This mode runs all of the Conformance tests.
+    /// An unofficial mode of running the e2e tests which removes some of the longest running tests
+    /// so that tests can complete in the fastest time possible while maximizing coverage.
+    ConformanceLite,
+    /// This mode runs all the tests in the K8s E2E conformance test suite.
     CertifiedConformance,
     /// This mode will run a single test from the e2e test suite which is known to be simple and
     /// fast. Use this mode as a quick check that the cluster is responding and reachable.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Resolves https://github.com/bottlerocket-os/bottlerocket-test-system/issues/467


**Description of changes:**
```
agent-config: support sonobuoy e2e test mode 'conformance-lite'
```

**Testing done:**
Ran `testsys run aws-k8s` with `--mode conformance-lite` and confirmed that the e2e plugin was running `conformance-lite` tests:

TestSpec:
```
...
Spec:
  Agent:
    Capabilities:  <nil>
    Configuration:
      Assume Role:             <nil>
      Kube Conformance Image:  <nil>
      kubeconfigBase64:        ${x86-64-aws-k8s-121.encodedKubeconfig}
      Kubernetes Version:      <nil>
      Mode:                    conformance-lite
      Plugin:                  e2e
    Image:                     testsys:sonobuoy-test-agent-etung-test
    Keep Running:              true
    Name:                      sonobuoy-test-agent
    Pull Secret:               <nil>
    Secrets:                   <nil>
    Timeout:                   <nil>
  Depends On:                  <nil>
  Resources:
    x86-64-aws-k8s-121-instances
    x86-64-aws-k8s-121
  Retries:  <nil>
Status:
  Agent:
    Error:  <nil>
    Results:
    Task State:  running
  Controller:
    Resource Error:  <nil>
Events:              <none>

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
