### PR TITLE
ec2-resource: accept vector of instance types

### DIFF
--- a/bottlerocket/testsys/src/run_aws_ecs.rs
+++ b/bottlerocket/testsys/src/run_aws_ecs.rs
@@ -355,7 +355,11 @@ impl RunAwsEcs {
             node_ami: self.ami.clone(),
             // TODO - configurable
             instance_count: Some(2),
-            instance_type: self.instance_type.clone(),
+            instance_types: self
+                .instance_type
+                .clone()
+                .map(|instance_type| vec![instance_type])
+                .unwrap_or_default(),
             cluster_name: self.cluster_name.clone(),
             region: self.region.clone(),
             instance_profile_arn: self

--- a/bottlerocket/testsys/src/run_aws_k8s.rs
+++ b/bottlerocket/testsys/src/run_aws_k8s.rs
@@ -373,7 +373,11 @@ impl RunAwsK8s {
             node_ami: self.ami.clone(),
             // TODO - configurable
             instance_count: Some(2),
-            instance_type: self.instance_type.clone(),
+            instance_types: self
+                .instance_type
+                .clone()
+                .map(|instance_type| vec![instance_type])
+                .unwrap_or_default(),
             cluster_name: self.cluster_name.clone(),
             region: self.region.clone(),
             instance_profile_arn: format!("${{{}.iamInstanceProfileArn}}", cluster_resource_name),

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -146,7 +146,7 @@ pub struct Ec2Config {
     /// The type of instance to spin up. m5.large is recommended for x86_64 and m6g.large is
     /// recommended for arm64 on eks. c3.large is recommended for ecs. If no value is provided
     /// the recommended type will be used.
-    pub instance_type: Option<String>,
+    pub instance_types: Vec<String>,
 
     /// The name of the cluster we are creating instances for.
     pub cluster_name: String,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #525 

**Description of changes:**

Changed the `ec2_resource_agent`'s `instance_type` which accepted a string to `instance_types` which accepts a vector of strings. A user can now submit multiple instance types and the EC2 resource agent will try to provision instances of the types in the list until the list is exhausted or instances were successfully created. In case of an error (such as UnsupportedException or InstanceCapacityException) the agent will move on to the next type in the list.

**Testing done:**

- Ran an ECS test with a file containing a vector of three instance types. The EC2 resource agent tried to reserve instances of the first type in each availability zone in the given region, but this resulted in an InstanceCapacityException for each zone. It then moved on to the second type, which returned an UnsupportedException in the first availability zone, but the instances of this second type were successfully created in the second availability zone.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
