### PR TITLE
Support `e2e-repo-config` option to use E2E test images from custom image repos

### DIFF
--- a/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
@@ -37,7 +37,7 @@ use bottlerocket_agents::error::Error;
 use bottlerocket_agents::sonobuoy::{delete_sonobuoy, rerun_failed_sonobuoy, run_sonobuoy};
 use bottlerocket_agents::wireguard::setup_wireguard;
 use bottlerocket_agents::{
-    aws_test_config, base64_decode_write_file, error, init_agent_logger,
+    aws_test_config, base64_decode_write_file, error, init_agent_logger, E2E_REPO_CONFIG_PATH,
     TEST_CLUSTER_KUBECONFIG_PATH,
 };
 use bottlerocket_types::agent_config::{
@@ -86,8 +86,19 @@ impl test_agent::Runner for SonobuoyTestRunner {
         base64_decode_write_file(&self.config.kubeconfig_base64, TEST_CLUSTER_KUBECONFIG_PATH)
             .await?;
         info!("Stored kubeconfig in {}", TEST_CLUSTER_KUBECONFIG_PATH);
+        let e2e_repo_config = match &self.config.e2e_repo_config_base64 {
+            Some(e2e_repo_config_base64) => {
+                info!("Decoding e2e-repo-config config");
+                base64_decode_write_file(e2e_repo_config_base64, E2E_REPO_CONFIG_PATH).await?;
+                info!("Stored e2e-repo-config in {}", E2E_REPO_CONFIG_PATH);
+                Some(E2E_REPO_CONFIG_PATH)
+            }
+            None => None,
+        };
+
         run_sonobuoy(
             TEST_CLUSTER_KUBECONFIG_PATH,
+            e2e_repo_config,
             &self.config,
             &self.results_dir,
         )
@@ -104,8 +115,19 @@ impl test_agent::Runner for SonobuoyTestRunner {
         base64_decode_write_file(&self.config.kubeconfig_base64, TEST_CLUSTER_KUBECONFIG_PATH)
             .await?;
         info!("Stored kubeconfig in {}", TEST_CLUSTER_KUBECONFIG_PATH);
+        let e2e_repo_config = match &self.config.e2e_repo_config_base64 {
+            Some(e2e_repo_config_base64) => {
+                info!("Decoding e2e-repo-config config");
+                base64_decode_write_file(e2e_repo_config_base64, E2E_REPO_CONFIG_PATH).await?;
+                info!("Stored e2e-repo-config in {}", E2E_REPO_CONFIG_PATH);
+                Some(E2E_REPO_CONFIG_PATH)
+            }
+            None => None,
+        };
+
         rerun_failed_sonobuoy(
             TEST_CLUSTER_KUBECONFIG_PATH,
+            e2e_repo_config,
             &self.config,
             &self.results_dir,
         )

--- a/bottlerocket/agents/src/bin/vsphere-vm-resource-agent/vsphere_vm_provider.rs
+++ b/bottlerocket/agents/src/bin/vsphere-vm-resource-agent/vsphere_vm_provider.rs
@@ -2,7 +2,7 @@ use crate::aws::{create_ssm_activation, ensure_ssm_service_role, wait_for_ssm_re
 use crate::tuf::download_target;
 use bottlerocket_agents::wireguard::setup_wireguard;
 use bottlerocket_agents::{
-    aws_resource_config, decode_write_kubeconfig, TEST_CLUSTER_KUBECONFIG_PATH,
+    aws_resource_config, base64_decode_write_file, TEST_CLUSTER_KUBECONFIG_PATH,
 };
 use bottlerocket_types::agent_config::{
     TufRepoConfig, VSphereVmConfig, AWS_CREDENTIALS_SECRET_NAME, VSPHERE_CREDENTIALS_SECRET_NAME,
@@ -152,7 +152,8 @@ impl Create for VMCreator {
         set_govc_env_vars(&spec.configuration);
 
         let vsphere_cluster = spec.configuration.cluster.clone();
-        decode_write_kubeconfig(
+        debug!("Decoding and writing out kubeconfig for vSphere cluster");
+        base64_decode_write_file(
             &vsphere_cluster.kubeconfig_base64,
             TEST_CLUSTER_KUBECONFIG_PATH,
         )

--- a/bottlerocket/agents/src/error.rs
+++ b/bottlerocket/agents/src/error.rs
@@ -22,11 +22,8 @@ pub enum Error {
         source: SdkError<AssumeRoleError>,
     },
 
-    #[snafu(display("Failed to base64-decode '{}' for test cluster: {}", what, source))]
-    Base64Decode {
-        what: String,
-        source: base64::DecodeError,
-    },
+    #[snafu(display("Failed to decode base64 blob: {}", source))]
+    Base64Decode { source: base64::DecodeError },
 
     #[snafu(display("Could not convert '{}' secret to string: {}", what, source))]
     Conversion { what: String, source: FromUtf8Error },
@@ -37,9 +34,9 @@ pub enum Error {
     #[snafu(display("Failed to setup environment variables: {}", what))]
     EnvSetup { what: String },
 
-    #[snafu(display("Failed to write '{}': {}", what, source))]
-    Write {
-        what: String,
+    #[snafu(display("Failed to write file at '{}': {}", path, source))]
+    WriteFile {
+        path: String,
         source: std::io::Error,
     },
 

--- a/bottlerocket/agents/src/lib.rs
+++ b/bottlerocket/agents/src/lib.rs
@@ -31,6 +31,7 @@ use test_agent::Runner;
 pub const DEFAULT_AGENT_LEVEL_FILTER: LevelFilter = LevelFilter::Info;
 pub const DEFAULT_TASK_DEFINITION: &str = "testsys-bottlerocket-aws-default-ecs-smoke-test-v1";
 pub const TEST_CLUSTER_KUBECONFIG_PATH: &str = "/local/test-cluster.kubeconfig";
+pub const E2E_REPO_CONFIG_PATH: &str = "/local/e2e-repo-config.yaml";
 pub const DEFAULT_REGION: &str = "us-west-2";
 
 /// Decode base64 blob and write to a file at the specified path
@@ -39,9 +40,11 @@ pub async fn base64_decode_write_file(
     path_to_write_to: &str,
 ) -> Result<(), error::Error> {
     let path = Path::new(path_to_write_to);
-    let decoded_bytes = base64::decode(base64_content.as_bytes())
-        .context(error::Base64DecodeSnafu)?;
-    fs::write(path, decoded_bytes).context(error::WriteFileSnafu { path: path_to_write_to })?;
+    let decoded_bytes =
+        base64::decode(base64_content.as_bytes()).context(error::Base64DecodeSnafu)?;
+    fs::write(path, decoded_bytes).context(error::WriteFileSnafu {
+        path: path_to_write_to,
+    })?;
     Ok(())
 }
 

--- a/bottlerocket/agents/src/lib.rs
+++ b/bottlerocket/agents/src/lib.rs
@@ -33,17 +33,15 @@ pub const DEFAULT_TASK_DEFINITION: &str = "testsys-bottlerocket-aws-default-ecs-
 pub const TEST_CLUSTER_KUBECONFIG_PATH: &str = "/local/test-cluster.kubeconfig";
 pub const DEFAULT_REGION: &str = "us-west-2";
 
-/// Decode and write out the kubeconfig file for a test cluster to a specified path
-pub async fn decode_write_kubeconfig(
-    kubeconfig_base64: &str,
-    kubeconfig_path: &str,
+/// Decode base64 blob and write to a file at the specified path
+pub async fn base64_decode_write_file(
+    base64_content: &str,
+    path_to_write_to: &str,
 ) -> Result<(), error::Error> {
-    let kubeconfig_path = Path::new(kubeconfig_path);
-    info!("Decoding kubeconfig for test cluster");
-    let decoded_bytes = base64::decode(kubeconfig_base64.as_bytes())
-        .context(error::Base64DecodeSnafu { what: "kubeconfig" })?;
-    info!("Storing kubeconfig in {}", kubeconfig_path.display());
-    fs::write(kubeconfig_path, decoded_bytes).context(error::WriteSnafu { what: "kubeconfig" })?;
+    let path = Path::new(path_to_write_to);
+    let decoded_bytes = base64::decode(base64_content.as_bytes())
+        .context(error::Base64DecodeSnafu)?;
+    fs::write(path, decoded_bytes).context(error::WriteFileSnafu { path: path_to_write_to })?;
     Ok(())
 }
 

--- a/bottlerocket/agents/src/sonobuoy.rs
+++ b/bottlerocket/agents/src/sonobuoy.rs
@@ -60,7 +60,7 @@ pub async fn rerun_failed_sonobuoy(
     info!("Rerunning sonobuoy");
     let status = Command::new("/usr/bin/sonobuoy")
         .args(kubeconfig_arg.to_owned())
-        .arg("e2e")
+        .arg("run")
         .arg("--wait")
         .arg("--rerun-failed")
         .arg(results_filepath.as_os_str())

--- a/bottlerocket/agents/src/wireguard.rs
+++ b/bottlerocket/agents/src/wireguard.rs
@@ -1,5 +1,5 @@
-use crate::{base64_decode_write_file, error};
 use crate::error::Error;
+use crate::{base64_decode_write_file, error};
 use agent_common::secrets::SecretData;
 use log::{debug, info};
 use snafu::{ensure, OptionExt, ResultExt};
@@ -20,10 +20,7 @@ pub async fn setup_wireguard(wireguard_secret: &SecretData) -> Result<(), Error>
     })?;
     debug!("Decoding wireguard conf for setting up wireguard VPN");
     base64_decode_write_file(&base64_encoded_wireguard_conf, WIREGUARD_CONF_PATH).await?;
-    info!(
-        "Stored wireguard conf in {}",
-        WIREGUARD_CONF_PATH
-    );
+    info!("Stored wireguard conf in {}", WIREGUARD_CONF_PATH);
     let output = Command::new("/usr/bin/wg-quick")
         .env("WG_QUICK_USERSPACE_IMPLEMENTATION", "boringtun")
         .env("WG_SUDO", "1")

--- a/bottlerocket/agents/src/wireguard.rs
+++ b/bottlerocket/agents/src/wireguard.rs
@@ -1,10 +1,8 @@
-use crate::error;
+use crate::{base64_decode_write_file, error};
 use crate::error::Error;
 use agent_common::secrets::SecretData;
-use log::info;
+use log::{debug, info};
 use snafu::{ensure, OptionExt, ResultExt};
-use std::fs;
-use std::path::Path;
 use std::process::Command;
 
 pub const WIREGUARD_CONF_PATH: &str = "/local/wg0.conf";
@@ -20,20 +18,12 @@ pub async fn setup_wireguard(wireguard_secret: &SecretData) -> Result<(), Error>
     .context(error::ConversionSnafu {
         what: "wireguard_secret_name",
     })?;
-    let wireguard_config_path = Path::new(WIREGUARD_CONF_PATH);
-    info!("Decoding wireguard conf for setting up wireguard VPN");
-    let decoded_bytes = base64::decode(base64_encoded_wireguard_conf.as_bytes()).context(
-        error::Base64DecodeSnafu {
-            what: "wireguard conf",
-        },
-    )?;
+    debug!("Decoding wireguard conf for setting up wireguard VPN");
+    base64_decode_write_file(&base64_encoded_wireguard_conf, WIREGUARD_CONF_PATH).await?;
     info!(
-        "Storing wireguard conf in {}",
-        wireguard_config_path.display()
+        "Stored wireguard conf in {}",
+        WIREGUARD_CONF_PATH
     );
-    fs::write(wireguard_config_path, decoded_bytes).context(error::WriteSnafu {
-        what: "wireguard conf",
-    })?;
     let output = Command::new("/usr/bin/wg-quick")
         .env("WG_QUICK_USERSPACE_IMPLEMENTATION", "boringtun")
         .env("WG_SUDO", "1")

--- a/bottlerocket/testsys/src/run_aws_k8s.rs
+++ b/bottlerocket/testsys/src/run_aws_k8s.rs
@@ -40,13 +40,12 @@ pub(crate) struct RunAwsK8s {
     #[structopt(long, default_value = "e2e")]
     sonobuoy_plugin: String,
 
-    /// The mode used for the sonobuoy test. One of `non-disruptive-conformance`,
-    /// `certified-conformance`, `quick`. Although the Sonobuoy binary defaults to
-    /// `non-disruptive-conformance`, we default to `quick` to make a quick test the most ergonomic.
+    /// The test mode passed to the sonobuoy E2E plugin. We default to `quick` to make a quick test
+    /// the most ergonomic.
     #[structopt(long, default_value = "quick")]
     sonobuoy_mode: SonobuoyMode,
 
-    /// The kubernetes conformance image used for the sonobuoy test.
+    /// The kubernetes conformance image used for the sonobuoy E2E plugin.
     #[structopt(long)]
     kubernetes_conformance_image: Option<String>,
 

--- a/bottlerocket/testsys/src/run_sonobuoy.rs
+++ b/bottlerocket/testsys/src/run_sonobuoy.rs
@@ -46,13 +46,12 @@ pub(crate) struct RunSonobuoy {
     #[structopt(long, default_value = "e2e")]
     plugin: String,
 
-    /// The mode used for the sonobuoy test. One of `non-disruptive-conformance`,
-    /// `certified-conformance`, `quick`. Although the Sonobuoy binary defaults to
-    /// `non-disruptive-conformance`, we default to `quick` to make a quick test the most ergonomic.
+    /// The test mode passed to the sonobuoy E2E plugin. We default to `quick` to make a quick test
+    /// the most ergonomic.
     #[structopt(long, default_value = "quick")]
     mode: SonobuoyMode,
 
-    /// The kubernetes conformance image used for the sonobuoy test.
+    /// The kubernetes conformance image used for the sonobuoy E2E plugin.
     #[structopt(long)]
     kubernetes_conformance_image: Option<String>,
 

--- a/bottlerocket/testsys/src/run_vmware.rs
+++ b/bottlerocket/testsys/src/run_vmware.rs
@@ -394,6 +394,7 @@ impl RunVmware {
                             kubeconfig_base64: encoded_kubeconfig.to_string(),
                             plugin: self.sonobuoy_plugin.clone(),
                             mode: self.sonobuoy_mode,
+                            e2e_repo_config_base64: None,
                             kubernetes_version: None,
                             kube_conformance_image: self.kubernetes_conformance_image.clone(),
                             assume_role: self.assume_role.clone(),

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -53,6 +53,7 @@ pub struct SonobuoyConfig {
     pub kubeconfig_base64: String,
     pub plugin: String,
     pub mode: SonobuoyMode,
+    pub e2e_repo_config_base64: Option<String>,
     /// This will be passed to `sonobuoy run` as `--kubernetes-version` if `kube_conformance_image`
     /// is `None`. **Caution**: if you provide `kubernetes_version`, it must precisely match the
     /// control plane version. If it is off by even a patch-level from the control plane, some tests


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Resolves https://github.com/bottlerocket-os/bottlerocket-test-system/issues/468


**Description of changes:**
```
    testsys, sonobuoy-test-agent: support e2e-repo-config option
    
    This adds support for the e2e-repo-config option when running sonobuoy
    e2e tests.
```
```
    sonobuoy-test-agent: rerun-failed fix
    
    Newer versions of sonobuoy no longer uses `e2e` as the subcommand for
    rerunning failed tests. It is now a flag under the `run` subcommand.
```
```
    agents: refactor `decode_write_*`
    
    Generalizes `decode_write_kubeconfig` so it's not specific to decoding
    base64 blobs of kubeconfig files.
```
```
    testsys-cli: adjust descriptions for sonobuoy-related options
```


**Testing done:**
Ran some tests in a cluster located in cn-north-1. I provided a custom image repository with mirrored E2E images.

My E2E image repo config
```
$ cat china-image-repo-config 
buildImageRegistry: blah.dkr.ecr.cn-north-1.amazonaws.com.cn
dockerGluster: blah.dkr.ecr.cn-north-1.amazonaws.com.cn
dockerLibraryRegistry: blah.dkr.ecr.cn-north-1.amazonaws.com.cn
e2eRegistry: blah.dkr.ecr.cn-north-1.amazonaws.com.cn
e2eVolumeRegistry: blah.dkr.ecr.cn-north-1.amazonaws.com.cn
gcRegistry: blah.dkr.ecr.cn-north-1.amazonaws.com.cn
gcEtcdRegistry: blah.dkr.ecr.cn-north-1.amazonaws.com.cn
promoterE2eRegistry: blah.dkr.ecr.cn-north-1.amazonaws.com.cn
sigStorageRegistry: blah.dkr.ecr.cn-north-1.amazonaws.com.cn
```

```
$ testsys run aws-k8s   \
     --name "upgrade-downgrade-x86-64-aws-k8s-122-quick"   \
     --test-agent-image "blah.dkr.ecr.cn-north-1.amazonaws.com.cn/testsys:sonobuoy-test-agent"  \
     --keep-running \
     --sonobuoy-mode "quick" \
     --sonobuoy-e2e-repo-config ./china-image-repo-config \
     --region "cn-north-1" \
     --cluster-name "x86-64-aws-k8s-122" \
     --cluster-creation-policy "never" \
     --cluster-destruction-policy "never" \
     --cluster-provider-image "blah.dkr.ecr.cn-north-1.amazonaws.com.cn/testsys:eks-resource-agent" \
     --ami "ami-05714665a2f3d9d76" \
     --instance-type m5.large \
     --ec2-provider-image "blah.dkr.ecr.cn-north-1.amazonaws.com.cn/testsys:ec2-resource-agent" \
     --kubernetes-conformance-image blah.dkr.ecr.cn-north-1.amazonaws.com.cn/conformance:v1.22.9
Created resource object 'x86-64-aws-k8s-122'
Created resource object 'x86-64-aws-k8s-122-instances'
Created test object 'china-upgrade-downgrade-x86-64-aws-k8s-122-quick'


$ testsys logs china-upgrade-downgrade-x86-64-aws-k8s-122-quick --follow
"[2022-07-12T23:24:20Z INFO  sonobuoy_test_agent] Initializing Sonobuoy test agent...\n"
"[2022-07-12T23:24:20Z INFO  bottlerocket_agents] Creating a custom region provider for 'us-west-2' to be used in the aws config.\n"
"[2022-07-12T23:24:20Z INFO  sonobuoy_test_agent] Decoding kubeconfig for test cluster\n"
"[2022-07-12T23:24:20Z INFO  sonobuoy_test_agent] Stored kubeconfig in /local/test-cluster.kubeconfig\n"
"[2022-07-12T23:24:20Z INFO  sonobuoy_test_agent] Decoding e2e-repo-config config\n"
"[2022-07-12T23:24:20Z INFO  sonobuoy_test_agent] Stored e2e-repo-config in /local/e2e-repo-config.yaml\n"
"[2022-07-12T23:24:20Z INFO  bottlerocket_agents::sonobuoy] Running sonobuoy\n"
....
"23:24:41 Waiting for the aggregator status to become Running. Currently the status is Status: Pending, Reason: Unschedulable, no nodes available to schedule pods\n"
"23:25:01    PLUGIN     NODE    STATUS   RESULT   PROGRESS\n"
"23:25:01       e2e   global   running                    \n"
"23:25:01 \n"
"23:25:01 Sonobuoy is still running. Runs can take 60 minutes or more depending on cluster and plugin configuration.\n"
"...\n"
"23:25:41       e2e   global   complete   passed   Passed:  1, Failed:  0, Remaining:  0\n"
"23:25:41 Sonobuoy has completed. Use `sonobuoy retrieve` to get results.\n"
"[2022-07-12T23:25:41Z INFO  bottlerocket_agents::sonobuoy] Sonobuoy testing has completed, checking results\n"
"[2022-07-12T23:25:41Z INFO  bottlerocket_agents::sonobuoy] Running sonobuoy retrieve\n"
"tmp/.tmpFgJmWH/sonobuoy-results.tar.gz\n"
"[2022-07-12T23:25:41Z INFO  bottlerocket_agents::sonobuoy] Sonobuoy testing has completed, printing results\n"
...
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
