### PR TITLE
Ignore AWS SDK for Rust and smithy-rs in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # For AWS SDK for Rust, ignore all (but one) updates
+      # - dependency-name: "aws-config"
+      - dependency-name: "aws-endpoint"
+      - dependency-name: "aws-http"
+      - dependency-name: "aws-hyper"
+      - dependency-name: "aws-sig*"
+      - dependency-name: "aws-sdk*"
+      - dependency-name: "aws-smithy*"
+      - dependency-name: "aws-types"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,11 +5,13 @@ on:
       - '**.md'
       - 'design/**'
       - 'toos/**'
+      - '.github/dependabot.yml'
   push:
     paths-ignore:
       - '**.md'
       - 'design/**'
       - 'toos/**'
+      - '.github/dependabot.yml'
     branches: [develop]
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,13 +4,13 @@ on:
     paths-ignore:
       - '**.md'
       - 'design/**'
-      - 'toos/**'
+      - 'tools/**'
       - '.github/dependabot.yml'
   push:
     paths-ignore:
       - '**.md'
       - 'design/**'
-      - 'toos/**'
+      - 'tools/**'
       - '.github/dependabot.yml'
     branches: [develop]
 jobs:


### PR DESCRIPTION
**Description of changes:**

Since these dependencies need to be updated in unison, we'll take care of them manually.
`aws-config` was left commented out to provide a single notification that an update has occurred.

Also ignores triggering the **build** workflow when making future changes to `dependabot.yml` and fixes a typo in the same file.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
