### PR TITLE
Actions: update docs directory path

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,13 +3,13 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
-      - 'design/**'
+      - 'docs/**'
       - 'tools/**'
       - '.github/dependabot.yml'
   push:
     paths-ignore:
       - '**.md'
-      - 'design/**'
+      - 'docs/**'
       - 'tools/**'
       - '.github/dependabot.yml'
     branches: [develop]


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

We originally had a `design` directory that contained the design doc for testsys. We added more docs and restructured things, so `design` was renamed to `docs`. There is a GitHub Action configuration that tries to ignore this path to skip running tests if only docs have changed. This updates the config to use the correct current name.

**Testing done:**

Will need to verify with job triggers after this merges.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
