### PR TITLE
Add Eq trait to model structs

### DIFF
--- a/bottlerocket/agents/src/bin/eks-resource-agent/eks_provider.rs
+++ b/bottlerocket/agents/src/bin/eks-resource-agent/eks_provider.rs
@@ -240,12 +240,13 @@ async fn is_cluster_creation_required(
                     )
                 )
             ),
-        CreationPolicy::Never if !cluster_exists => return Err(
-            ProviderError::new_with_context(
-                Resources::Clear, format!(
-                    "The cluster '{}' does not exist and creation policy '{:?}' requires that it exist",
-                    cluster_name,
-                    creation_policy
+        CreationPolicy::Never if !cluster_exists =>
+            Err(
+                ProviderError::new_with_context(
+                    Resources::Clear, format!(
+                        "The cluster '{}' does not exist and creation policy '{:?}' requires that it exist",
+                        cluster_name,
+                        creation_policy
                 )
             )
         ),

--- a/model/src/resource.rs
+++ b/model/src/resource.rs
@@ -11,7 +11,9 @@ use std::fmt::{Display, Formatter};
 /// A resource required by a test. For example, a compute instance or cluster. The `CustomResource`
 /// derive also produces a struct named `Resource` which represents a resource CRD object in the k8s
 /// API.
-#[derive(Clone, CustomResource, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, CustomResource, Debug, Default, Deserialize, JsonSchema, PartialEq, Eq, Serialize,
+)]
 #[kube(
     derive = "Default",
     derive = "PartialEq",

--- a/model/src/test.rs
+++ b/model/src/test.rs
@@ -9,7 +9,9 @@ use std::borrow::Cow;
 
 /// A TestSys Test. The `CustomResource` derive also produces a struct named `Test` which represents
 /// a test CRD object in the k8s API.
-#[derive(Clone, CustomResource, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, CustomResource, Debug, Default, Deserialize, JsonSchema, PartialEq, Eq, Serialize,
+)]
 #[kube(
     derive = "Default",
     derive = "PartialEq",


### PR DESCRIPTION
**Issue number:**

Closes: #501 

**Description of changes:**

With the update to the latest ructc release (1.63.0) there was a new
error introduced when running clippy checks. We had a couple structs in
our model that had the `PartialEq` trait, but could also have `Eq` since
all of their members supported `Eq`.

This updates the two structs with the `Eq` trait. Once past that error
there was also a new error about an unnecessary use of `return`. So this
removes that statement and reformats that section of code to be
consistent with the similar code block above it.

**Testing done:**

Ran `cargo clippy --locked -- -D warnings` like we do in CI and verified it no longer returns an error.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
