### PR TITLE
Truncate resource name and append object UID

### DIFF
--- a/controller/src/resource_controller/context.rs
+++ b/controller/src/resource_controller/context.rs
@@ -41,8 +41,16 @@ pub(super) struct ResourceInterface {
 
 impl ResourceInterface {
     pub(super) fn new(resource: Resource, context: Context) -> Result<Self> {
-        let creation_job = format!("{}-creation", resource.object_name());
-        let destruction_job = format!("{}-destruction", resource.object_name());
+        let mut resource_name = resource.object_name().to_string();
+
+        // Selects the UID from the k8s object to append to the truncated job name, preventing duplicate job names
+        let id = match resource.metadata.uid.as_ref() {
+            Some(r) => r,
+            None => "",
+        };
+        resource_name.truncate(15);
+        let creation_job = format!("{}{}-creation", resource_name, id);
+        let destruction_job = format!("{}{}-destruction", resource_name, id);
         Ok(Self {
             resource,
             context,

--- a/controller/src/resource_controller/context.rs
+++ b/controller/src/resource_controller/context.rs
@@ -4,7 +4,7 @@ use anyhow::Context as AnyhowContext;
 use kube::Api;
 use log::debug;
 use model::clients::{CrdClient, ResourceClient};
-use model::constants::{ENV_RESOURCE_ACTION, ENV_RESOURCE_NAME};
+use model::constants::{ENV_RESOURCE_ACTION, ENV_RESOURCE_NAME, TRUNC_LEN};
 use model::{CrdExt, Resource, ResourceAction};
 use std::sync::Arc;
 
@@ -48,7 +48,9 @@ impl ResourceInterface {
             Some(r) => r,
             None => "",
         };
-        resource_name.truncate(15);
+        // Truncates the resource name down to TRUNC_LEN so that the truncated name + 36-character UID is at most 51 characters long
+        // This ensures that the new name with the -creation or -destruction suffix is within the k8s-enforced 63-character limit
+        resource_name.truncate(TRUNC_LEN);
         let creation_job = format!("{}{}-creation", resource_name, id);
         let destruction_job = format!("{}{}-destruction", resource_name, id);
         Ok(Self {

--- a/model/src/constants.rs
+++ b/model/src/constants.rs
@@ -57,6 +57,9 @@ pub const FINALIZER_TEST_JOB: &str = testsys!("test-job");
 
 pub const TESTSYS_RESULTS_FILE: &str = "/output.tar.gz";
 
+// Used by the controller to truncate resource names
+pub const TRUNC_LEN: usize = 15;
+
 #[test]
 fn testsys_constants_macro_test() {
     assert_eq!("testsys.bottlerocket.aws", testsys!());

--- a/selftest/src/cluster.rs
+++ b/selftest/src/cluster.rs
@@ -8,7 +8,7 @@ use kube::{
     Api, Client, Config,
 };
 use model::clients::{HttpStatusCode, StatusCode};
-use model::constants::{LABEL_COMPONENT, LABEL_PROVIDER_NAME, NAMESPACE};
+use model::constants::{LABEL_COMPONENT, LABEL_PROVIDER_NAME, NAMESPACE, TRUNC_LEN};
 use model::{Resource, Test};
 use std::fmt::Debug;
 use std::{convert::TryInto, fs::File};
@@ -371,7 +371,7 @@ impl Cluster {
         let resource = resource_api.get(name).await?;
         let pods = pod_api.list(&ListParams::default()).await?.items;
         let mut truncated_name = name.to_string();
-        truncated_name.truncate(15);
+        truncated_name.truncate(TRUNC_LEN);
         for pod in pods {
             if pod.metadata.name.unwrap_or_default().starts_with(&format!(
                 "{}{}-destruction",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #353 

**Description of changes:**

Instead of simply appending -creation and -destruction to the resource name to generate the job names, the object UID created by k8s is now appended to a truncated resource name. This ensures that every creation- and destruction-job has a unique name, even if the resource names contain the same first 51 or more characters. Since the resource name gets truncated down to 15 characters, the situation where a destruction pod cannot be created because the name is too long will never occur.

The does_resource_destruction_pod_exist test in cluster.rs has been changed to reflect the new destruction pod naming scheme.

**Testing done:**

- Ran testsys with a test YAML file that depends on one resource with a name shorter than 51 characters
- Ran testsys with a test YAML file that depends on one resource with a name between 51 characters and 54 characters
- Ran testsys with a test YAML file that depends on one resource with a name longer than 54 characters
- Ran testsys with a test YAML file that depends on two resources with names longer than 51 characters, where the first 51 characters are the same
- Checked that all of the above resources could be created and deleted successfully, and the test passed

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
