### PR TITLE
agents: allow session duration for assumed role

### DIFF
--- a/bottlerocket/agents/src/bin/ecs-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/ecs-test-agent/main.rs
@@ -41,6 +41,7 @@ impl Runner for EcsTestRunner {
             self,
             &self.aws_secret_name,
             &self.config.assume_role,
+            &None,
             &self.config.region,
         )
         .await?;

--- a/bottlerocket/agents/src/bin/migration-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/migration-test-agent/main.rs
@@ -81,6 +81,7 @@ impl test_agent::Runner for MigrationTestRunner {
             self,
             &self.aws_secret_name,
             &self.config.assume_role,
+            &None,
             &Some(self.config.aws_region.clone()),
         )
         .await?;

--- a/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
@@ -72,7 +72,14 @@ impl test_agent::Runner for SonobuoyTestRunner {
     }
 
     async fn run(&mut self) -> Result<TestResults, Self::E> {
-        aws_test_config(self, &self.aws_secret_name, &self.config.assume_role, &None).await?;
+        aws_test_config(
+            self,
+            &self.aws_secret_name,
+            &self.config.assume_role,
+            &None,
+            &None,
+        )
+        .await?;
 
         if let Some(wireguard_secret_name) = &self.wireguard_secret_name {
             // If a wireguard secret is specified, try to set up an wireguard connection with the
@@ -107,7 +114,14 @@ impl test_agent::Runner for SonobuoyTestRunner {
 
     async fn rerun_failed(&mut self, _prev_results: &TestResults) -> Result<TestResults, Self::E> {
         // Set up the aws credentials if they were provided.
-        aws_test_config(self, &self.aws_secret_name, &self.config.assume_role, &None).await?;
+        aws_test_config(
+            self,
+            &self.aws_secret_name,
+            &self.config.assume_role,
+            &None,
+            &None,
+        )
+        .await?;
 
         delete_sonobuoy(TEST_CLUSTER_KUBECONFIG_PATH).await?;
 

--- a/bottlerocket/agents/src/lib.rs
+++ b/bottlerocket/agents/src/lib.rs
@@ -80,6 +80,7 @@ pub async fn aws_test_config<R>(
     runner: &R,
     aws_secret_name: &Option<SecretName>,
     assume_role: &Option<String>,
+    assume_role_session_duration: &Option<i32>,
     region: &Option<String>,
 ) -> Result<SdkConfig, R::E>
 where
@@ -118,6 +119,7 @@ where
             .assume_role()
             .role_arn(role_arn)
             .role_session_name("testsys")
+            .set_duration_seconds(*assume_role_session_duration)
             .send()
             .await
             .context(error::AssumeRoleSnafu { role_arn })?


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Allow configuration of assume role duration for test agents. Some tests may need longer than the 1hr granted by default for assumed roles.

**Testing done:**

Tested and ecs test with assumed role duration changed.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
