### PR TITLE
Controller logs

### DIFF
--- a/cli/src/logs.rs
+++ b/cli/src/logs.rs
@@ -37,19 +37,19 @@ impl Logs {
             (Some(test), None, None, false ) => {
                 let mut logs = client.test_logs(test, self.follow).await.context("Unable to get logs.")?;
                 while let Some(line) = logs.next().await {
-                    println!("{:#?}", line.context("Unable to read line")?);
+                    print!("{}", String::from_utf8_lossy(&line.context("Unable to read line")?));
                 }
             }
             (None, Some(resource), Some(state), false) => {
                 let mut logs = client.resource_logs(resource, state, self.follow).await.context("Unable to get logs.")?;
                 while let Some(line) = logs.next().await {
-                    println!("{:#?}", line.context("Unable to read line")?);
+                    print!("{}", String::from_utf8_lossy(&line.context("Unable to read line")?));
                 }
             }
             (None, None, None, true) => {
                 let mut logs = client.controller_logs(self.follow).await.context("Unable to get logs.")?;
                 while let Some(line) = logs.next().await {
-                    println!("{:#?}", line.context("Unable to read line")?);
+                    print!("{}", String::from_utf8_lossy(&line.context("Unable to read line")?));
                 }
             }
             _ => return Err(Error::msg("Invalid arguments were provided. Exactly one of `--test`, `--resource`, and `--controller` must be used.")),

--- a/model/src/test_manager/manager.rs
+++ b/model/src/test_manager/manager.rs
@@ -385,6 +385,26 @@ impl TestManager {
             })
     }
 
+    /// Retrieve the logs of the controller.
+    pub async fn controller_logs(
+        &self,
+        follow: bool,
+    ) -> Result<impl Stream<Item = core::result::Result<Bytes, Error>>> {
+        let pod_api: Api<Pod> = self.namespaced_api();
+        let pod = self.controller_pod().await?;
+        let log_params = LogParams {
+            follow,
+            pretty: true,
+            ..Default::default()
+        };
+        pod_api
+            .log_stream(&pod.name(), &log_params)
+            .await
+            .context(error::KubeSnafu {
+                action: "stream logs",
+            })
+    }
+
     /// Write the results from a testsys `Test` to a given `destination`. The results are in the
     /// form of a tarball containing all files placed in the test agents output directory.
     pub async fn write_test_results(&self, test_name: &str, destination: &Path) -> Result<()> {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #504 

**Description of changes:**

This adds a `--controller` subcommand to the `cli logs` command. This subcommand retrieves the controller logs from Kubernetes that the developer would normally have to access through a `kubectl` command. The controller logs are very useful for debugging events that happen on the cluster. The format of the logs was also changed to be more easily readable by humans. Previously, they were printed as byte-strings with `\n` simply part of the string. Now, the `\n` characters are correctly interpreted and every log line is actually printed on a new line.

**Testing done:**

- Ran a `ctl logs --controller` command, which shows the same logs as printed by the `kubectl logs <controller-pod-name>` command
- Tried a `ctl logs --controller --test <test-name>` command, which correctly shows an error message
- Tried a `ctl logs --controller --resource <resource-name>` command, which correctly shows an error message

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
