### PR TITLE
ec2_provider: try to create instances in any subnet in region

### DIFF
--- a/bottlerocket/agents/src/bin/ecs-resource-agent/ecs_provider.rs
+++ b/bottlerocket/agents/src/bin/ecs-resource-agent/ecs_provider.rs
@@ -47,11 +47,11 @@ pub struct CreatedCluster {
     /// The region of the cluster.
     pub region: String,
 
-    /// A public subnet id for this cluster.
-    pub public_subnet_id: Option<String>,
+    /// A vector of public subnet ids for this cluster.
+    pub public_subnet_ids: Vec<String>,
 
-    /// A private subnet id for this cluster.
-    pub private_subnet_id: Option<String>,
+    /// A vector of private subnet ids for this cluster.
+    pub private_subnet_ids: Vec<String>,
 
     /// The iam instance role that was created for ecs
     pub iam_instance_profile_arn: String,
@@ -251,14 +251,10 @@ async fn created_cluster(
     Ok(CreatedCluster {
         cluster_name: cluster_name.to_string(),
         region,
-        public_subnet_id: first_subnet_id(&public_subnet_ids),
-        private_subnet_id: first_subnet_id(&private_subnet_ids),
+        public_subnet_ids,
+        private_subnet_ids,
         iam_instance_profile_arn,
     })
-}
-
-fn first_subnet_id(subnet_ids: &[String]) -> Option<String> {
-    subnet_ids.get(0).map(|id| id.to_string())
 }
 
 async fn default_vpc(ec2_client: &aws_sdk_ec2::Client) -> ProviderResult<String> {

--- a/bottlerocket/agents/src/bin/eks-resource-agent/eks_provider.rs
+++ b/bottlerocket/agents/src/bin/eks-resource-agent/eks_provider.rs
@@ -68,11 +68,11 @@ pub struct CreatedCluster {
     /// The cluster DNS IP.
     pub cluster_dns_ip: String,
 
-    /// A single public subnet id. Will be `None` if no public ids exist.
-    pub public_subnet_id: Option<String>,
+    /// A vector of public subnet ids. Will be empty if no public ids exist.
+    pub public_subnet_ids: Vec<String>,
 
-    /// A single private subnet id. Will be `None` if no private ids exist.
-    pub private_subnet_id: Option<String>,
+    /// A vector of private subnet ids. Will be empty if no private ids exist.
+    pub private_subnet_ids: Vec<String>,
 
     /// Security groups necessary for ec2 instances
     pub security_groups: Vec<String>,
@@ -486,8 +486,8 @@ async fn created_cluster(
         endpoint,
         certificate,
         cluster_dns_ip,
-        public_subnet_id: first_subnet_id(&public_subnet_ids),
-        private_subnet_id: first_subnet_id(&private_subnet_ids),
+        public_subnet_ids,
+        private_subnet_ids,
         nodegroup_sg,
         controlplane_sg,
         clustershared_sg,
@@ -612,10 +612,6 @@ fn cluster_dns_ip_from_service_ipv6_cidr() {
         .unwrap(),
         "fd30:1c53:5f8a::a".to_string()
     )
-}
-
-fn first_subnet_id(subnet_ids: &[String]) -> Option<String> {
-    subnet_ids.get(0).map(|id| id.to_string())
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/bottlerocket/testsys/src/run_aws_ecs.rs
+++ b/bottlerocket/testsys/src/run_aws_ecs.rs
@@ -435,10 +435,6 @@ impl RunAwsEcs {
                             region: Some(format!("${{{}.region}}", cluster_resource_name)),
                             cluster_name: format!("${{{}.clusterName}}", cluster_resource_name),
                             task_count: self.task_count,
-                            subnets: vec![format!(
-                                "${{{}.publicSubnetIds}}",
-                                cluster_resource_name
-                            )],
                             task_definition_name_and_revision: self
                                 .task_definition_name_and_revision
                                 .clone(),

--- a/bottlerocket/testsys/src/run_aws_k8s.rs
+++ b/bottlerocket/testsys/src/run_aws_k8s.rs
@@ -377,7 +377,7 @@ impl RunAwsK8s {
             cluster_name: self.cluster_name.clone(),
             region: self.region.clone(),
             instance_profile_arn: format!("${{{}.iamInstanceProfileArn}}", cluster_resource_name),
-            subnet_id: format!("${{{}.privateSubnetId}}", cluster_resource_name),
+            subnet_ids: vec![],
             cluster_type: ClusterType::Eks,
             endpoint: Some(format!("${{{}.endpoint}}", cluster_resource_name)),
             certificate: Some(format!("${{{}.certificate}}", cluster_resource_name)),
@@ -392,6 +392,14 @@ impl RunAwsK8s {
         let previous_value = ec2_config.insert(
             "securityGroups".to_owned(),
             Value::String(format!("${{{}.securityGroups}}", cluster_resource_name)),
+        );
+        if previous_value.is_none() {
+            todo!("This is an error: fields in the Ec2Config struct have changed")
+        }
+
+        let previous_value = ec2_config.insert(
+            "subnetIds".to_owned(),
+            Value::String(format!("${{{}.privateSubnetIds}}", cluster_resource_name)),
         );
         if previous_value.is_none() {
             todo!("This is an error: fields in the Ec2Config struct have changed")

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -157,8 +157,8 @@ pub struct Ec2Config {
     /// The instance profile that should be attached to these instances.
     pub instance_profile_arn: String,
 
-    /// The subnet the instances should be launched using.
-    pub subnet_id: String,
+    /// The subnets the instances should be launched using.
+    pub subnet_ids: Vec<String>,
 
     /// The type of cluster we are launching instances to.
     pub cluster_type: ClusterType,
@@ -347,7 +347,7 @@ pub struct EcsTestConfig {
     pub cluster_name: String,
     #[serde(default = "default_count")]
     pub task_count: i32,
-    pub subnet: String,
+    pub subnets: Vec<String>,
     /// The task definition (including the revision number) for a custom task to be run. If the task
     /// name is `foo` and the revision is `3`, use `foo:3`. If no
     /// `task_definition_name_and_revision` is provided, the agent will use the latest task

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -347,7 +347,6 @@ pub struct EcsTestConfig {
     pub cluster_name: String,
     #[serde(default = "default_count")]
     pub task_count: i32,
-    pub subnets: Vec<String>,
     /// The task definition (including the revision number) for a custom task to be run. If the task
     /// name is `foo` and the revision is `3`, use `foo:3`. If no
     /// `task_definition_name_and_revision` is provided, the agent will use the latest task


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #578 

**Description of changes:**

Instead of the CRDs containing a single subnet, they will now contain a vector of all of the subnets in a region. This allows the EC2 provider to try to run instances on different availability zones if some of them do not support the instance type. The EC2 provider will iterate over the subnets and try to run instances in each one. If the run_instances method is successful, the function continues with the expected behavior. If not, the function will show a warning and attempt the next subnet. If none of them worked, the function errors out just like before the changes.

**Testing done:**

- Ran instances with GPUs on us-west-2. Before the changes, the code would pick availability zone us-west-2d where GPU instances were not supported. With these changes, the following logs are shown:

```
[2022-09-22T23:05:04Z INFO  resource_agent::agent] Initializing Agent
[2022-09-22T23:05:04Z INFO  ec2_resource_agent::ec2_provider] Beginning instance creation with instance UUID: ******************************
[2022-09-22T23:05:04Z INFO  ec2_resource_agent::ec2_provider] Using instance type 'g2.2xlarge'
[2022-09-22T23:05:04Z INFO  ec2_resource_agent::ec2_provider] Creating 2 instance(s)
[2022-09-22T23:05:04Z INFO  ec2_resource_agent::ec2_provider] Starting instances in subnet subnet-d*******
[2022-09-22T23:05:05Z WARN  ec2_resource_agent::ec2_provider] An error occurred while trying to create instances using subnet subnet-d*******: Error { code: "Unsupported", message: "Your requested instance type (g2.2xlarge) is not supported in your requested Availability Zone (us-west-2d). Please retry your request by not specifying an Availability Zone or choosing us-west-2a, us-west-2b, us-west-2c." }
[2022-09-22T23:05:05Z INFO  ec2_resource_agent::ec2_provider] Starting instances in subnet subnet-c*******
[2022-09-22T23:05:07Z INFO  ec2_resource_agent::ec2_provider] Created instances using subnet subnet-c*******
[2022-09-22T23:05:07Z INFO  ec2_resource_agent::ec2_provider] Checking instance IDs
[2022-09-22T23:05:07Z INFO  ec2_resource_agent::ec2_provider] Waiting for instances to reach the running state
[2022-09-22T23:05:18Z INFO  ec2_resource_agent::ec2_provider] Done: instances {"i-********************", "i-*******************"} are running
```
- Ran `aws_k8s` which resulted in the following output:
```
 NAME                          TYPE        STATE        PASSED    SKIPPED    FAILED  
 eks-test                      Test        passed       1         6441       0       
 eks-test-cluster-instances    Resource    completed                                 
 my-cluster                    Resource    completed                                                                            
```

- Ran `aws_ecs` which resulted in the following output:
```
 NAME                            TYPE          STATE         PASSED     SKIPPED     FAILED   
 external-cluster                Resource      completed                                     
 external-cluster-instances      Resource      completed                                     
 testsys-demo                    Test          passed        1          0           0        

```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
