### PR TITLE
Fix link to design doc in root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bottlerocket Test System
 
 A system for testing Bottlerocket.
-To learn more about how it works, see the [design](design/DESIGN.md) document.
+To learn more about how it works, see the [design](docs/DESIGN.md) document.
 
 ## Overview
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -3,7 +3,7 @@
 ## What is TestSys
 
 TestSys is a framework that leverages Kubernetes (K8s) to create resources and run tests.
-To learn more about how it works, see the [design](design/DESIGN.md) document.
+To learn more about how it works, see the [design](DESIGN.md) document.
 
 ### Navigating the `bottlerocket-test-system` repo
 
@@ -61,7 +61,7 @@ For tests, once necessary resources have been created (resources named in the `r
 For resources, once necessary resources have been created (resources named in the `depends_on` field of the resource spec), a K8s job is created and the `create` function of the agent is run.
 Once a resource is marked for deletion (`cli delete`), the `destroy` function of the resource is run, and the finalizers are removed so that the resource can be cleaned up by K8s.
 
-For more info, see the [design](design/DESIGN.md) document.
+For more info, see the [design](DESIGN.md) document.
 
 ### [Model](model)
 


### PR DESCRIPTION
**Issue number:**
N/a

**Description of changes:**

Root readme link to design doc is broken

**Testing done:**

👀 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
