### PR TITLE
controller: remove unnecessary let-binding

### DIFF
--- a/controller/src/resource_controller/context.rs
+++ b/controller/src/resource_controller/context.rs
@@ -101,7 +101,7 @@ impl ResourceInterface {
     }
 
     pub(super) async fn remove_job(&self, op: ResourceAction) -> Result<()> {
-        let _ = delete_job(self.k8s_client(), self.job_name(op))
+        delete_job(self.k8s_client(), self.job_name(op))
             .await
             .context(format!("Unable to remove job '{}'", self.job_name(op)))?;
         Ok(())


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
This removes the unnecessary let-binding for the unit value. With the latest rust toolchain version this constituted a build error.


**Testing done:**
Build no longer fails.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
