### PR TITLE
Explicitly set rust version for CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v3
-      - run: rustup update stable
+      - run: rustup default 1.61.0
       - run: make build
         # If we forget to add yamlgen changes to our commits, this will fail.
       - name: ensure that git is clean
@@ -41,5 +41,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: rustup update stable
+      - run: rustup default 1.61.0
       - run: make cargo-deny


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This sets our rust version to 1.61.0 in our GitHub Action definition to
match what is being done in the main bottlerocket repo. This prevents
new releases of rust from potentially breaking our builds without
warning.

**Testing done:**

Visual inspection and results for this PR from the GitHub Action running.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
