### PR TITLE
agent: add new `privileged` field

### DIFF
--- a/bottlerocket/testsys/src/run_aws_ecs.rs
+++ b/bottlerocket/testsys/src/run_aws_ecs.rs
@@ -324,7 +324,6 @@ impl RunAwsEcs {
                     image: self.cluster_provider_image.clone(),
                     pull_secret: self.cluster_provider_pull_secret.clone(),
                     keep_running: self.keep_cluster_provider_running,
-                    timeout: None,
                     configuration: Some(
                         EcsClusterConfig {
                             cluster_name: self.cluster_name.to_owned(),
@@ -337,7 +336,7 @@ impl RunAwsEcs {
                         .context(error::ConfigMapSnafu)?,
                     ),
                     secrets,
-                    capabilities: None,
+                    ..Default::default()
                 },
                 ..Default::default()
             },
@@ -384,10 +383,9 @@ impl RunAwsEcs {
                     image: self.ec2_provider_image.clone(),
                     pull_secret: self.ec2_provider_pull_secret.clone(),
                     keep_running: self.keep_instance_provider_running,
-                    timeout: None,
                     configuration: Some(ec2_config),
                     secrets,
-                    capabilities: None,
+                    ..Default::default()
                 },
                 destruction_policy: DestructionPolicy::OnDeletion,
             },
@@ -421,7 +419,6 @@ impl RunAwsEcs {
                     image: self.test_agent_image.clone(),
                     pull_secret: self.test_agent_pull_secret.clone(),
                     keep_running: self.keep_running,
-                    timeout: None,
                     configuration: Some(
                         EcsTestConfig {
                             region: Some(format!("${{{}.region}}", cluster_resource_name)),
@@ -437,7 +434,7 @@ impl RunAwsEcs {
                         .context(error::ConfigMapSnafu)?,
                     ),
                     secrets,
-                    capabilities: None,
+                    ..Default::default()
                 },
             },
             status: None,
@@ -488,10 +485,9 @@ impl RunAwsEcs {
                     image: migration_agent_image.to_string(),
                     pull_secret: migration_agent_pull_secret.clone(),
                     keep_running: self.keep_running,
-                    timeout: None,
                     configuration: Some(migration_config),
                     secrets,
-                    capabilities: None,
+                    ..Default::default()
                 },
             },
             status: None,

--- a/bottlerocket/testsys/src/run_aws_k8s.rs
+++ b/bottlerocket/testsys/src/run_aws_k8s.rs
@@ -341,7 +341,6 @@ impl RunAwsK8s {
                     image: self.cluster_provider_image.clone(),
                     pull_secret: self.cluster_provider_pull_secret.clone(),
                     keep_running: self.keep_cluster_provider_running,
-                    timeout: None,
                     configuration: Some(
                         EksClusterConfig {
                             cluster_name: self.cluster_name.clone(),
@@ -355,7 +354,7 @@ impl RunAwsK8s {
                         .context(error::ConfigMapSnafu)?,
                     ),
                     secrets,
-                    capabilities: None,
+                    ..Default::default()
                 },
                 destruction_policy: self.cluster_destruction_policy,
             },
@@ -411,10 +410,9 @@ impl RunAwsK8s {
                     image: self.ec2_provider_image.clone(),
                     pull_secret: self.ec2_provider_pull_secret.clone(),
                     keep_running: self.keep_instance_provider_running,
-                    timeout: None,
                     configuration: Some(ec2_config),
                     secrets,
-                    capabilities: None,
+                    ..Default::default()
                 },
                 destruction_policy: DestructionPolicy::OnDeletion,
             },
@@ -457,7 +455,6 @@ impl RunAwsK8s {
                     image: self.test_agent_image.clone(),
                     pull_secret: self.test_agent_pull_secret.clone(),
                     keep_running: self.keep_running,
-                    timeout: None,
                     configuration: Some(
                         SonobuoyConfig {
                             kubeconfig_base64: format!(
@@ -475,8 +472,7 @@ impl RunAwsK8s {
                         .context(error::ConfigMapSnafu)?,
                     ),
                     secrets,
-                    // FIXME: Add CLI option for setting this
-                    capabilities: None,
+                    ..Default::default()
                 },
             },
             status: None,
@@ -527,10 +523,9 @@ impl RunAwsK8s {
                     image: migration_agent_image.to_string(),
                     pull_secret: migration_agent_pull_secret.clone(),
                     keep_running: self.keep_running,
-                    timeout: None,
                     configuration: Some(migration_config),
                     secrets,
-                    capabilities: None,
+                    ..Default::default()
                 },
             },
             status: None,

--- a/bottlerocket/testsys/src/run_sonobuoy.rs
+++ b/bottlerocket/testsys/src/run_sonobuoy.rs
@@ -109,7 +109,6 @@ impl RunSonobuoy {
                     image: self.image.clone(),
                     pull_secret: self.pull_secret.clone(),
                     keep_running: self.keep_running,
-                    timeout: None,
                     configuration: Some(
                         SonobuoyConfig {
                             kubeconfig_base64: kubeconfig_string,
@@ -129,8 +128,7 @@ impl RunSonobuoy {
                             .insert(AWS_CREDENTIALS_SECRET_NAME.to_string(), secret_name.clone());
                         secrets_map
                     }),
-                    // FIXME: Add CLI option for setting this
-                    capabilities: None,
+                    ..Default::default()
                 },
             },
             status: None,

--- a/bottlerocket/testsys/src/run_vmware.rs
+++ b/bottlerocket/testsys/src/run_vmware.rs
@@ -354,10 +354,10 @@ impl RunVmware {
                     image: self.vm_provider_image.clone(),
                     pull_secret: self.vm_provider_pull_secret.clone(),
                     keep_running: self.keep_instance_provider_running,
-                    timeout: None,
                     configuration: Some(vm_config),
                     secrets,
                     capabilities: Some(self.capabilities.clone()),
+                    ..Default::default()
                 },
                 destruction_policy: DestructionPolicy::OnDeletion,
             },
@@ -388,7 +388,6 @@ impl RunVmware {
                     image: self.test_agent_image.clone(),
                     pull_secret: self.test_agent_pull_secret.clone(),
                     keep_running: self.keep_running,
-                    timeout: None,
                     configuration: Some(
                         SonobuoyConfig {
                             kubeconfig_base64: encoded_kubeconfig.to_string(),
@@ -404,6 +403,7 @@ impl RunVmware {
                     ),
                     secrets: Some(secrets),
                     capabilities: Some(self.capabilities.clone()),
+                    ..Default::default()
                 },
             },
             status: None,
@@ -450,10 +450,10 @@ impl RunVmware {
                     image: migration_agent_image.to_string(),
                     pull_secret: migration_agent_pull_secret.clone(),
                     keep_running: self.keep_running,
-                    timeout: None,
                     configuration: Some(migration_config),
                     secrets: Some(secrets),
                     capabilities: Some(self.capabilities.clone()),
+                    ..Default::default()
                 },
             },
             status: None,

--- a/controller/src/job/job_builder.rs
+++ b/controller/src/job/job_builder.rs
@@ -42,11 +42,12 @@ impl JobBuilder<'_> {
         let vars = env_vars(self.environment_variables);
         let labels = create_labels(self.job_type, &self.agent.name, self.job_name);
         // Set up the container's security context
-        let security_context = self.agent.capabilities.as_ref().map(|c| SecurityContext {
-            capabilities: Some(Capabilities {
+        let security_context = Some(SecurityContext {
+            capabilities: self.agent.capabilities.as_ref().map(|c| Capabilities {
                 add: Some(c.to_owned()),
                 ..Capabilities::default()
             }),
+            privileged: self.agent.privileged,
             ..SecurityContext::default()
         });
 

--- a/model/src/agent.rs
+++ b/model/src/agent.rs
@@ -57,6 +57,8 @@ pub struct Agent {
     pub secrets: Option<BTreeMap<SecretType, SecretName>>,
     /// Linux capabilities to add for the agent container, e.g. NET_ADMIN
     pub capabilities: Option<Vec<String>>,
+    /// Whether the agent container needs to be privileged or not
+    pub privileged: Option<bool>,
 }
 
 impl Agent {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
Author: Erikson Tung <etung@amazon.com>
Date:   Thu Sep 22 16:49:01 2022 -0700

    agent: add new `privileged` field
    
    Adds a new `privileged` field for configuring securitycontext.privileged
    for the agent containers.
    
    Use `..Default::default()` when we're instantiating `Agent`s.
```


**Testing done:**
With the following Resouce agent spec:
```
apiVersion: testsys.bottlerocket.aws/v1
kind: Resource
metadata:
  name: vsphere-k8s-cluster-1-23
  namespace: testsys-bottlerocket-aws
spec:
  agent:
    name: vsphere-k8s-cluster-resource-agent
    image: <>.dkr.ecr.us-west-2.amazonaws.com/vsphere-k8s-cluster-resource-agent:latest
    keepRunning: false
    privileged: true
    timeout: 20d
    secrets:
      vsphereCredentials: <>
    configuration:
      creation_policy: IfNotExists
      version: v1.23
      ovaName: "bottlerocket-vmware-k8s-1.23-x86_64-v1.10.1.ova"
      tufRepo:
        metadataUrl: "https://updates.bottlerocket.aws/2020-07-07/vmware-k8s-1.23/x86_64/"
        targetsUrl: "https://updates.bottlerocket.aws/targets"
      vcenterHostUrl: <>
      vcenterDatacenter: <>
      vcenterDatastore: <>
      vcenterNetwork: <>
      vcenterResourcePool: <>
      vcenterWorkloadFolder: <>
      mgmtClusterKubeconfigBase64: <>
      cluster:
        name: br-eksa-123
        controlPlaneEndpointIp: <>
      destructionPolicy: OnDeletion

```

With `privileged: true` defined, the agent is able to run `dockerd` in the pod container as expected:
```bash
$ kubectl logs vsphere-k8s-clu4ba79b28-9733-4f37-99a2-317a743ea0d1-creatitbsw9 -n testsys-bottlerocket-aws -f
[2022-10-21T06:05:05Z INFO  resource_agent::agent] Initializing Agent
[2022-10-21T06:05:05Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Creation policy is 'Create' and cluster 'br-eksa-123' does not exist: creating cluster
[2022-10-21T06:05:05Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Downloading OVA 'bottlerocket-vmware-k8s-1.23-x86_64-v1.10.1.ova'
[2022-10-21T06:05:12Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Importing OVA and creating a VM template out of it
[2022-10-21T06:05:24Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Tagging VM template
2022-10-21T06:05:51.772Z        V4      Logger init completed   {"vlevel": 6}
2022-10-21T06:05:51.773Z        V6      Executing command       {"cmd": "/usr/bin/docker version --format {{.Client.Version}}"}
2022-10-21T06:05:51.800Z        V6      Executing command       {"cmd": "/usr/bin/docker info --format '{{json .MemTotal}}'"}
2022-10-21T06:05:52.232Z        V4      Reading bundles manifest        {"url": "https://anywhere-assets.eks.amazonaws.com/releases/bundles/18/manifest.yaml"}
2022-10-21T06:05:52.583Z        V4      Relative network path specified, using path /SDDC-Datacenter/network/sddc-cgw-network-2
2022-10-21T06:05:52.947Z        V5      Retrier:        {"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2022-10-21T06:05:52.947Z        V2      Pulling docker image    {"image": "public.ecr.aws/eks-anywhere/cli-tools:v0.11.4-eks-a-18"}
2022-10-21T06:05:52.947Z        V6      Executing command       {"cmd": "/usr/bin/docker pull public.ecr.aws/eks-anywhere/cli-tools:v0.11.4-eks-a-18"}
2022-10-21T06:05:59.881Z        V5      Retry execution successful      {"retries": 1, "duration": "6.934506458s"}
2022-10-21T06:05:59.881Z        V3      Initializing long running container     {"name": "eksa_1666332352947367595", "image": "public.ecr.aws/eks-anywhere/cli-tools:v0.11.4-eks-a-18"}
2022-10-21T06:05:59.881Z        V6      Executing command       {"cmd": "/usr/bin/docker run -d --name eksa_1666332352947367595 --network host -w /local/eksa-work -v /var/run/docker.sock:/var/run/docker.sock -v /local:/local -v /local/eksa-work:/local/eksa-work --entrypoint sleep public.ecr.aws/eks-anywhere/cli-tools:v0.11.4-eks-a-18 infinity"}
2022-10-21T06:06:01.854Z        V4      Task start      {"task_name": "setup-validate"}
2022-10-21T06:06:01.854Z        V0      Performing setup and validations
2022-10-21T06:06:01.854Z        V4      Relative network path specified, using path /SDDC-Datacenter/network/sddc-cgw-network-2
2022-10-21T06:06:01.871Z        V0      ✅ Connected to server
2022-10-21T06:06:01.871Z        V5      Retrier:        {"timeout": "2562047h47m16.854775807s", "backoffFactor": null}
2022-10-21T06:06:01.871Z        V6      Executing command       {"cmd": "/usr/bin/docker exec -i -e GOVC_URL=<> -e GOVC_INSECURE=false -e GOVC_DATACENTER=<>-e GOVC_TLS_KNOWN_HOSTS=br-eksa-123/generated/govc_known_hosts -e GOVC_USERNAME=***** -e GOVC_PASSWORD=***** eksa_1666332352947367595 govc about -k"}
...
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
