### PR TITLE
agent: fix task state during test retries.

### DIFF
--- a/agent/test-agent/src/agent.rs
+++ b/agent/test-agent/src/agent.rs
@@ -106,7 +106,7 @@ where
             );
             if let Err(e) = self
                 .client
-                .send_test_done(test_results.clone())
+                .send_test_results(test_results.clone())
                 .await
                 .map_err(error::Error::Client)
             {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**

Fixes a bug where the task state of a test was set as `Completed` even if the test was being rerun. Previously the `TaskState` was set to complete as soon as a the first test result was in even though the test may be rerunning. This pr stops the `TaskState` from changing until the test is complete.

**Testing done:**

Ran a test that failed and was rerun and `task_state` was not set to complete.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
