### PR TITLE
Updates: Clap to 4.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,33 +689,31 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
  "vec_map",
 ]
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "385007cbbed899260395a4107435fead4cad80684461b3cc78238bdcb0bad58f"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.15.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "db342ce9fda24fb191e2ed4e102055a4d381c1086a06630174cd8da8d5d917ce"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -726,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -739,7 +737,7 @@ version = "0.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "clap 3.2.22",
+ "clap 4.0.12",
  "env_logger",
  "futures",
  "log",
@@ -2863,12 +2861,6 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.0", features = ["derive"] }
 env_logger = "0.9"
 futures = "0.3.24"
 log = "0.4"

--- a/cli/src/add_secret.rs
+++ b/cli/src/add_secret.rs
@@ -35,7 +35,7 @@ pub(crate) struct AddSecretMap {
     name: SecretName,
 
     /// Key value pairs for secrets. (Key=value)
-    #[clap(parse(try_from_str = parse_key_val))]
+    #[clap(value_parser = parse_key_val)]
     args: Vec<(String, String)>,
 }
 

--- a/cli/src/results.rs
+++ b/cli/src/results.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{value_parser, Parser};
 use model::test_manager::TestManager;
 use std::path::PathBuf;
 
@@ -10,7 +10,7 @@ pub(crate) struct Results {
     #[clap(short = 'n', long)]
     test_name: String,
     /// The place the test results should be written (results.tar.gz)
-    #[clap(long, parse(from_os_str), default_value = "results.tar.gz")]
+    #[clap(long, value_parser = value_parser!(PathBuf), default_value = "results.tar.gz")]
     destination: PathBuf,
 }
 

--- a/cli/src/run_file.rs
+++ b/cli/src/run_file.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{value_parser, Parser};
 use model::test_manager::{read_manifest, TestManager};
 use std::path::PathBuf;
 
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 #[derive(Debug, Parser)]
 pub(crate) struct RunFile {
     /// Path to test crd YAML file.
-    #[clap(parse(from_os_str))]
+    #[clap(value_parser = value_parser!(PathBuf))]
     path: PathBuf,
 }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A


**Description of changes:**

This update removed the `parse` attribute for args. This was replaced by `value_parser`. `from_os_str` was also removed and the parser needed to be created using `value_parser!(PathBuf)` for the same functionality.

**Testing done:**

GH actions

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
