### PR TITLE
CI: Skip some tasks on push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,8 @@ jobs:
   license-check:
     # A small machine is OK for this independent job.
     runs-on: ubuntu-latest
+    # If we already checked the PR, we don't need to check the actual push
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v3
       - run: rustup default 1.61.0


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Several of our CI tests run on both pull_request (when a PR is
submitted) and push (when the PR is actually merged into the develop
branch). Some things make sense to run on both as a safeguard to make
sure multiple changes in flight did not cause an issue. But some things
will not have changed.

This makes the "license check" task only run on the PR as nothing in
licensing should change by the time a PR is committed into the branch.

We may want to review other tasks that are run and decide if they are
really necessary or not.

**Testing done:**

Visual review and results of the CI jobs on this PR.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
