### PR TITLE
TestManager: Custom columns for status table

### DIFF
--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -24,6 +24,7 @@ pub use resource::{
     ResourceStatus,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 pub use test::{
     AgentStatus, ControllerStatus, Outcome, Test, TestResults, TestSpec, TestStatus, TestUserState,
 };
@@ -69,6 +70,13 @@ impl Crd {
         match self {
             Self::Test(test) => test.metadata.name.to_owned(),
             Self::Resource(resource) => resource.metadata.name.to_owned(),
+        }
+    }
+
+    pub fn labels(&self) -> BTreeMap<String, String> {
+        match self {
+            Self::Test(test) => test.metadata.labels.to_owned().unwrap_or_default(),
+            Self::Resource(resource) => resource.metadata.labels.to_owned().unwrap_or_default(),
         }
     }
 }


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

A step towards https://github.com/bottlerocket-os/bottlerocket/issues/2422
After this pr is merged, `cargo make test` can add the build id as a label and use the new crd label function to write a custom column as `BUILD ID`.

**Description of changes:**

This pr allows users to add additional columns to the status table via `StatusSnapshot::new_column(<HEADER>, <FUNCTION TO GET VALUE>)`. For each crd, the function will be run and the response will be added as an additional column.

**Testing done:**
```rust
status.new_column("ARCH", |crd| crd.labels().get("testsys/arch").cloned())
```
Creates the usual status window with an additional column displaying the value for `testsys/arch` or nothing if the key is not set.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
