### PR TITLE
utils: setup_test_env now checks for session token

### DIFF
--- a/agent/utils/src/aws.rs
+++ b/agent/utils/src/aws.rs
@@ -133,6 +133,15 @@ where
         what: "access-key-id",
     })?;
 
+    if let Some(token) = aws_secret.get("session-token") {
+        env::set_var(
+            "AWS_SESSION_TOKEN",
+            String::from_utf8(token.to_owned()).context(error::ConversionSnafu {
+                what: "session-token",
+            })?,
+        );
+    };
+
     env::set_var("AWS_ACCESS_KEY_ID", access_key_id);
     env::set_var("AWS_SECRET_ACCESS_KEY", secret_access_key);
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #568 

**Description of changes:**

Similar to https://github.com/bottlerocket-os/bottlerocket-test-system/pull/564, the `setup_test_env` function in `utils/aws.rs` was not checking for a session token in the secret. This prevented the tests from running when an assumed role was used.

**Testing done:**

- Ran code to create cluster providing secret with assumed role and no session token: fails to run test
- Ran code to create cluster providing secret with assumed role and incorrect session token: fails to run test
- Ran code to create cluster providing secret with assumed role and correct session token: test passes

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
