### PR TITLE
utils: added code to check for optional session token

### DIFF
--- a/agent/utils/src/aws.rs
+++ b/agent/utils/src/aws.rs
@@ -271,6 +271,16 @@ where
         resources,
         "Could not convert secret-access-key to String",
     )?;
+    if let Some(token) = aws_secret.get("session-token") {
+        env::set_var(
+            "AWS_SESSION_TOKEN",
+            resource_agent::provider::IntoProviderError::context(
+                String::from_utf8(token.to_owned()),
+                resources,
+                "Could not convert session-token to String",
+            )?,
+        );
+    };
 
     env::set_var("AWS_ACCESS_KEY_ID", access_key_id);
     env::set_var("AWS_SECRET_ACCESS_KEY", secret_access_key);


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #562 

**Description of changes:**

Added code to `setup_resource_env` to check the provided secret for a session token, and set the environment variable if a token is present. The session token is needed when temporary credentials from an assumed user are used.

**Testing done:**

- Ran code to create cluster providing secret with assumed role and no session token: fails to create instances
- Ran code to create cluster providing secret with assumed role and incorrect session token: fails to create instances
- Ran code to create cluster providing secret with assumed role and correct session token: instances are created

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
