### PR TITLE
Bottlerocket Testing Cli

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,7 @@ jobs:
       - run: make duplicator-resource-agent
       - run: make example-resource-agent
       - run: make example-test-agent
+      - run: make example-test-agent-cli
       - run: make integ-test
         env:
           TESTSYS_SELFTEST_SKIP_IMAGE_BUILDS: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
+name = "argh"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e7e4aa7e40747e023c0761dafcb42333a9517575bbf1241747f68dd3177a62"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f2bd7ff6ed6414f4e5521bd509bae46454bbd513801767ced3f21a751ab4bc"
+dependencies = [
+ "argh_shared",
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47253b98986dafc7a3e1cf3259194f1f47ac61abb57a57f46ec09e48d004ecda"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,7 +561,7 @@ dependencies = [
  "resource-agent",
  "serde",
  "serde_json",
- "serde_plain",
+ "serde_plain 1.0.0",
  "sha2",
  "snafu",
  "test-agent",
@@ -549,7 +578,7 @@ version = "0.0.1"
 dependencies = [
  "model",
  "serde",
- "serde_plain",
+ "serde_plain 1.0.0",
 ]
 
 [[package]]
@@ -685,7 +714,7 @@ dependencies = [
  "selftest",
  "serde",
  "serde_json",
- "serde_plain",
+ "serde_plain 1.0.0",
  "terminal_size",
  "tokio",
  "yamlgen",
@@ -1577,7 +1606,7 @@ dependencies = [
  "selftest",
  "serde",
  "serde_json",
- "serde_plain",
+ "serde_plain 1.0.0",
  "serde_yaml",
  "snafu",
  "tabled 0.6.1",
@@ -2389,6 +2418,15 @@ dependencies = [
 
 [[package]]
 name = "serde_plain"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625fb0da2b006092b426a94acc1611bec52f2ec27bb27b266a9f93c29ee38eda"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_plain"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95455e7e29fada2052e72170af226fbe368a4ca33dee847875325d9fdb133858"
@@ -2673,6 +2711,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-agent-cli"
+version = "0.1.0"
+dependencies = [
+ "agent-common",
+ "argh",
+ "assert_cmd",
+ "async-trait",
+ "env_logger",
+ "log",
+ "model",
+ "selftest",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_plain 0.3.0",
+ "snafu",
+ "tar",
+ "tempfile",
+ "test-agent",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "testsys"
 version = "0.0.1"
 dependencies = [
@@ -2690,7 +2752,7 @@ dependencies = [
  "selftest",
  "serde",
  "serde_json",
- "serde_plain",
+ "serde_plain 1.0.0",
  "serde_yaml",
  "snafu",
  "structopt",
@@ -2921,7 +2983,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
- "serde_plain",
+ "serde_plain 1.0.0",
  "snafu",
  "tempfile",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "agent/agent-common",
     "agent/resource-agent",
     "agent/test-agent",
+    "agent/test-agent-cli",
     "bottlerocket/agents",
     "cli",
     "bottlerocket/types",

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ TAG_IMAGES = $(addprefix tag-, $(IMAGES))
 # Store targets to push images
 PUSH_IMAGES = $(addprefix push-, $(IMAGES))
 
-.PHONY: build sdk-openssl example-test-agent example-resource-agent \
+.PHONY: build sdk-openssl example-test-agent example-test-agent-cli example-resource-agent \
 	images fetch integ-test show-variables cargo-deny tools $(IMAGES) \
 	tag-images $(TAG_IMAGES) push-images $(PUSH_IMAGES) print-image-names
 
@@ -86,6 +86,14 @@ example-resource-agent: show-variables fetch
 		--network none \
 		-f agent/resource-agent/examples/example_resource_agent/Dockerfile .
 
+# Build the container image for the example test-agent-cli program
+example-test-agent-cli: show-variables fetch
+	docker build $(DOCKER_BUILD_FLAGS) \
+		--build-arg ARCH="$(TESTSYS_BUILD_HOST_UNAME_ARCH)" \
+		--build-arg BUILDER_IMAGE="$(BUILDER_IMAGE)" \
+		--tag "example-test-agent-cli" \
+		-f agent/test-agent-cli/examples/example_test_agent_cli/Dockerfile .
+
 # Build the container image for the example duplicator resource-agent program
 duplicator-resource-agent: show-variables fetch
 	docker build $(DOCKER_BUILD_FLAGS) \
@@ -143,6 +151,7 @@ integ-test: $(if $(TESTSYS_SELFTEST_SKIP_IMAGE_BUILDS), ,controller example-test
 	$(shell pwd)/bin/download-kind.sh --platform $(TESTSYS_BUILD_HOST_PLATFORM) --goarch ${TESTSYS_BUILD_HOST_GOARCH}
 	docker tag example-test-agent example-test-agent:integ
 	docker tag controller controller:integ
+	docker tag example-test-agent-cli  example-test-agent-cli:integ
 	docker tag duplicator-resource-agent duplicator-resource-agent:integ
 	cargo test --features integ -- --test-threads=$(TESTSYS_SELFTEST_THREADS)
 

--- a/agent/test-agent-cli/Cargo.toml
+++ b/agent/test-agent-cli/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "test-agent-cli"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+argh = "0.1"
+agent-common = { version = "0.0.1", path = "../agent-common" }
+test-agent = { version = "0.0.1", path = "../test-agent" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
+tokio-util = "0.7"
+log = "0.4"
+model = { version = "0.0.1", path = "../../model" }
+snafu = "0.7"
+async-trait = "0.1"
+tempfile = "3"
+serde_json = "1"
+env_logger = "0.9"
+serde_plain = "0.3"
+serde_derive = "1"
+serde = "1"
+tar = "0.4"
+
+[dev-dependencies]
+assert_cmd = "2.0"
+selftest = { version = "0.0.1", path = "../../selftest" }

--- a/agent/test-agent-cli/design/RUNBOOK.md
+++ b/agent/test-agent-cli/design/RUNBOOK.md
@@ -1,0 +1,99 @@
+# Steps to use Test-agent Command Line Interface
+`test-agent-cli` lets you write TestSys test using Bash and help in receiving and sending information from/to the TestSys cluster.
+
+## Prerequisites:
+* kind: https://kind.sigs.k8s.io/docs/user/quick-start/
+* Kubectl: https://kubernetes.io/docs/tasks/tools/
+* Docker : https://docs.docker.com/get-started/
+
+## Steps to install TestSys
+Set the TESTSYS_DIR variable to point to the directory in which you have cloned the project. For example:
+```shell
+export TESTSYS_DIR="${HOME}/repos/bottlerocket-test-system"
+```
+Set alias   
+```shell
+alias cli="${TESTSYS_DIR}/.cargo/bin/cli"
+```
+Install the `cli` command line tool into the local CARGO_HOME as: 
+   ```shell
+   cd "${TESTSYS_DIR}"
+   cargo install --path "${TESTSYS_DIR}/cli" --force
+   ```
+
+## Steps to create Bash based TestAgent:
+
+The following commands can be used to communicate with a TestSys cluster. Create a bash script like [Example test](../examples/example_test_agent_cli/example-test.sh).
+```shell
+# Get the configuration details and set the task state running
+test-agent-cli init
+
+# Get the number of retires allowed in case of failing tests
+test-agent-cli retry-count
+
+# Get the secret value using the secret key
+test-agent-cli get-secret secret-key
+
+# Send the result of every test run to test object in Controller
+test-agent-cli send-result -o pass -p 1 -f 0 -s 0
+
+# Send any error encountered in test
+test-agent-cli send-error error-message
+
+# Mark the test as completed
+test-agent-cli terminate --results-dir results_directory
+```
+Create a [Dockerfile](../examples/example_test_agent_cli/Dockerfile).\
+Remember to set the ENTRYPOINT to the test Bash script and install the required packages.
+
+Create the docker image.\
+**Note**: Add a target to the `Makefile` to create the new image.  
+   ```shell 
+   make example-test-agent-cli 
+   docker image tag example-test-agent-cli example-test-agent-cli:bash
+   ```
+
+Create and tag the controller image.
+   ```shell
+   make controller 
+   docker image tag controller controller:bash
+   ```
+
+## Steps to use Bash based TestAgent:
+
+Check if the cluster already exists: 
+   ```shell
+   kind get clusters
+   ```
+If the cluster already exists, it should be deleted.
+   ```shell
+   kind delete cluster --name <testsys_cluster_name>
+   ```
+Create the new cluster.
+   ```shell
+   kind create cluster --name <testsys_cluster_name>
+   ``` 
+Now the images created earlier need to be added to the cluster.
+   ```shell
+   kind load docker-image controller:bash example-test-agent-cli:bash --name <testsys_cluster_name>
+   ```
+Install TestSys to the cluster.  
+   ```shell
+   cli install --controller-uri controller:bash 
+   ```
+
+Create a [yaml file](../tests/data/deploy_test.yaml) for Test.
+
+Run the test.
+   ```shell
+   cli run file <filename>
+   ```
+Check the status of the test.
+   ```shell
+   cli status -c
+   ```
+Cleanup all the resources.
+   ```shell
+   cli delete
+   ```
+

--- a/agent/test-agent-cli/examples/example_test_agent_cli/Dockerfile
+++ b/agent/test-agent-cli/examples/example_test_agent_cli/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1.1.3-experimental
+ARG BUILDER_IMAGE
+FROM ${BUILDER_IMAGE} as build
+
+ARG ARCH
+USER root
+# We need these environment variables set for building the `openssl-sys` crate
+ENV PKG_CONFIG_PATH=/${ARCH}-bottlerocket-linux-musl/sys-root/usr/lib/pkgconfig
+ENV PKG_CONFIG_ALLOW_CROSS=1
+ENV CARGO_HOME=/src/.cargo
+ENV OPENSSL_STATIC=true
+ENV CARGO_HOME=/src/.cargo
+ADD ./ /src/
+WORKDIR /src/agent/test-agent-cli
+RUN --mount=type=cache,mode=0777,target=/src/target \
+    cargo install --locked --offline --target ${ARCH}-bottlerocket-linux-musl --path .  --root ./
+
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+# Install all the required packages for Bash test script.
+RUN yum update -y \
+    && yum install -y jq \
+    && yum clean all
+
+COPY --from=build /src/agent/test-agent-cli/bin/test-agent-cli /usr/local/bin/
+# Copy the Bash test script
+COPY --from=build /src/agent/test-agent-cli/examples/example_test_agent_cli/example-test.sh ./
+
+# Mark the test script as entry point
+ENTRYPOINT ["/bin/bash", "./example-test.sh"]
+

--- a/agent/test-agent-cli/examples/example_test_agent_cli/example-test.sh
+++ b/agent/test-agent-cli/examples/example_test_agent_cli/example-test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# The config structure is as follows:
+#   person: String
+#   helloCount: Integer
+#   helloDurationMilliseconds: Integer
+
+# Store the configuration details in a JSON file and mark the test as Running
+test-agent-cli init > ExampleConfig.json
+
+echo "starting the Example test"
+
+person=$(jq '.person' ExampleConfig.json)
+helloCount=$(jq '.helloCount' ExampleConfig.json)
+helloDurationMilliseconds=$(jq '.helloDurationMilliseconds' ExampleConfig.json)
+
+echo "${person}"
+echo "${helloDurationMilliseconds}"
+echo "${helloCount}"
+
+# Get the number of retries allowed in case of a failing test
+retries=$(test-agent-cli retry-count)
+echo "no of retries are $retries"
+
+# Get the secret for a key
+secret=$(test-agent-cli get-secret key1)
+echo "Value for secret is $secret"
+
+# Perform the test with this bash script.
+test () {
+    for ((i = 1; i <= helloCount; i++))
+    do
+        echo "Hello ${i} to ${person}"
+        sleep "${helloDurationMilliseconds}"
+    done
+}
+
+# Retry the test in case of failure
+if ! test && [ "$retries" -gt 0 ]; then
+    for ((i = 1; i <= "$retries"; i ++))
+    do
+        echo "Test failed again, retrying ${i} of $retries"
+        # Send the test results for this retry.
+        test-agent-cli send-result -o fail -p 0 -f 1 -s 0
+
+        if test; then
+            break
+        fi
+    done
+fi
+
+# Send the test results after consuming all the retries
+test-agent-cli send-result -o pass -p 1 -f 0 -s 0
+
+# Mark the test as completed.
+test-agent-cli terminate --results-dir results_directory
+

--- a/agent/test-agent-cli/src/error.rs
+++ b/agent/test-agent-cli/src/error.rs
@@ -1,0 +1,33 @@
+use snafu::Snafu;
+use std::string::FromUtf8Error;
+
+/// The crate-wide result type.
+pub(crate) type Result<T> = std::result::Result<T, Error>;
+
+/// The crate-wide error type.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub(crate) enum Error {
+    #[snafu(display("An error occured while creating archive: {}", source))]
+    Archive { source: std::io::Error },
+
+    #[snafu(display("Unable to communicate with Kuberenetes: {}", source))]
+    Client { source: test_agent::ClientError },
+
+    #[snafu(display("Configuration missing from the test secret data"))]
+    ConfMissing,
+
+    #[snafu(display("Could not convert {} secret to string: {}", what, source))]
+    Conversion { what: String, source: FromUtf8Error },
+
+    #[snafu(display("Could not serialize object: {}", source))]
+    JsonSerialize { source: serde_json::Error },
+
+    #[snafu(display("Unable to get secret name for key '{}'", key))]
+    SecretKeyFetch { key: String },
+
+    #[snafu(display("Unable to get secret '{}'", source))]
+    SecretMissing {
+        source: agent_common::secrets::Error,
+    },
+}

--- a/agent/test-agent-cli/src/get_secret.rs
+++ b/agent/test-agent-cli/src/get_secret.rs
@@ -1,0 +1,49 @@
+use crate::error::{
+    ClientSnafu, ConfMissingSnafu, ConversionSnafu, Result, SecretKeyFetchSnafu, SecretMissingSnafu,
+};
+use crate::init::TestConfig;
+use agent_common::secrets::SecretsReader;
+use argh::FromArgs;
+use snafu::{OptionExt, ResultExt};
+use test_agent::{Client, DefaultClient, Spec};
+
+#[derive(Debug, FromArgs, PartialEq)]
+#[argh(subcommand, name = "get-secret", description = "Get secret for a key")]
+pub(crate) struct GetSecret {
+    #[argh(
+        positional,
+        short = 'k',
+        description = "secret key whose value you like to get"
+    )]
+    secret_key: String,
+}
+
+impl GetSecret {
+    pub(crate) async fn run(&self, k8s_client: DefaultClient) -> Result<()> {
+        let spec: Spec<TestConfig> = k8s_client.spec().await.context(ClientSnafu)?;
+        let secret_name = spec
+            .secrets
+            .get(&self.secret_key)
+            .context(SecretKeyFetchSnafu {
+                key: &self.secret_key,
+            })?;
+
+        let secrets_reader = SecretsReader::new();
+        let secret_data = secrets_reader
+            .get_secret(secret_name)
+            .context(SecretMissingSnafu)?;
+
+        let secret = String::from_utf8(
+            secret_data
+                .get(secret_name.as_str())
+                .context(ConfMissingSnafu)?
+                .to_owned(),
+        )
+        .context(ConversionSnafu {
+            what: "secret_name",
+        })?;
+
+        println!("{:#?}", secret);
+        Ok(())
+    }
+}

--- a/agent/test-agent-cli/src/init.rs
+++ b/agent/test-agent-cli/src/init.rs
@@ -1,0 +1,37 @@
+use crate::error::{ClientSnafu, JsonSerializeSnafu, Result};
+use argh::FromArgs;
+use model::Configuration;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use snafu::ResultExt;
+use test_agent::{Client, DefaultClient, Spec};
+
+#[derive(Debug, FromArgs, PartialEq)]
+#[argh(
+    subcommand,
+    name = "init",
+    description = "set task_state running and get the configuration details required for test"
+)]
+pub(crate) struct Init {}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TestConfig {
+    #[serde(flatten)]
+    config: Map<String, Value>,
+}
+
+impl Configuration for TestConfig {}
+
+impl Init {
+    pub(crate) async fn run(&self, k8s_client: DefaultClient) -> Result<()> {
+        k8s_client.send_test_starting().await.context(ClientSnafu)?;
+        let spec: Spec<TestConfig> = k8s_client.spec().await.context(ClientSnafu)?;
+
+        println!(
+            "{}",
+            serde_json::to_string(&spec.configuration).context(JsonSerializeSnafu)?
+        );
+        Ok(())
+    }
+}

--- a/agent/test-agent-cli/src/main.rs
+++ b/agent/test-agent-cli/src/main.rs
@@ -1,0 +1,88 @@
+mod error;
+mod get_secret;
+mod init;
+mod retry_count;
+mod send_results;
+mod terminate;
+mod test_error;
+
+use argh::FromArgs;
+use env_logger::Builder;
+use error::Result;
+use log::LevelFilter;
+use snafu::ResultExt;
+use test_agent::BootstrapData;
+use test_agent::{Client, DefaultClient};
+
+#[derive(FromArgs)]
+/// The command line interface help in receiving and sending information from/to the Testsys cluster for Bash test scripts.
+struct Args {
+    /// set logging verbosity [trace|debug|info|warn|error]. If the environment variable `RUST_LOG`
+    /// is present, it overrides the default logging behavior. See https://docs.rs/env_logger/latest
+    #[argh(option, default = "LevelFilter::Info")]
+    log_level: LevelFilter,
+
+    #[argh(subcommand)]
+    command: Command,
+}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand)]
+enum Command {
+    /// Get secret value for a key
+    GetSecret(get_secret::GetSecret),
+    /// Set the Task state running, return config details
+    Init(init::Init),
+    /// Get number of retries allowed
+    RetryCount(retry_count::RetryCount),
+    /// Send test results
+    SendResults(send_results::SendResults),
+    /// Mark Task state complete, handle keep running, save all results to a tar archive.
+    Terminate(terminate::Terminate),
+    /// Send any error encountered
+    TestError(test_error::TestError),
+}
+
+#[tokio::main]
+async fn main() {
+    let args: Args = argh::from_env();
+    init_logger(args.log_level);
+    if let Err(e) = run(args).await {
+        eprintln!("{:?}", e);
+        std::process::exit(1);
+    }
+}
+
+async fn run(args: Args) -> Result<()> {
+    let bootstrap_data = BootstrapData::from_env().unwrap();
+    let client = DefaultClient::new(bootstrap_data)
+        .await
+        .context(error::ClientSnafu)?;
+
+    match args.command {
+        Command::GetSecret(get_secret) => get_secret.run(client).await,
+        Command::Init(init) => init.run(client).await,
+        Command::RetryCount(retry_count) => retry_count.run(client).await,
+        Command::SendResults(send_results) => send_results.run(client).await,
+        Command::Terminate(terminate) => terminate.run(client).await,
+        Command::TestError(test_error) => test_error.run(client).await,
+    }
+}
+
+/// Initialize the logger with the value passed by `--log-level` (or its default) when the
+/// `RUST_LOG` environment variable is not present. If present, the `RUST_LOG` environment variable
+/// overrides `--log-level`/`level`.
+fn init_logger(level: LevelFilter) {
+    match std::env::var(env_logger::DEFAULT_FILTER_ENV).ok() {
+        Some(_) => {
+            // RUST_LOG exists; env_logger will use it.
+            Builder::from_default_env().init();
+        }
+        None => {
+            // RUST_LOG does not exist; use default log level for this crate only.
+            Builder::new()
+                .filter(Some(env!("CARGO_CRATE_NAME")), level)
+                .init();
+        }
+    }
+}

--- a/agent/test-agent-cli/src/retry_count.rs
+++ b/agent/test-agent-cli/src/retry_count.rs
@@ -1,0 +1,20 @@
+use crate::error::{ClientSnafu, Result};
+use argh::FromArgs;
+use snafu::ResultExt;
+use test_agent::{Client, DefaultClient};
+
+#[derive(Debug, FromArgs, PartialEq)]
+#[argh(
+    subcommand,
+    name = "retry-count",
+    description = "Number of retries allowed in case of failing test"
+)]
+pub(crate) struct RetryCount {}
+
+impl RetryCount {
+    pub(crate) async fn run(&self, k8s_client: DefaultClient) -> Result<()> {
+        let retries = k8s_client.retries().await.context(ClientSnafu)?;
+        println!("{}", &retries);
+        Ok(())
+    }
+}

--- a/agent/test-agent-cli/src/send_results.rs
+++ b/agent/test-agent-cli/src/send_results.rs
@@ -1,0 +1,46 @@
+use crate::error::{ClientSnafu, Result};
+use argh::FromArgs;
+use model::{Outcome, TestResults};
+use snafu::ResultExt;
+use test_agent::{Client, DefaultClient};
+
+#[derive(Debug, FromArgs, PartialEq)]
+#[argh(
+    subcommand,
+    name = "send-result",
+    description = "send test result for every rerun"
+)]
+pub(crate) struct SendResults {
+    #[argh(
+        short = 'o',
+        option,
+        description = "outcome of result as in pass/fail/timeout/unknown"
+    )]
+    outcome: String,
+    #[argh(short = 'p', option, description = "number of passed test cases")]
+    passed: u64,
+    #[argh(short = 'f', option, description = "number of failed test cases")]
+    failed: u64,
+    #[argh(short = 's', option, description = "number of skipped test cases")]
+    skipped: u64,
+    #[argh(option, description = "additional result information")]
+    other_info: Option<String>,
+}
+
+impl SendResults {
+    pub(crate) async fn run(&self, k8s_client: DefaultClient) -> Result<()> {
+        let outcome: Outcome = serde_plain::from_str::<Outcome>(&self.outcome).unwrap();
+        let test_results = TestResults {
+            outcome,
+            num_passed: self.passed,
+            num_failed: self.failed,
+            num_skipped: self.skipped,
+            other_info: self.other_info.clone(),
+        };
+        k8s_client
+            .send_test_results(test_results)
+            .await
+            .context(ClientSnafu)?;
+        Ok(())
+    }
+}

--- a/agent/test-agent-cli/src/terminate.rs
+++ b/agent/test-agent-cli/src/terminate.rs
@@ -1,0 +1,73 @@
+use crate::error::{self, ArchiveSnafu, ClientSnafu, Result};
+use argh::FromArgs;
+use log::{error, info};
+use snafu::ResultExt;
+use std::fs;
+use std::fs::File;
+use std::path::PathBuf;
+use std::time::Duration;
+use tar::Builder;
+use test_agent::{Client, DefaultClient};
+use tokio::time::sleep;
+
+#[derive(Debug, FromArgs, PartialEq)]
+#[argh(subcommand, name = "terminate", description = "complete the test")]
+pub(crate) struct Terminate {
+    #[argh(short = 'd', option, description = "results directory")]
+    results_dir: String,
+}
+
+impl Terminate {
+    pub(crate) async fn run(&self, k8s_client: DefaultClient) -> Result<()> {
+        // Wrap all the test results in a tar archive
+        self.tar_results(&k8s_client).await?;
+
+        // Mark task_status as complete, in either condition: Test results sent or not.
+        // Resource status will be marked as "noTests" in case of no test results
+        k8s_client
+            .send_test_completed()
+            .await
+            .context(ClientSnafu)?;
+
+        self.loop_while_keep_running_is_true(&k8s_client).await;
+
+        Ok(())
+    }
+
+    async fn loop_while_keep_running_is_true(&self, k8s_client: &DefaultClient) {
+        info!("Waiting for keep running flag");
+        loop {
+            sleep(Duration::from_secs(10)).await;
+            if !self.keep_running(k8s_client).await {
+                info!("'keep_running' has been set to false, exiting.");
+                return;
+            }
+        }
+    }
+
+    async fn keep_running(&self, k8s_client: &DefaultClient) -> bool {
+        match k8s_client.keep_running().await {
+            Err(e) => {
+                error!("Unable to communicate with Kuberenetes: '{}'", e);
+                // If we can't communicate Kubernetes, its safest to
+                // stay running in case some debugging is needed.
+                true
+            }
+            Ok(value) => value,
+        }
+    }
+
+    async fn tar_results(&self, k8s_client: &DefaultClient) -> Result<()> {
+        fs::create_dir_all("/".to_owned() + &self.results_dir).context(ArchiveSnafu)?;
+        let results_dir = PathBuf::from(r"/".to_owned() + &self.results_dir);
+        let tar = File::create(k8s_client.results_file().await.context(ClientSnafu)?)
+            .context(ArchiveSnafu)?;
+
+        let mut archive = Builder::new(tar);
+        archive
+            .append_dir_all("test-results", results_dir)
+            .context(error::ArchiveSnafu)?;
+        archive.into_inner().context(error::ArchiveSnafu)?;
+        Ok(())
+    }
+}

--- a/agent/test-agent-cli/src/test_error.rs
+++ b/agent/test-agent-cli/src/test_error.rs
@@ -1,0 +1,25 @@
+use crate::error::{ClientSnafu, Result};
+use argh::FromArgs;
+use snafu::ResultExt;
+use test_agent::{Client, DefaultClient};
+
+#[derive(Debug, FromArgs, PartialEq)]
+#[argh(
+    subcommand,
+    name = "send-error",
+    description = "send error encountered"
+)]
+pub(crate) struct TestError {
+    #[argh(positional, description = "error message")]
+    error: String,
+}
+
+impl TestError {
+    pub(crate) async fn run(&self, k8s_client: DefaultClient) -> Result<()> {
+        k8s_client
+            .send_error(&self.error)
+            .await
+            .context(ClientSnafu)?;
+        Ok(())
+    }
+}

--- a/agent/test-agent-cli/tests/cli_test.rs
+++ b/agent/test-agent-cli/tests/cli_test.rs
@@ -1,0 +1,75 @@
+#![cfg(feature = "integ")]
+mod data;
+use assert_cmd::Command;
+use model::{constants::NAMESPACE, Test};
+use selftest::Cluster;
+use tokio::time::Duration;
+
+const POD_TIMEOUT: Duration = Duration::from_secs(300);
+#[tokio::test]
+async fn test_system() {
+    let cluster_name = "integ-test";
+    let cluster = Cluster::new(cluster_name).unwrap();
+    cluster.load_image_to_cluster("controller:integ").unwrap();
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "install",
+        "--controller-uri",
+        "controller:integ",
+    ]);
+    cmd.assert().success();
+    cluster.wait_for_controller(POD_TIMEOUT).await.unwrap();
+
+    cluster
+        .load_image_to_cluster("example-test-agent-cli:integ")
+        .unwrap();
+
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "run",
+        "file",
+        data::integ_test_dependent_path().to_str().unwrap(),
+    ]);
+    cmd.assert().success();
+
+    cluster
+        .wait_for_test_pod("hello-world-cli", POD_TIMEOUT)
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_secs(15)).await;
+
+    let mut cmd = Command::cargo_bin("testsys").unwrap();
+    cmd.args(&[
+        "--kubeconfig",
+        cluster.kubeconfig().to_str().unwrap(),
+        "status",
+        "-c",
+        "-r",
+        "--json",
+    ]);
+
+    let parse: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&cmd.output().unwrap().stdout)).unwrap();
+
+    assert_eq!(
+        parse
+            .get("results")
+            .unwrap()
+            .get(1)
+            .unwrap()
+            .get("state")
+            .unwrap(),
+        &"passed"
+    );
+
+    cluster.delete_test("hello-world-cli").await.unwrap();
+    cluster
+        .wait_for_deletion::<Test>("hello-world-cli", Some(NAMESPACE), POD_TIMEOUT)
+        .await
+        .unwrap();
+}

--- a/agent/test-agent-cli/tests/data.rs
+++ b/agent/test-agent-cli/tests/data.rs
@@ -1,0 +1,9 @@
+#![allow(unused)]
+
+use std::path::PathBuf;
+
+pub fn integ_test_dependent_path() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.join("test-agent-cli/tests/data/deploy_test.yaml")
+}

--- a/agent/test-agent-cli/tests/data/deploy_test.yaml
+++ b/agent/test-agent-cli/tests/data/deploy_test.yaml
@@ -1,0 +1,18 @@
+apiVersion: testsys.bottlerocket.aws/v1
+kind: Test
+metadata:
+  name: hello-world-cli
+  namespace: testsys-bottlerocket-aws
+spec:
+  retries: 5
+  agent:
+    name: hello-agent-cli
+    image: example-test-agent-cli:integ
+    keepRunning: false
+    configuration:
+      mode: Fast
+      person: Bones the Cat
+      helloCount: 1
+      helloDurationMilliseconds: 2
+  resources: []
+  dependsOn: []

--- a/agent/test-agent/src/k8s_client.rs
+++ b/agent/test-agent/src/k8s_client.rs
@@ -95,6 +95,14 @@ impl Client for DefaultClient {
         Ok(())
     }
 
+    async fn send_test_completed(&self) -> Result<(), Self::E> {
+        self.client
+            .send_agent_task_state(&self.name, TaskState::Completed)
+            .await
+            .context(K8sSnafu)?;
+        Ok(())
+    }
+
     async fn send_test_results(&self, results: TestResults) -> Result<(), Self::E> {
         self.client
             .send_test_results(&self.name, results)

--- a/agent/test-agent/src/lib.rs
+++ b/agent/test-agent/src/lib.rs
@@ -135,6 +135,9 @@ pub trait Client: Sized {
     async fn send_error<E>(&self, error: E) -> Result<(), Self::E>
     where
         E: Debug + Display + Send + Sync;
+
+    /// Set the task state as `Completed` indicating that no more retries or testing will occur.
+    async fn send_test_completed(&self) -> Result<(), Self::E>;
 }
 
 /// Provides the default [`Client`] implementation.

--- a/agent/test-agent/tests/mock.rs
+++ b/agent/test-agent/tests/mock.rs
@@ -131,6 +131,11 @@ impl Client for MockClient {
     async fn retries(&self) -> Result<u32, Self::E> {
         Ok(0)
     }
+
+    async fn send_test_completed(&self) -> Result<(), Self::E> {
+        println!("MockClient::send_test_completed");
+        Ok(())
+    }
 }
 
 /// This test runs [`MyRunner`] inside a [`TestAgent`] with k8s and the container environment mocked

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -80,6 +80,8 @@ For example, we have created a [test agent which uses Sonobuoy] to test the Kube
 
 [test agent which uses Sonobuoy]: https://github.com/bottlerocket-os/bottlerocket-test-system/tree/develop/bottlerocket-agents/src/bin/sonobuoy-test-agent
 
+Test agents can also be created using [bash scripts](../agent/test-agent-cli/examples/example_test_agent_cli/example-test.sh).
+
 **[TestAgent Library]**:
 
 A Rust library (using [kube-rs]) that is provided for writing TestAgents.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->
**Description of changes:**
 A CLI that can help in writing test case using Bash Script(This CLI takes care of all the interaction with Kubernetes Cluster). This CLI contains following commands
- [x] test-agent-cli get config
- [x] test-agent-cli get retries
- [x] test-agent-cli get secret 
- [x] test-agent-cli send test start
- [x] test-agent-cli send test done
- [x] test-agent-cli send result --outcome Pass --passed 1 --failed 0 --skipped 0
- [x] test-agent-cli send test error -e 'Some error occurred'

**Testing done:**

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.


