### PR TITLE
Removes node affinity for x86. Enables arm building/running.

### DIFF
--- a/model/src/system/controller.rs
+++ b/model/src/system/controller.rs
@@ -195,20 +195,11 @@ pub fn controller_deployment(
                             required_during_scheduling_ignored_during_execution: Some(
                                 NodeSelector {
                                     node_selector_terms: vec![NodeSelectorTerm {
-                                        match_expressions: Some(vec![
-                                            NodeSelectorRequirement {
-                                                key: "kubernetes.io/os".to_string(),
-                                                operator: "In".to_string(),
-                                                values: Some(vec!["linux".to_string()]),
-                                            },
-                                            NodeSelectorRequirement {
-                                                key: "kubernetes.io/arch".to_string(),
-                                                operator: "In".to_string(),
-                                                // TODO make sure the pod works on arm64 before adding arm64 here.
-                                                // https://github.com/bottlerocket-os/bottlerocket-test-system/issues/90
-                                                values: Some(vec!["amd64".to_string()]),
-                                            },
-                                        ]),
+                                        match_expressions: Some(vec![NodeSelectorRequirement {
+                                            key: "kubernetes.io/os".to_string(),
+                                            operator: "In".to_string(),
+                                            values: Some(vec!["linux".to_string()]),
+                                        }]),
                                         ..Default::default()
                                     }],
                                 },

--- a/yamlgen/deploy/testsys-controller.yaml
+++ b/yamlgen/deploy/testsys-controller.yaml
@@ -121,10 +121,6 @@ spec:
                     operator: In
                     values:
                       - linux
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
       containers:
         - image: "6456745674567.dkr.ecr.us-west-2.amazonaws.com/controller:v0.1.2"
           name: controller


### PR DESCRIPTION
### Issue number:

Fixes #90 

### Description of changes:

This removes the node affinity for x86 kubernetes nodes. All images are currently buildable on 

Validated images are buildable and can be run on aarch64 dev box.

### Testing done:

Prior to this change, tests would not be scheduled on local kind clusters on an aarch64 dev-box.

Now, all images are buildable and `make integ-test` passes. I was a bit surprised this was the only change that needed to be made since most of the image infrastructure / docker commands were already in place, so if there are more validations to be done, let me know!!

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
