### PR TITLE
bottlerocket-agents: add '--all' to sonobuoy delete

### DIFF
--- a/bottlerocket/agents/src/sonobuoy.rs
+++ b/bottlerocket/agents/src/sonobuoy.rs
@@ -219,6 +219,7 @@ pub async fn delete_sonobuoy(kubeconfig_path: &str) -> Result<(), error::Error> 
     let status = Command::new("/usr/bin/sonobuoy")
         .args(kubeconfig_arg)
         .arg("delete")
+        .arg("--all")
         .arg("--wait")
         .status()
         .context(error::SonobuoyProcessSnafu)?;


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
To ensure all potential lingering namespaces from the conformance test is properly cleaned-up, we need to pass the '--all' flag to 'sonobuoy delete'



**Testing done:**
I have a cluster with a lingering namespace from a previous K8s conformance test run.
```bash
$ kubectl get namespace
NAME                       STATUS        AGE
default                    Active        2y19d
kube-node-lease            Active        2y19d
kube-public                Active        2y19d
kube-system                Active        2y19d
selinux-check              Active        188d
webhook-9752               Active        63s
webhook-9752-markers       Active        63s
```

After running `sonobuoy delete --all --wait` the namespace gets properly deleted.
```bash
$ sonobuoy delete --all --wait
INFO[0000] already deleted                               kind=namespace namespace=sonobuoy
INFO[0000] delete request issued                         kind=clusterrolebindings
INFO[0000] delete request issued                         kind=clusterroles
INFO[0000] delete request issued                         kind=namespace namespace=webhook-9752

Namespace "sonobuoy" has been deleted

Deleted all ClusterRoles and ClusterRoleBindings.

Found 1 namespaces that still need to be deleted: [webhook-9752]

Namespace "sonobuoy" has been deleted

Deleted all ClusterRoles and ClusterRoleBindings.

All E2E namespaces deleted
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
