### PR TITLE
controller: Allow exclusive access to resources

### DIFF
--- a/bottlerocket/testsys/src/run_aws_ecs.rs
+++ b/bottlerocket/testsys/src/run_aws_ecs.rs
@@ -313,6 +313,7 @@ impl RunAwsEcs {
             },
             spec: ResourceSpec {
                 depends_on: None,
+                conflicts_with: None,
                 agent: Agent {
                     name: "ecs-provider".to_string(),
                     image: self.cluster_provider_image.clone(),
@@ -371,6 +372,7 @@ impl RunAwsEcs {
             },
             spec: ResourceSpec {
                 depends_on: Some(vec![cluster_resource_name.to_owned()]),
+                conflicts_with: None,
                 agent: Agent {
                     name: "ec2-provider".to_string(),
                     image: self.ec2_provider_image.clone(),

--- a/bottlerocket/testsys/src/run_aws_k8s.rs
+++ b/bottlerocket/testsys/src/run_aws_k8s.rs
@@ -335,6 +335,7 @@ impl RunAwsK8s {
             },
             spec: ResourceSpec {
                 depends_on: None,
+                conflicts_with: None,
                 agent: Agent {
                     name: "eks-provider".to_string(),
                     image: self.cluster_provider_image.clone(),
@@ -404,6 +405,7 @@ impl RunAwsK8s {
             },
             spec: ResourceSpec {
                 depends_on: Some(vec![cluster_resource_name.to_owned()]),
+                conflicts_with: None,
                 agent: Agent {
                     name: "ec2-provider".to_string(),
                     image: self.ec2_provider_image.clone(),

--- a/bottlerocket/testsys/src/run_vmware.rs
+++ b/bottlerocket/testsys/src/run_vmware.rs
@@ -349,6 +349,7 @@ impl RunVmware {
             },
             spec: ResourceSpec {
                 depends_on: None,
+                conflicts_with: None,
                 agent: Agent {
                     name: "vsphere-vm-provider".to_string(),
                     image: self.vm_provider_image.clone(),

--- a/controller/src/resource_controller/mod.rs
+++ b/controller/src/resource_controller/mod.rs
@@ -96,6 +96,13 @@ async fn do_creation_action(r: ResourceInterface, action: CreationAction) -> Res
                 dependency
             );
         }
+        CreationAction::WaitForConflict(conflict) => {
+            debug!(
+                "'{}' is waiting for conflicting resource '{}' to be destroyed",
+                r.name(),
+                conflict
+            );
+        }
         CreationAction::AddResourceFinalizer => {
             let _ = r
                 .resource_client()
@@ -113,6 +120,9 @@ async fn do_creation_action(r: ResourceInterface, action: CreationAction) -> Res
 
 async fn do_destruction_action(r: ResourceInterface, action: DestructionAction) -> Result<()> {
     match action {
+        DestructionAction::StartResourceDeletion => {
+            r.resource_client().delete(r.name()).await?;
+        }
         DestructionAction::RemoveCreationJob => {
             r.remove_job(ResourceAction::Create).await?;
         }

--- a/model/src/resource.rs
+++ b/model/src/resource.rs
@@ -30,6 +30,8 @@ use std::fmt::{Display, Formatter};
 pub struct ResourceSpec {
     /// Other resources that must to be created before this one can be created.
     pub depends_on: Option<Vec<String>>,
+    /// Creation of this resource will not begin until all conflicting resources have been deleted.
+    pub conflicts_with: Option<Vec<String>>,
     /// Information about the resource agent.
     pub agent: Agent,
     /// Whether/when the resource controller will destroy the resource (`OnDeletion` is the
@@ -214,9 +216,10 @@ pub enum DestructionPolicy {
     OnDeletion,
     /// The controller will not delete this resource even when the Kubernetes object is deleted.
     Never,
-    // TODO - support additional destruction policies such as...
-    // OnTestSuccess,
-    // OnTestCompletion,
+    /// The controller will delete this resource when all tests requiring it have passed.
+    OnTestSuccess,
+    /// The controller will delete this resource when all tests requiring it have finished.
+    OnTestCompletion,
 }
 
 impl Default for DestructionPolicy {

--- a/yamlgen/deploy/testsys-crd.yaml
+++ b/yamlgen/deploy/testsys-crd.yaml
@@ -258,6 +258,12 @@ spec:
                     - name
                     - timeout
                   type: object
+                conflictsWith:
+                  description: Creation of this resource will not begin until all conflicting resources have been deleted.
+                  items:
+                    type: string
+                  nullable: true
+                  type: array
                 dependsOn:
                   description: Other resources that must to be created before this one can be created.
                   items:
@@ -270,6 +276,8 @@ spec:
                   enum:
                     - onDeletion
                     - never
+                    - onTestSuccess
+                    - onTestCompletion
                     - "null"
                   nullable: true
                   type: string


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Closes #429 
Closes #428


**Description of changes:**

Adds a new field `conflicts_with` to the `resource` crd. This field allows users to prevent a resource from being created while another resource still exists. 

In order to prevent the user from being required to manually delete the resource, 2 new `DestructionPolicy`s were implemented: `OnTestSuccess` and `OnTestCompletion`. `OnTestSuccess` will delete the resource once all resources depending on it have been deleted and all tests requiring it passed. `OnTestCompletion` will delete the resource once all resources depending on it are deleted and all tests using it have completed regardless of test outcome. 

This significantly reduces the waiting time when testing bottlerocket because instances will be cleaned up as soon as possible and not at the command of the operator.

**Testing done:**

Tested multiple resources requiring the same resource and the resource with `conflicts_with` did not start until the other resources had been deleted.

Tested that resources waiting for depending resources to be deleted before starting their own automatic deletion.

Tested that resources properly delete based on `OnTestSuccess` and `OnTestCompletion`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
