### PR TITLE
test_controller: send error taskstate to test agent

### DIFF
--- a/controller/src/test_controller/action.rs
+++ b/controller/src/test_controller/action.rs
@@ -106,7 +106,7 @@ pub(super) async fn determine_delete_action(t: &TestInterface) -> Result<Action>
     } else if t.test().has_finalizer(FINALIZER_MAIN) {
         Ok(Action::RemoveMainFinalizer)
     } else {
-        handle_bad_job_state(t, ErrorState::Zombie).await
+        Ok(Action::Error(ErrorState::Zombie))
     }
 }
 
@@ -196,14 +196,14 @@ async fn task_not_done_action(t: &TestInterface, is_task_state_running: bool) ->
                 if t.test().resource_error().is_some() {
                     Ok(Action::RegisterResourceCreationError(s))
                 } else {
-                    handle_bad_job_state(t, ErrorState::ResourceErrorExists(s)).await
+                    Ok(Action::Error(ErrorState::ResourceErrorExists(s)))
                 }
             }
             Resources::Ready => Ok(dependency_wait_action(t)
                 .await?
                 .unwrap_or(Action::StartTest)),
         },
-        JobState::None => handle_bad_job_state(t, ErrorState::HandleJobRemovedBeforeDone).await,
+        JobState::None => Ok(Action::Error(ErrorState::HandleJobRemovedBeforeDone)),
         JobState::Unknown => {
             trace!("Waiting for test agent '{}' container to start", t.name());
             Ok(Action::WaitForTest)
@@ -223,7 +223,7 @@ async fn task_not_done_action(t: &TestInterface, is_task_state_running: bool) ->
                     .unwrap_or(Ok(false))
                     .unwrap_or(false)
                 {
-                    return handle_bad_job_state(t, ErrorState::JobTimeout).await;
+                    return Ok(Action::Error(ErrorState::JobTimeout));
                 }
             }
             if t.test().agent_status().task_state == TaskState::Unknown
@@ -233,41 +233,12 @@ async fn task_not_done_action(t: &TestInterface, is_task_state_running: bool) ->
                     "Test '{}' failed to reach running state within time limit",
                     t.name()
                 );
-                return handle_bad_job_state(t, ErrorState::JobStart).await;
+                return Ok(Action::Error(ErrorState::JobStart));
             }
             trace!("Test '{}' is running", t.name());
             Ok(Action::WaitForTest)
         }
-        JobState::Failed => handle_bad_job_state(t, ErrorState::JobFailure).await,
-        JobState::Exited => handle_bad_job_state(t, ErrorState::JobExitBeforeDone).await,
+        JobState::Failed => Ok(Action::Error(ErrorState::JobFailure)),
+        JobState::Exited => Ok(Action::Error(ErrorState::JobExitBeforeDone)),
     }
-}
-
-/// Determines the error message based on the given ErrorState and sends this to the TestAgent
-async fn handle_bad_job_state(t: &TestInterface, error_state: ErrorState) -> Result<Action> {
-    let error_message = match error_state.clone() {
-        ErrorState::ResourceErrorExists(s) => s,
-        ErrorState::HandleJobRemovedBeforeDone => {
-            "The job was removed before the test completed".to_string()
-        }
-        ErrorState::JobTimeout => {
-            "The test agent did not finish within the specified time".to_string()
-        }
-        ErrorState::JobStart => "The job failed to start in time".to_string(),
-        ErrorState::JobFailure => "The job failed".to_string(),
-        ErrorState::JobExitBeforeDone => {
-            "The test agent exited before marking the test complete".to_string()
-        }
-        ErrorState::Zombie => {
-            "The main finalizer has been removed but the object still exists".to_string()
-        }
-        ErrorState::TestError(e) => e,
-    };
-    t.test_client()
-        .send_agent_task_state(t.name(), TaskState::Error)
-        .await?;
-    t.test_client()
-        .send_agent_error(t.name(), &error_message)
-        .await?;
-    Ok(Action::Error(error_state))
 }

--- a/controller/src/test_controller/action.rs
+++ b/controller/src/test_controller/action.rs
@@ -238,7 +238,15 @@ async fn task_not_done_action(t: &TestInterface, is_task_state_running: bool) ->
             trace!("Test '{}' is running", t.name());
             Ok(Action::WaitForTest)
         }
-        JobState::Failed => Ok(Action::Error(ErrorState::JobFailure)),
+        JobState::Failed => {
+            t.test_client()
+                .send_agent_task_state(t.name(), TaskState::Error)
+                .await?;
+            t.test_client()
+                .send_agent_error(t.name(), "The job failed")
+                .await?;
+            Ok(Action::Error(ErrorState::JobFailure))
+        }
         JobState::Exited => Ok(Action::Error(ErrorState::JobExitBeforeDone)),
     }
 }


### PR DESCRIPTION
Modified controller to send Error TaskState to Test Agent in case of bad job state

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #506 

**Description of changes:**

In case of test job failure (for example, when an argument is given of the wrong type, like String instead of int), the controller would correctly set the JobFailure Error state but the TaskState of the Test was never updated. This would result in a perpetual "waiting" state, so the user would not know what was going on unless they looked at the test logs. This PR adds a function to the controller to set the TaskState of the test to TaskState::Error and give it the error message as displayed by the controller based on the bad job state. When using the `cli status` command, the state of the test now says `error` instead of `waiting` if a bad job state happens.

**Testing done:**

- Ran the `cli status` command for a test file that contained all arguments of the correct type (State is "passed")
- Ran the `cli status` command for a test file that contained an argument of the wrong type (State is "error")
- Ran the `cli status` command for a test file that takes an argument from a resource file with the correct type (State is "passed")
- Ran the `cli status` command for a test file that takes an argument from a resource file with the wrong type (State is "error")
- Ran the `cli status` command for a test file that cannot pull the image (State is "error" after the JobTimeout occurs)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
