### PR TITLE
ecs-resource-agent: added field for existing profile

### DIFF
--- a/bottlerocket/testsys/src/run_aws_ecs.rs
+++ b/bottlerocket/testsys/src/run_aws_ecs.rs
@@ -146,6 +146,11 @@ pub(crate) struct RunAwsEcs {
     /// The arn for the role that should be assumed by the agents.
     #[structopt(long)]
     assume_role: Option<String>,
+
+    /// The IAM instance profile name for the EC2 instances in the ECS cluster. If no value is
+    /// provided, then the ECS test agent will attempt to create an IAM instance profile.
+    #[structopt(long)]
+    iam_instance_profile_name: Option<String>,
 }
 
 impl RunAwsEcs {
@@ -326,6 +331,7 @@ impl RunAwsEcs {
                             region: Some(self.region.clone()),
                             vpc: self.vpc.clone(),
                             assume_role: self.assume_role.clone(),
+                            iam_instance_profile_name: self.iam_instance_profile_name.clone(),
                         }
                         .into_map()
                         .context(error::ConfigMapSnafu)?,

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -212,6 +212,10 @@ pub struct EcsClusterConfig {
 
     /// The role that should be assumed when creating the ecs cluster.
     pub assume_role: Option<String>,
+
+    /// The IAM instance profile name for the EC2 instances in the ECS cluster. If no value is
+    /// provided, then the ECS test agent will attempt to create an IAM instance profile.
+    pub iam_instance_profile_name: Option<String>,
 }
 
 impl Configuration for EcsClusterConfig {}


### PR DESCRIPTION
Added field for existing IAM profile to the CRD and code to check if the field contains a value: if so, retrieves the ARN of the submitted profile instead of the default one.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

#379 

**Description of changes:**

Added a field to the ecs-resource-agent CRD where a user can enter the name of an existing IAM instance profile. This allows cluster creation without IAM role creation permissions. The ecs-provider code will check if the field is used, and if so, attempt to retrieve the ARN of the submitted profile instead of the default one. If this is unsuccessful (because, for example, the profile does not exist), the ECS creation throws an error.

**Testing done:**

- Ran ECS test without the field: everything ran exactly like before the changes
- Ran ECS test with a profile name that does not exist:
`Provider error: An error occurred but no resources were left behind, The iam instance profile name was not found.: An error left resources behind that can be destroyed, Unable to get instance profile.: NoSuchEntityException: Instance Profile does-not-exist cannot be found.`
- Ran ECS test with a profile name that does exist: everything ran exactly like before the changes

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
