### PR TITLE
yamlgen: Upgrade serde-yaml to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,7 +1532,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "thiserror",
  "tokio",
  "tokio-native-tls",
@@ -1702,7 +1702,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
- "serde_yaml",
+ "serde_yaml 0.9.11",
  "snafu",
  "tabled 0.6.1",
  "tokio",
@@ -2559,6 +2559,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f31df3f50926cdf2855da5fd8812295c34752cb20438dae42a67f79e021ac3"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,7 +2867,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
- "serde_yaml",
+ "serde_yaml 0.9.11",
  "snafu",
  "structopt",
  "tabled 0.4.2",
@@ -3248,6 +3261,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3586,7 +3605,7 @@ version = "0.0.2"
 dependencies = [
  "kube",
  "model",
- "serde_yaml",
+ "serde_yaml 0.9.11",
 ]
 
 [[package]]

--- a/bottlerocket/testsys/Cargo.toml
+++ b/bottlerocket/testsys/Cargo.toml
@@ -19,7 +19,7 @@ model = { version = "0.0.2", path = "../../model" }
 serde = "1.0.144"
 serde_plain = "1"
 serde_json = "1.0.85"
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 snafu = "0.7"
 structopt = "0.3"
 tabled = "0.4"

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -23,7 +23,7 @@ schemars = "0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1"
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 snafu = "0.7"
 tabled = "0.6"
 tokio =  { version = "1", features = ["rt-multi-thread", "sync", "fs"] }

--- a/yamlgen/Cargo.toml
+++ b/yamlgen/Cargo.toml
@@ -8,4 +8,4 @@ license = "MIT OR Apache-2.0"
 [build-dependencies]
 kube = { version = "0.74", default-features = false }
 model = { version = "0.0.2", path = "../model" }
-serde_yaml = "0.8"
+serde_yaml = "0.9"

--- a/yamlgen/build.rs
+++ b/yamlgen/build.rs
@@ -21,6 +21,7 @@ use std::path::PathBuf;
 
 const YAMLGEN_DIR: &str = env!("CARGO_MANIFEST_DIR");
 const HEADER: &str = "# This file is generated. Do not edit.\n";
+const YAML_SEPARATOR: &str = "---\n";
 // FIXME: set this to an public ECR image eventually
 const DEFAULT_TESTSYS_CONTROLLER_IMAGE: &str =
     "6456745674567.dkr.ecr.us-west-2.amazonaws.com/controller:v0.1.2";
@@ -46,11 +47,13 @@ fn main() {
     let path = PathBuf::from(YAMLGEN_DIR)
         .join("deploy")
         .join("testsys-agent.yaml");
-    let testsys_agent = File::create(&path).unwrap();
+    let mut testsys_agent = File::create(&path).unwrap();
 
     // testsys-crd related K8S manifest
     testsys_crd.write_all(HEADER.as_bytes()).unwrap();
+    testsys_crd.write_all(YAML_SEPARATOR.as_bytes()).unwrap();
     serde_yaml::to_writer(&testsys_crd, &Test::crd()).unwrap();
+    testsys_crd.write_all(YAML_SEPARATOR.as_bytes()).unwrap();
     serde_yaml::to_writer(&testsys_crd, &Resource::crd()).unwrap();
 
     // Read the controller image and image-pull-secrets identifier from environment variables
@@ -61,10 +64,25 @@ fn main() {
 
     // testsys-controller related K8S manifest
     testsys_controller.write_all(HEADER.as_bytes()).unwrap();
+    testsys_controller
+        .write_all(YAML_SEPARATOR.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&testsys_controller, &testsys_namespace()).unwrap();
+    testsys_controller
+        .write_all(YAML_SEPARATOR.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&testsys_controller, &controller_service_account()).unwrap();
+    testsys_controller
+        .write_all(YAML_SEPARATOR.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&testsys_controller, &controller_cluster_role()).unwrap();
+    testsys_controller
+        .write_all(YAML_SEPARATOR.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(&testsys_controller, &controller_cluster_role_binding()).unwrap();
+    testsys_controller
+        .write_all(YAML_SEPARATOR.as_bytes())
+        .unwrap();
     serde_yaml::to_writer(
         &testsys_controller,
         &controller_deployment(controller_image, controller_image_pull_secrets),
@@ -72,12 +90,20 @@ fn main() {
     .unwrap();
 
     // testsys-agent related K8S manifest
+    testsys_agent.write_all(HEADER.as_bytes()).unwrap();
+    testsys_agent.write_all(YAML_SEPARATOR.as_bytes()).unwrap();
     serde_yaml::to_writer(&testsys_agent, &testsys_namespace()).unwrap();
+    testsys_agent.write_all(YAML_SEPARATOR.as_bytes()).unwrap();
     serde_yaml::to_writer(&testsys_agent, &agent_service_account(AgentType::Test)).unwrap();
+    testsys_agent.write_all(YAML_SEPARATOR.as_bytes()).unwrap();
     serde_yaml::to_writer(&testsys_agent, &agent_cluster_role(AgentType::Test)).unwrap();
+    testsys_agent.write_all(YAML_SEPARATOR.as_bytes()).unwrap();
     serde_yaml::to_writer(&testsys_agent, &agent_cluster_role_binding(AgentType::Test)).unwrap();
+    testsys_agent.write_all(YAML_SEPARATOR.as_bytes()).unwrap();
     serde_yaml::to_writer(&testsys_agent, &agent_service_account(AgentType::Resource)).unwrap();
+    testsys_agent.write_all(YAML_SEPARATOR.as_bytes()).unwrap();
     serde_yaml::to_writer(&testsys_agent, &agent_cluster_role(AgentType::Resource)).unwrap();
+    testsys_agent.write_all(YAML_SEPARATOR.as_bytes()).unwrap();
     serde_yaml::to_writer(
         &testsys_agent,
         &agent_cluster_role_binding(AgentType::Resource),

--- a/yamlgen/deploy/testsys-agent.yaml
+++ b/yamlgen/deploy/testsys-agent.yaml
@@ -1,3 +1,4 @@
+# This file is generated. Do not edit.
 ---
 apiVersion: v1
 kind: Namespace
@@ -20,23 +21,23 @@ metadata:
   name: testsys-test-agent-role
   namespace: testsys-bottlerocket-aws
 rules:
-  - apiGroups:
-      - testsys.bottlerocket.aws
-    resources:
-      - tests
-      - tests/status
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - testsys.bottlerocket.aws
-    resources:
-      - resources
-    verbs:
-      - get
+- apiGroups:
+  - testsys.bottlerocket.aws
+  resources:
+  - tests
+  - tests/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - testsys.bottlerocket.aws
+  resources:
+  - resources
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -48,9 +49,9 @@ roleRef:
   kind: ClusterRole
   name: testsys-test-agent-role
 subjects:
-  - kind: ServiceAccount
-    name: testsys-test-agent-account
-    namespace: testsys-bottlerocket-aws
+- kind: ServiceAccount
+  name: testsys-test-agent-account
+  namespace: testsys-bottlerocket-aws
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -66,17 +67,17 @@ metadata:
   name: testsys-resource-agent-role
   namespace: testsys-bottlerocket-aws
 rules:
-  - apiGroups:
-      - testsys.bottlerocket.aws
-    resources:
-      - resources
-      - resources/status
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
+- apiGroups:
+  - testsys.bottlerocket.aws
+  resources:
+  - resources
+  - resources/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -88,6 +89,6 @@ roleRef:
   kind: ClusterRole
   name: testsys-resource-agent-role
 subjects:
-  - kind: ServiceAccount
-    name: testsys-resource-agent-account
-    namespace: testsys-bottlerocket-aws
+- kind: ServiceAccount
+  name: testsys-resource-agent-account
+  namespace: testsys-bottlerocket-aws

--- a/yamlgen/deploy/testsys-controller.yaml
+++ b/yamlgen/deploy/testsys-controller.yaml
@@ -21,58 +21,58 @@ metadata:
   name: testsys-controller-role
   namespace: testsys-bottlerocket-aws
 rules:
-  - apiGroups:
-      - testsys.bottlerocket.aws
-    resources:
-      - tests
-      - tests/status
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - testsys.bottlerocket.aws
-    resources:
-      - resources
-      - resources/status
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
-  - apiGroups:
-      - batch
-    resources:
-      - jobs
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - get
-      - list
-      - patch
-      - update
+- apiGroups:
+  - testsys.bottlerocket.aws
+  resources:
+  - tests
+  - tests/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - testsys.bottlerocket.aws
+  resources:
+  - resources
+  - resources/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -84,9 +84,9 @@ roleRef:
   kind: ClusterRole
   name: testsys-controller-role
 subjects:
-  - kind: ServiceAccount
-    name: testsys-controller-service-account
-    namespace: testsys-bottlerocket-aws
+- kind: ServiceAccount
+  name: testsys-controller-service-account
+  namespace: testsys-bottlerocket-aws
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -116,12 +116,12 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                      - linux
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
-        - image: "6456745674567.dkr.ecr.us-west-2.amazonaws.com/controller:v0.1.2"
-          name: controller
+      - image: 6456745674567.dkr.ecr.us-west-2.amazonaws.com/controller:v0.1.2
+        name: controller
       serviceAccountName: testsys-controller-service-account

--- a/yamlgen/deploy/testsys-crd.yaml
+++ b/yamlgen/deploy/testsys-crd.yaml
@@ -14,167 +14,167 @@ spec:
     singular: test
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: ".status.agent.taskState"
-          name: State
-          type: string
-        - jsonPath: ".status.agent.results.outcome"
-          name: Result
-          type: string
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Auto-generated derived type for TestSpec via `CustomResource`"
-          properties:
-            spec:
-              description: "A TestSys Test. The `CustomResource` derive also produces a struct named `Test` which represents a test CRD object in the k8s API."
-              properties:
-                agent:
-                  description: Information about the test agent.
-                  properties:
-                    capabilities:
-                      description: "Linux capabilities to add for the agent container, e.g. NET_ADMIN"
-                      items:
-                        type: string
-                      nullable: true
-                      type: array
-                    configuration:
-                      description: "The configuration to pass to the agent. This is 'open' to allow agents to define their own schemas."
-                      nullable: true
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                    image:
-                      description: The URI of the agent container image.
+  - additionalPrinterColumns:
+    - jsonPath: .status.agent.taskState
+      name: State
+      type: string
+    - jsonPath: .status.agent.results.outcome
+      name: Result
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for TestSpec via `CustomResource`
+        properties:
+          spec:
+            description: A TestSys Test. The `CustomResource` derive also produces a struct named `Test` which represents a test CRD object in the k8s API.
+            properties:
+              agent:
+                description: Information about the test agent.
+                properties:
+                  capabilities:
+                    description: Linux capabilities to add for the agent container, e.g. NET_ADMIN
+                    items:
                       type: string
-                    keepRunning:
-                      description: Determine if the pod should keep running after it has finished or encountered and error.
-                      type: boolean
-                    name:
-                      description: The name of the agent.
-                      type: string
-                    pullSecret:
-                      description: The name of an image registry pull secret if one is needed to pull the agent image.
-                      nullable: true
-                      type: string
-                    secrets:
-                      additionalProperties:
-                        maxLength: 253
-                        minLength: 1
-                        pattern: "^[a-zA-Z0-9_-]{1,253}$"
-                        type: string
-                      description: "A map of `SecretType` -> `SecretName` where `SecretType` is defined by the agent that will use it, and `SecretName` is provided by the user. `SecretName` is constrained to ascii alphanumerics plus underscores and dashes."
-                      nullable: true
-                      type: object
-                    timeout:
-                      description: The maximum amount of time an agent should be left to run.
+                    nullable: true
+                    type: array
+                  configuration:
+                    description: The configuration to pass to the agent. This is 'open' to allow agents to define their own schemas.
+                    nullable: true
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  image:
+                    description: The URI of the agent container image.
+                    type: string
+                  keepRunning:
+                    description: Determine if the pod should keep running after it has finished or encountered and error.
+                    type: boolean
+                  name:
+                    description: The name of the agent.
+                    type: string
+                  pullSecret:
+                    description: The name of an image registry pull secret if one is needed to pull the agent image.
+                    nullable: true
+                    type: string
+                  secrets:
+                    additionalProperties:
                       maxLength: 253
                       minLength: 1
-                      nullable: true
-                      pattern: "^((([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?|\\d+)$"
+                      pattern: ^[a-zA-Z0-9_-]{1,253}$
                       type: string
-                  required:
-                    - configuration
-                    - image
-                    - keepRunning
-                    - name
-                    - timeout
-                  type: object
-                dependsOn:
-                  description: Other tests that must be completed before this one can be run.
-                  items:
+                    description: A map of `SecretType` -> `SecretName` where `SecretType` is defined by the agent that will use it, and `SecretName` is provided by the user. `SecretName` is constrained to ascii alphanumerics plus underscores and dashes.
+                    nullable: true
+                    type: object
+                  timeout:
+                    description: The maximum amount of time an agent should be left to run.
+                    maxLength: 253
+                    minLength: 1
+                    nullable: true
+                    pattern: ^((([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?|\d+)$
                     type: string
-                  nullable: true
-                  type: array
-                resources:
-                  description: The list of resources required by this test. The test controller will wait for these resources to become ready before running the test agent.
-                  items:
+                required:
+                - configuration
+                - image
+                - keepRunning
+                - name
+                - timeout
+                type: object
+              dependsOn:
+                description: Other tests that must be completed before this one can be run.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              resources:
+                description: The list of resources required by this test. The test controller will wait for these resources to become ready before running the test agent.
+                items:
+                  type: string
+                type: array
+              retries:
+                description: The number of retries the agent is allowed to perform after a failed test.
+                format: uint32
+                minimum: 0.0
+                nullable: true
+                type: integer
+            required:
+            - agent
+            - resources
+            type: object
+          status:
+            description: The status field of the TestSys Test CRD. This is where the controller and agents will write information about the status of the test run.
+            nullable: true
+            properties:
+              agent:
+                description: Information written by the test agent.
+                properties:
+                  error:
+                    description: Due to structural OpenAPI constraints, the error message must be provided separately instead of as a value within the `RunState::Error` variant. If the `run_state` is `Error` then there *may* be an error message here. If there is an error message here and the `run_state` is *not* `Error`, the this is a bad state and the `error_message` should be ignored.
+                    nullable: true
                     type: string
-                  type: array
-                retries:
-                  description: The number of retries the agent is allowed to perform after a failed test.
-                  format: uint32
-                  minimum: 0.0
-                  nullable: true
-                  type: integer
-              required:
-                - agent
-                - resources
-              type: object
-            status:
-              description: The status field of the TestSys Test CRD. This is where the controller and agents will write information about the status of the test run.
-              nullable: true
-              properties:
-                agent:
-                  description: Information written by the test agent.
-                  properties:
-                    error:
-                      description: "Due to structural OpenAPI constraints, the error message must be provided separately instead of as a value within the `RunState::Error` variant. If the `run_state` is `Error` then there *may* be an error message here. If there is an error message here and the `run_state` is *not* `Error`, the this is a bad state and the `error_message` should be ignored."
-                      nullable: true
-                      type: string
-                    results:
-                      items:
-                        properties:
-                          numFailed:
-                            format: uint64
-                            minimum: 0.0
-                            type: integer
-                          numPassed:
-                            format: uint64
-                            minimum: 0.0
-                            type: integer
-                          numSkipped:
-                            format: uint64
-                            minimum: 0.0
-                            type: integer
-                          otherInfo:
-                            nullable: true
-                            type: string
-                          outcome:
-                            description: "The `Outcome` of a test run, reported by the test agent."
-                            enum:
-                              - pass
-                              - fail
-                              - timeout
-                              - unknown
-                            type: string
-                        required:
-                          - numFailed
-                          - numPassed
-                          - numSkipped
-                          - outcome
-                        type: object
-                      type: array
-                    taskState:
-                      description: The states that an agent declares about its task (e.g. running tests or creating/destroying resources).
-                      enum:
-                        - unknown
-                        - running
-                        - completed
-                        - error
-                      type: string
-                  required:
-                    - results
-                    - taskState
-                  type: object
-                controller:
-                  description: Information written by the controller.
-                  properties:
-                    resourceError:
-                      nullable: true
-                      type: string
-                  type: object
-              required:
-                - agent
-                - controller
-              type: object
-          required:
-            - spec
-          title: Test
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                  results:
+                    items:
+                      properties:
+                        numFailed:
+                          format: uint64
+                          minimum: 0.0
+                          type: integer
+                        numPassed:
+                          format: uint64
+                          minimum: 0.0
+                          type: integer
+                        numSkipped:
+                          format: uint64
+                          minimum: 0.0
+                          type: integer
+                        otherInfo:
+                          nullable: true
+                          type: string
+                        outcome:
+                          description: The `Outcome` of a test run, reported by the test agent.
+                          enum:
+                          - pass
+                          - fail
+                          - timeout
+                          - unknown
+                          type: string
+                      required:
+                      - numFailed
+                      - numPassed
+                      - numSkipped
+                      - outcome
+                      type: object
+                    type: array
+                  taskState:
+                    description: The states that an agent declares about its task (e.g. running tests or creating/destroying resources).
+                    enum:
+                    - unknown
+                    - running
+                    - completed
+                    - error
+                    type: string
+                required:
+                - results
+                - taskState
+                type: object
+              controller:
+                description: Information written by the controller.
+                properties:
+                  resourceError:
+                    nullable: true
+                    type: string
+                type: object
+            required:
+            - agent
+            - controller
+            type: object
+        required:
+        - spec
+        title: Test
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -190,189 +190,189 @@ spec:
     singular: resource
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: ".spec.destructionPolicy"
-          name: DestructionPolicy
-          type: string
-        - jsonPath: ".status.creation.taskState"
-          name: CreationState
-          type: string
-        - jsonPath: ".status.destruction.taskState"
-          name: DestructionState
-          type: string
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Auto-generated derived type for ResourceSpec via `CustomResource`"
-          properties:
-            spec:
-              description: "A resource required by a test. For example, a compute instance or cluster. The `CustomResource` derive also produces a struct named `Resource` which represents a resource CRD object in the k8s API."
-              properties:
-                agent:
-                  description: Information about the resource agent.
-                  properties:
-                    capabilities:
-                      description: "Linux capabilities to add for the agent container, e.g. NET_ADMIN"
-                      items:
-                        type: string
-                      nullable: true
-                      type: array
-                    configuration:
-                      description: "The configuration to pass to the agent. This is 'open' to allow agents to define their own schemas."
-                      nullable: true
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                    image:
-                      description: The URI of the agent container image.
+  - additionalPrinterColumns:
+    - jsonPath: .spec.destructionPolicy
+      name: DestructionPolicy
+      type: string
+    - jsonPath: .status.creation.taskState
+      name: CreationState
+      type: string
+    - jsonPath: .status.destruction.taskState
+      name: DestructionState
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for ResourceSpec via `CustomResource`
+        properties:
+          spec:
+            description: A resource required by a test. For example, a compute instance or cluster. The `CustomResource` derive also produces a struct named `Resource` which represents a resource CRD object in the k8s API.
+            properties:
+              agent:
+                description: Information about the resource agent.
+                properties:
+                  capabilities:
+                    description: Linux capabilities to add for the agent container, e.g. NET_ADMIN
+                    items:
                       type: string
-                    keepRunning:
-                      description: Determine if the pod should keep running after it has finished or encountered and error.
-                      type: boolean
-                    name:
-                      description: The name of the agent.
-                      type: string
-                    pullSecret:
-                      description: The name of an image registry pull secret if one is needed to pull the agent image.
-                      nullable: true
-                      type: string
-                    secrets:
-                      additionalProperties:
-                        maxLength: 253
-                        minLength: 1
-                        pattern: "^[a-zA-Z0-9_-]{1,253}$"
-                        type: string
-                      description: "A map of `SecretType` -> `SecretName` where `SecretType` is defined by the agent that will use it, and `SecretName` is provided by the user. `SecretName` is constrained to ascii alphanumerics plus underscores and dashes."
-                      nullable: true
-                      type: object
-                    timeout:
-                      description: The maximum amount of time an agent should be left to run.
+                    nullable: true
+                    type: array
+                  configuration:
+                    description: The configuration to pass to the agent. This is 'open' to allow agents to define their own schemas.
+                    nullable: true
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  image:
+                    description: The URI of the agent container image.
+                    type: string
+                  keepRunning:
+                    description: Determine if the pod should keep running after it has finished or encountered and error.
+                    type: boolean
+                  name:
+                    description: The name of the agent.
+                    type: string
+                  pullSecret:
+                    description: The name of an image registry pull secret if one is needed to pull the agent image.
+                    nullable: true
+                    type: string
+                  secrets:
+                    additionalProperties:
                       maxLength: 253
                       minLength: 1
-                      nullable: true
-                      pattern: "^((([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?|\\d+)$"
+                      pattern: ^[a-zA-Z0-9_-]{1,253}$
                       type: string
-                  required:
-                    - configuration
-                    - image
-                    - keepRunning
-                    - name
-                    - timeout
-                  type: object
-                conflictsWith:
-                  description: Creation of this resource will not begin until all conflicting resources have been deleted.
-                  items:
+                    description: A map of `SecretType` -> `SecretName` where `SecretType` is defined by the agent that will use it, and `SecretName` is provided by the user. `SecretName` is constrained to ascii alphanumerics plus underscores and dashes.
+                    nullable: true
+                    type: object
+                  timeout:
+                    description: The maximum amount of time an agent should be left to run.
+                    maxLength: 253
+                    minLength: 1
+                    nullable: true
+                    pattern: ^((([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?|\d+)$
                     type: string
-                  nullable: true
-                  type: array
-                dependsOn:
-                  description: Other resources that must to be created before this one can be created.
-                  items:
-                    type: string
-                  nullable: true
-                  type: array
-                destructionPolicy:
-                  default: onDeletion
-                  description: "Whether/when the resource controller will destroy the resource (`OnDeletion` is the default)."
-                  enum:
-                    - onDeletion
-                    - never
-                    - onTestSuccess
-                    - onTestCompletion
-                    - "null"
-                  nullable: true
+                required:
+                - configuration
+                - image
+                - keepRunning
+                - name
+                - timeout
+                type: object
+              conflictsWith:
+                description: Creation of this resource will not begin until all conflicting resources have been deleted.
+                items:
                   type: string
-              required:
-                - agent
-              type: object
-            status:
-              description: A status struct to be used by a resource agent.
-              nullable: true
-              properties:
-                agentInfo:
-                  description: Open content to be used by the resource agent to store state.
-                  nullable: true
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                createdResource:
-                  description: A description of the resource that has been created by the resource agent.
-                  nullable: true
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                creation:
-                  description: The state or the resource agent when creating resources.
-                  properties:
-                    error:
-                      nullable: true
-                      properties:
-                        error:
-                          description: The error message.
-                          type: string
-                        errorResources:
-                          description: "The status of left-behind resources, if any."
-                          enum:
-                            - orphaned
-                            - remaining
-                            - clear
-                            - unknown
-                          type: string
-                      required:
-                        - error
-                        - errorResources
-                      type: object
-                    taskState:
-                      description: The states that an agent declares about its task (e.g. running tests or creating/destroying resources).
-                      enum:
+                nullable: true
+                type: array
+              dependsOn:
+                description: Other resources that must to be created before this one can be created.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              destructionPolicy:
+                default: onDeletion
+                description: Whether/when the resource controller will destroy the resource (`OnDeletion` is the default).
+                enum:
+                - onDeletion
+                - never
+                - onTestSuccess
+                - onTestCompletion
+                - 'null'
+                nullable: true
+                type: string
+            required:
+            - agent
+            type: object
+          status:
+            description: A status struct to be used by a resource agent.
+            nullable: true
+            properties:
+              agentInfo:
+                description: Open content to be used by the resource agent to store state.
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              createdResource:
+                description: A description of the resource that has been created by the resource agent.
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              creation:
+                description: The state or the resource agent when creating resources.
+                properties:
+                  error:
+                    nullable: true
+                    properties:
+                      error:
+                        description: The error message.
+                        type: string
+                      errorResources:
+                        description: The status of left-behind resources, if any.
+                        enum:
+                        - orphaned
+                        - remaining
+                        - clear
                         - unknown
-                        - running
-                        - completed
-                        - error
-                      type: string
-                  required:
-                    - taskState
-                  type: object
-                destruction:
-                  description: The state of the resource agent when destroying resources.
-                  properties:
-                    error:
-                      nullable: true
-                      properties:
-                        error:
-                          description: The error message.
-                          type: string
-                        errorResources:
-                          description: "The status of left-behind resources, if any."
-                          enum:
-                            - orphaned
-                            - remaining
-                            - clear
-                            - unknown
-                          type: string
-                      required:
-                        - error
-                        - errorResources
-                      type: object
-                    taskState:
-                      description: The states that an agent declares about its task (e.g. running tests or creating/destroying resources).
-                      enum:
+                        type: string
+                    required:
+                    - error
+                    - errorResources
+                    type: object
+                  taskState:
+                    description: The states that an agent declares about its task (e.g. running tests or creating/destroying resources).
+                    enum:
+                    - unknown
+                    - running
+                    - completed
+                    - error
+                    type: string
+                required:
+                - taskState
+                type: object
+              destruction:
+                description: The state of the resource agent when destroying resources.
+                properties:
+                  error:
+                    nullable: true
+                    properties:
+                      error:
+                        description: The error message.
+                        type: string
+                      errorResources:
+                        description: The status of left-behind resources, if any.
+                        enum:
+                        - orphaned
+                        - remaining
+                        - clear
                         - unknown
-                        - running
-                        - completed
-                        - error
-                      type: string
-                  required:
-                    - taskState
-                  type: object
-              required:
-                - agentInfo
-                - createdResource
-                - creation
-                - destruction
-              type: object
-          required:
-            - spec
-          title: Resource
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                        type: string
+                    required:
+                    - error
+                    - errorResources
+                    type: object
+                  taskState:
+                    description: The states that an agent declares about its task (e.g. running tests or creating/destroying resources).
+                    enum:
+                    - unknown
+                    - running
+                    - completed
+                    - error
+                    type: string
+                required:
+                - taskState
+                type: object
+            required:
+            - agentInfo
+            - createdResource
+            - creation
+            - destruction
+            type: object
+        required:
+        - spec
+        title: Resource
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
### Issue number:
Closes #559

### Description of changes:

```
serde-yaml 0.9.x carries a breaking change where `---\n` are not prepended to documents.
This patch adds those yaml sperators manually.

Signed-off-by: John McBride <jpmmcb@amazon.com>
```

### Testing done:

`make build` and all is well 👍🏼 

Looks like in [`serde-yaml` 0.9](https://github.com/dtolnay/serde-yaml/releases/tag/0.9.0), they also changed the backend yaml generator which is likely why there are so many formatting changes with this patch: these should be fine regardless 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
