### PR TITLE
test-agent: Wait for terminate before sending done

### DIFF
--- a/agent/test-agent/src/k8s_client.rs
+++ b/agent/test-agent/src/k8s_client.rs
@@ -111,14 +111,6 @@ impl Client for DefaultClient {
         Ok(())
     }
 
-    async fn send_test_done(&self, results: TestResults) -> Result<(), Self::E> {
-        self.client
-            .send_test_completed(&self.name, results)
-            .await
-            .context(K8sSnafu)?;
-        Ok(())
-    }
-
     async fn send_error<E>(&self, error: E) -> Result<(), Self::E>
     where
         E: Debug + Display + Send + Sync,

--- a/agent/test-agent/src/lib.rs
+++ b/agent/test-agent/src/lib.rs
@@ -127,10 +127,6 @@ pub trait Client: Sized {
     /// going to re-run the failed test cases.
     async fn send_test_results(&self, results: TestResults) -> Result<(), Self::E>;
 
-    /// Add a TestResults object to the array of TestResults in the test CRD and set the task state
-    /// as `Done` indicating that no more retries or testing will occur.
-    async fn send_test_done(&self, results: TestResults) -> Result<(), Self::E>;
-
     /// Send an error to the k8s API.
     async fn send_error<E>(&self, error: E) -> Result<(), Self::E>
     where

--- a/agent/test-agent/tests/mock.rs
+++ b/agent/test-agent/tests/mock.rs
@@ -98,11 +98,6 @@ impl Client for MockClient {
         Ok(())
     }
 
-    async fn send_test_done(&self, results: TestResults) -> Result<(), Self::E> {
-        println!("MockClient::send_test_done: {:?}", results);
-        Ok(())
-    }
-
     async fn send_test_results(&self, results: TestResults) -> Result<(), Self::E> {
         println!("MockClient::send_test_results: {:?}", results);
         Ok(())


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Before this change, a test was marked as complete before starting its termination. This can cause issues with automatic resource destruction. Instead, the test will terminate before the `Complete` state is sent.

**Testing done:**

Updated sonobuoy image was used to test conformance and migration testing on the same cluster and tests passed successfully.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
