### PR TITLE
resource-agents: vSphere K8s cluster provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,6 +118,36 @@ COPY --from=build-src /usr/share/licenses/testsys /licenses/testsys
 ENTRYPOINT ["./ecs-resource-agent"]
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
+# Builds the vSphere K8s cluster resource agent image
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 as vsphere-k8s-cluster-resource-agent
+
+RUN yum install -y tar && yum clean all
+RUN amazon-linux-extras install -y docker
+
+# Copy eksctl
+COPY --from=tools /eksctl /usr/bin/eksctl
+COPY --from=tools /licenses/eksctl /licenses/eksctl
+
+# Copy eksctl-anywhere
+COPY --from=tools /eksctl-anywhere /usr/bin/eksctl-anywhere
+COPY --from=tools /licenses/eksctl-anywhere /licenses/eksctl-anywhere
+
+# Copy govc
+COPY --from=build /usr/libexec/tools/govc /usr/local/bin/govc
+COPY --from=build /usr/share/licenses/govmomi /licenses/govmomi
+
+# Copy kubectl
+COPY --from=tools /kubectl /usr/local/bin/kubectl
+COPY --from=tools /licenses/kubernetes /licenses/kubernetes
+
+# Copy binary
+COPY --from=build-src /src/bottlerocket/agents/bin/vsphere-k8s-cluster-resource-agent ./
+# Copy licenses
+COPY --from=build-src /usr/share/licenses/testsys /licenses/testsys
+
+CMD dockerd --storage-driver vfs &>/dev/null & ./vsphere-k8s-cluster-resource-agent
+
+# =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Builds the ECS test agent image
 FROM public.ecr.aws/amazonlinux/amazonlinux:2 as ecs-test-agent
 # Copy binary

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ TESTSYS_BUILD_GOPROXY ?= direct
 # The set of bottlerocket images to create. Add new artifacts here when added
 # to the project.
 IMAGES = controller sonobuoy-test-agent ec2-resource-agent eks-resource-agent ecs-resource-agent \
-	migration-test-agent vsphere-vm-resource-agent ecs-test-agent
+	migration-test-agent vsphere-vm-resource-agent vsphere-k8s-cluster-resource-agent ecs-test-agent
 
 # Store targets for tagging images
 TAG_IMAGES = $(addprefix tag-, $(IMAGES))
@@ -138,7 +138,7 @@ tools:
 		./tools
 
 # Build the container image for a testsys agent
-eks-resource-agent ec2-resource-agent ecs-resource-agent vsphere-vm-resource-agent sonobuoy-test-agent migration-test-agent ecs-test-agent: show-variables fetch
+eks-resource-agent ec2-resource-agent ecs-resource-agent vsphere-vm-resource-agent vsphere-k8s-cluster-resource-agent sonobuoy-test-agent migration-test-agent ecs-test-agent: show-variables fetch
 	docker build $(DOCKER_BUILD_FLAGS) \
 		--build-arg ARCH="$(TESTSYS_BUILD_HOST_UNAME_ARCH)" \
 		--build-arg BUILDER_IMAGE="$(BUILDER_IMAGE)" \

--- a/bottlerocket/agents/src/bin/vsphere-k8s-cluster-resource-agent/README.md
+++ b/bottlerocket/agents/src/bin/vsphere-k8s-cluster-resource-agent/README.md
@@ -1,0 +1,46 @@
+# vSphere K8s Cluster resource agent
+
+This TestSys resource agent is responsible for provisioning vSphere K8s clusters via Cluster-API vSphere using [EKS Anywhere](https://github.com/aws/eks-anywhere).
+
+## Example configuration for the resource agent
+
+```yaml
+apiVersion: testsys.bottlerocket.aws/v1
+kind: Resource
+metadata:
+  name: my-vsphere-cluster
+  namespace: testsys-bottlerocket-aws
+spec:
+  agent:
+    name: vsphere-k8s-cluster-resource-agent
+    image: <vsphere-k8s-cluster-resource-agent-image>
+    keepRunning: false
+    privileged: true
+    timeout: 20d
+    secrets:
+      vsphereCredentials: <K8s secret storing username/password for vsphere API>
+    configuration:
+      name: br-eksa-123
+      controlPlaneEndpointIp: <IP to allocate for the cluster control plane endpoint>
+      creation_policy: IfNotExists
+      version: v1.23
+      ovaName: <name of the Bottlerocket OVA to import, e.g. "bottlerocket-vmware-k8s-1.23-x86_64-v1.10.1.ova">
+      tufRepo:
+        metadataUrl: "https://updates.bottlerocket.aws/2020-07-07/vmware-k8s-1.23/x86_64/"
+        targetsUrl: "https://updates.bottlerocket.aws/targets"
+      vcenterHostUrl: <vCenter host uRL>
+      vcenterDatacenter: <vCenter datacenter>
+      vcenterDatastore: <vCenter datastore>
+      vcenterNetwork: <vCenter network>
+      vcenterResourcePool: <vCenter resource pool>
+      vcenterWorkloadFolder: <vCenter workload folder>
+      mgmtClusterKubeconfigBase64: <Base64-encoded kubeconfig for the CAPI management cluster used to deploy the vSphere cluster>
+      destructionPolicy: OnDeletion
+```
+
+## How to set up EKS Anywhere cluster for use as management cluster
+
+EKS Anywhere recommends using a separate management cluster for managing different vSphere clusters.
+EKS Anywhere's "Getting Started" instructions has a [section on setting up an inital management cluster](https://anywhere.eks.amazonaws.com/docs/getting-started/production-environment/vsphere-getstarted/#create-an-initial-cluster).
+
+Once the management cluster created, you can base64-encode the kubeconfig for the management cluster and plug the value in the `mgmtClusterKubeconfigBase64` field of the Resource agent configuration.

--- a/bottlerocket/agents/src/bin/vsphere-k8s-cluster-resource-agent/main.rs
+++ b/bottlerocket/agents/src/bin/vsphere-k8s-cluster-resource-agent/main.rs
@@ -1,0 +1,46 @@
+/*!
+
+This resource agent provisions vSphere K8s clusters via CAPI with EKS-Anywhere
+
+!*/
+
+mod vsphere_k8s_cluster_provider;
+
+use crate::vsphere_k8s_cluster_provider::{VSphereK8sClusterCreator, VSphereK8sClusterDestroyer};
+use agent_utils::init_agent_logger;
+use resource_agent::clients::{DefaultAgentClient, DefaultInfoClient};
+use resource_agent::error::AgentResult;
+use resource_agent::{Agent, BootstrapData, Types};
+use std::env;
+use std::marker::PhantomData;
+
+#[tokio::main]
+async fn main() {
+    init_agent_logger(env!("CARGO_CRATE_NAME"), None);
+    let data = match BootstrapData::from_env() {
+        Ok(ok) => ok,
+        Err(e) => {
+            eprintln!("Unable to get bootstrap data: {}", e);
+            std::process::exit(1);
+        }
+    };
+    if let Err(e) = run(data).await {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    };
+}
+
+async fn run(data: BootstrapData) -> AgentResult<()> {
+    let types = Types {
+        info_client: PhantomData::<DefaultInfoClient>::default(),
+        agent_client: PhantomData::<DefaultAgentClient>::default(),
+    };
+    let agent = Agent::new(
+        types,
+        data,
+        VSphereK8sClusterCreator {},
+        VSphereK8sClusterDestroyer {},
+    )
+    .await?;
+    agent.run().await
+}

--- a/bottlerocket/agents/src/bin/vsphere-k8s-cluster-resource-agent/vsphere_k8s_cluster_provider.rs
+++ b/bottlerocket/agents/src/bin/vsphere-k8s-cluster-resource-agent/vsphere_k8s_cluster_provider.rs
@@ -1,0 +1,776 @@
+use agent_utils::base64_decode_write_file;
+use bottlerocket_agents::constants::TEST_CLUSTER_KUBECONFIG_PATH;
+use bottlerocket_agents::tuf::{download_target, tuf_repo_urls};
+use bottlerocket_agents::vsphere::vsphere_credentials;
+use bottlerocket_types::agent_config::{
+    CreationPolicy, VSphereK8sClusterConfig, VSPHERE_CREDENTIALS_SECRET_NAME,
+};
+use k8s_openapi::api::core::v1::{Node, Secret};
+use kube::api::ListParams;
+use kube::config::{KubeConfigOptions, Kubeconfig};
+use kube::{Api, Config};
+use log::{debug, info};
+use model::{Configuration, SecretName};
+use resource_agent::clients::InfoClient;
+use resource_agent::provider::{
+    Create, Destroy, IntoProviderError, ProviderError, ProviderResult, Resources, Spec,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::convert::TryFrom;
+use std::fmt::Debug;
+use std::fs::File;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::{env, fs};
+
+const WORKING_DIR: &str = "/local/eksa-work";
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProductionMemo {
+    /// In this resource we put some traces here that describe what our provider is doing.
+    pub current_status: String,
+
+    /// The name of the cluster we created.
+    pub cluster_name: Option<String>,
+
+    /// Whether the agent was instructed to create the cluster or not.
+    pub creation_policy: Option<CreationPolicy>,
+
+    /// Base64 encoded clusterspec for the workload cluster
+    pub encoded_clusterspec: String,
+
+    /// Name of the VM template for the control plane VMs
+    pub vm_template: String,
+
+    /// The name of the secret containing vCenter credentials.
+    pub vcenter_secret_name: Option<SecretName>,
+}
+
+impl Configuration for ProductionMemo {}
+
+/// Once we have fulfilled the `Create` request, we return information about the cluster we've created
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CreatedVSphereK8sCluster {
+    /// The name of the cluster.
+    pub cluster_name: String,
+
+    /// The cluster server endpoint.
+    pub endpoint: String,
+
+    /// Base64 encoded Kubeconfig for the vSphere K8s cluster
+    pub encoded_kubeconfig: String,
+}
+
+impl Configuration for CreatedVSphereK8sCluster {}
+
+pub struct VSphereK8sClusterCreator {}
+
+#[async_trait::async_trait]
+impl Create for VSphereK8sClusterCreator {
+    type Config = VSphereK8sClusterConfig;
+    type Info = ProductionMemo;
+    type Resource = CreatedVSphereK8sCluster;
+
+    async fn create<I>(
+        &self,
+        spec: Spec<Self::Config>,
+        client: &I,
+    ) -> ProviderResult<Self::Resource>
+    where
+        I: InfoClient,
+    {
+        let mut memo: ProductionMemo = client
+            .get_info()
+            .await
+            .context(Resources::Unknown, "Unable to get info from info client")?;
+        // Keep track of the state of resources
+        let mut resources = Resources::Clear;
+
+        // Get vSphere credentials to authenticate to vCenter via govmomi
+        let secret_name = spec
+            .secrets
+            .get(VSPHERE_CREDENTIALS_SECRET_NAME)
+            .context(resources, "Unable to fetch vSphere credentials")?;
+        vsphere_credentials(client, secret_name, &resources).await?;
+        memo.vcenter_secret_name = Some(secret_name.clone());
+
+        // Set current directory to somewhere other than '/' so eksctl-anywhere won't try to mount
+        // it in a container.
+        fs::create_dir_all(WORKING_DIR).context(
+            resources,
+            format!("Failed to create working directory '{}'", WORKING_DIR),
+        )?;
+        env::set_current_dir(Path::new(WORKING_DIR)).context(
+            resources,
+            format!("Failed to change current directory to {}", WORKING_DIR),
+        )?;
+
+        // Check whether cluster creation is necessary
+        let (do_create, message) = is_cluster_creation_required(
+            &spec.configuration,
+            spec.configuration.creation_policy.unwrap_or_default(),
+        )
+        .await?;
+        memo.current_status = message;
+        info!("{}", memo.current_status);
+        client
+            .send_info(memo.clone())
+            .await
+            .context(resources, "Error sending cluster creation message")?;
+
+        let mgmt_kubeconfig_path = format!("{}/mgmt.kubeconfig", WORKING_DIR);
+        let encoded_kubeconfig = if do_create {
+            let mgmt_k8s_client = write_validate_mgmt_kubeconfig(
+                &spec.configuration,
+                &mgmt_kubeconfig_path,
+                &resources,
+            )
+            .await?;
+            create_vsphere_k8s_cluster(
+                &spec.configuration,
+                &mgmt_kubeconfig_path,
+                &mut resources,
+                &mut memo,
+            )
+            .await?;
+            retrieve_workload_cluster_kubeconfig(
+                mgmt_k8s_client,
+                &spec.configuration.name,
+                &resources,
+            )
+            .await?
+        } else {
+            spec.configuration.kubeconfig_base64.to_owned().context(
+                resources,
+                "Kubeconfig for existing vSphere K8s cluster missing",
+            )?
+        };
+
+        // We are done, set our custom status to say so.
+        memo.current_status = "vSphere K8s cluster created".into();
+
+        client
+            .send_info(memo.clone())
+            .await
+            .context(resources, "Error sending final creation message")?;
+
+        Ok(CreatedVSphereK8sCluster {
+            cluster_name: spec.configuration.name,
+            endpoint: spec.configuration.control_plane_endpoint_ip,
+            encoded_kubeconfig,
+        })
+    }
+}
+
+/// Write out and check CAPI management cluster is accessible and valid
+async fn write_validate_mgmt_kubeconfig(
+    config: &VSphereK8sClusterConfig,
+    mgmt_kubeconfig_path: &str,
+    resources: &Resources,
+) -> ProviderResult<kube::client::Client> {
+    debug!("Decoding and writing out kubeconfig for the CAPI management cluster");
+    base64_decode_write_file(&config.mgmt_cluster_kubeconfig_base64, mgmt_kubeconfig_path)
+        .await
+        .context(
+            resources,
+            "Failed to write out kubeconfig for the CAPI management cluster",
+        )?;
+    let mgmt_kubeconfig = Kubeconfig::read_from(&mgmt_kubeconfig_path)
+        .context(resources, "Unable to read kubeconfig")?;
+    let mgmt_config =
+        Config::from_custom_kubeconfig(mgmt_kubeconfig.to_owned(), &KubeConfigOptions::default())
+            .await
+            .context(resources, "Unable load kubeconfig")?;
+    kube::client::Client::try_from(mgmt_config)
+        .context(resources, "Unable create K8s client from kubeconfig")
+}
+
+async fn is_cluster_creation_required(
+    config: &VSphereK8sClusterConfig,
+    creation_policy: CreationPolicy,
+) -> ProviderResult<(bool, String)> {
+    let cluster_exists = does_cluster_exist(config).await?;
+    match creation_policy {
+        CreationPolicy::Create if cluster_exists =>
+            Err(
+                ProviderError::new_with_context(
+                    Resources::Clear, format!(
+                        "The cluster '{}' already existed and creation policy '{:?}' requires that it not exist",
+                        config.name,
+                        creation_policy
+                    )
+                )
+            ),
+        CreationPolicy::Never if !cluster_exists =>
+            Err(
+                ProviderError::new_with_context(
+                    Resources::Clear, format!(
+                        "The cluster '{}' does not exist and creation policy '{:?}' requires that it exist",
+                        config.name,
+                        creation_policy
+                    )
+                )
+            ),
+        CreationPolicy::Create  =>{
+            Ok((true, format!("Creation policy is '{:?}' and cluster '{}' does not exist: creating cluster", creation_policy, config.name)))
+        },
+        CreationPolicy::IfNotExists if !cluster_exists => {
+            Ok((true, format!("Creation policy is '{:?}' and cluster '{}' does not exist: creating cluster", creation_policy, config.name)))
+        },
+        CreationPolicy::IfNotExists |
+        CreationPolicy::Never => {
+            Ok((false, format!("Creation policy is '{:?}' and cluster '{}' exists: not creating cluster", creation_policy, config.name)))
+        },
+    }
+}
+
+async fn does_cluster_exist(config: &VSphereK8sClusterConfig) -> ProviderResult<bool> {
+    if let Some(kubeconfig_base64) = &config.kubeconfig_base64 {
+        base64_decode_write_file(kubeconfig_base64, TEST_CLUSTER_KUBECONFIG_PATH)
+            .await
+            .context(
+                Resources::Clear,
+                "Failed to write out kubeconfig for vSphere K8s cluster",
+            )?;
+        let kubeconfig = Kubeconfig::read_from(TEST_CLUSTER_KUBECONFIG_PATH)
+            .context(Resources::Clear, "Unable to read kubeconfig")?;
+        let config =
+            Config::from_custom_kubeconfig(kubeconfig.to_owned(), &KubeConfigOptions::default())
+                .await
+                .context(Resources::Clear, "Unable load kubeconfig")?;
+        let k8s_client = kube::client::Client::try_from(config)
+            .context(Resources::Clear, "Unable create K8s client from kubeconfig")?;
+        let k8s_nodes: Api<Node> = Api::all(k8s_client);
+        let node_list = k8s_nodes.list(&ListParams::default()).await;
+        if node_list.is_ok() {
+            // If we can query nodes from the cluster, then we've validate that the kubeconfig is valid
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+async fn create_vsphere_k8s_cluster(
+    config: &VSphereK8sClusterConfig,
+    mgmt_kubeconfig_path: &str,
+    resources: &mut Resources,
+    memo: &mut ProductionMemo,
+) -> ProviderResult<()> {
+    let (metadata_url, targets_url) = tuf_repo_urls(&config.tuf_repo, resources)?;
+
+    // Set up environment variables for govc cli
+    set_govc_env_vars(config);
+
+    // Retrieve the OVA file
+    let ova_name = config.ova_name.to_owned();
+    info!("Downloading OVA '{}'", &config.ova_name);
+    let outdir = Path::new("/local/");
+    tokio::task::spawn_blocking(move || -> ProviderResult<()> {
+        download_target(
+            Resources::Clear,
+            &metadata_url,
+            &targets_url,
+            outdir,
+            &ova_name,
+        )
+    })
+    .await
+    .context(*resources, "Failed to join threads")??;
+
+    // Update the import spec for the OVA
+    let import_spec_output = Command::new("govc")
+        .arg("import.spec")
+        .arg(format!("/local/{}", &config.ova_name))
+        .output()
+        .context(*resources, "Failed to start govc")?;
+    let mut import_spec: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&import_spec_output.stdout))
+            .context(*resources, "Failed to deserialize govc import.spec output")?;
+    let network_mappings = import_spec
+        .get_mut("NetworkMapping")
+        .and_then(|network_mapping| network_mapping.as_array_mut())
+        .context(*resources, "Missing network mappings for VM network")?;
+    network_mappings.clear();
+    network_mappings.push(json!({"Name": "VM Network", "Network": &config.vcenter_network}));
+    *import_spec
+        .get_mut("MarkAsTemplate")
+        .context(*resources, "Missing 'MarkAsTemplate' in Import spec")? = json!(true);
+    let import_spec_file = File::create("/local/ova.importspec")
+        .context(*resources, "Failed to create ova import spec file")?;
+    serde_json::to_writer_pretty(&import_spec_file, &import_spec)
+        .context(*resources, "Failed to write out OVA import spec file")?;
+
+    // Import OVA and create a template out of it
+    info!("Importing OVA and creating a VM template out of it");
+    let vm_template_name = format!("{}-eksa-vmtemplate", &config.name);
+    let import_ova_output = Command::new("govc")
+        .arg("import.ova")
+        .arg("-options=/local/ova.importspec")
+        .arg(format!("-name={}", vm_template_name))
+        .arg(format!("/local/{}", &config.ova_name))
+        .output()
+        .context(*resources, "Failed to launch govc process")?;
+    *resources = Resources::Unknown;
+    if !import_ova_output.status.success() {
+        return Err(ProviderError::new_with_context(
+            *resources,
+            format!(
+                "Failed to import OVA: {}",
+                String::from_utf8_lossy(&import_ova_output.stderr)
+            ),
+        ));
+    }
+    *resources = Resources::Remaining;
+    memo.vm_template = vm_template_name.to_owned();
+
+    // EKS-A expects tags on the VM template
+    let vm_full_path = format!(
+        "{}/{}",
+        config.vcenter_workload_folder.trim_end_matches('/'),
+        vm_template_name
+    );
+    info!("Tagging VM template");
+    // Create the 'os' tag category
+    Command::new("govc")
+        .args(["tags.category.create", "-m", "-t", "VirtualMachine", "os"])
+        .output()
+        .context(*resources, "Failed to launch govc process")?;
+    // Create the 'os:bottlerocket' tag
+    // We don't check the command status since we just need the tag to exist and we don't care
+    // if it already exists. If it failed to create the tag, we'll find out when we try to tag.
+    Command::new("govc")
+        .args(["tags.create", "-c", "os", "os:bottlerocket"])
+        .output()
+        .context(*resources, "Failed to launch govc process")?;
+    // Tag the VM template with the OS tag
+    let tag_attach_output = Command::new("govc")
+        .args(["tags.attach", "os:bottlerocket"])
+        .arg(&vm_full_path)
+        .output()
+        .context(*resources, "Failed to launch govc process")?;
+    if !tag_attach_output.status.success() {
+        return Err(ProviderError::new_with_context(
+            *resources,
+            format!(
+                "Failed to tag VM template '{}': {}",
+                vm_template_name,
+                String::from_utf8_lossy(&tag_attach_output.stderr)
+            ),
+        ));
+    }
+    // Create the 'eksdRelease' tag category
+    Command::new("govc")
+        .args([
+            "tags.category.create",
+            "-m",
+            "-t",
+            "VirtualMachine",
+            "eksdRelease",
+        ])
+        .output()
+        .context(*resources, "Failed to launch govc process")?;
+    // Create the 'eksRelease' tag, e.g 'eksRelease:kubernetes-1-23-eks-6'
+    // EKS-A needs to make sure the VM template is tagged with a compatible EKS-D release number.
+    // Finding out which EKS-D release we're using in a given Bottlerocket OVA is hard and
+    // we really really don't care which EKS-D release for a given K8s cluster version we're
+    // testing here, we're just going to tag the VM template with a range of release numbers.
+    // The tag just has to exist for EKS-A to be happy. We choose 50 since it's highly unlikely
+    // a given K8s minor version will have 50 EKS-D releases.
+    let k8s_ver_str = config
+        .version
+        .context(*resources, "K8s version missing from configuration")?
+        .major_minor_without_v()
+        .replace('.', "-");
+    for release_number in 1..50 {
+        let eksd_ver_str = format!("kubernetes-{}-eks-{}", k8s_ver_str, release_number);
+        // Same reasons as above, we don't need to check the status here
+        Command::new("govc")
+            .args(["tags.create", "-c", "eksdRelease"])
+            .arg(&format!("eksdRelease:{}", eksd_ver_str))
+            .output()
+            .context(*resources, "Failed to launch govc process")?;
+        // Tag the VM template with the EKSD tag
+        let tag_attach_output = Command::new("govc")
+            .args(["tags.attach", &format!("eksdRelease:{}", eksd_ver_str)])
+            .arg(&vm_full_path)
+            .output()
+            .context(*resources, "Failed to launch govc process")?;
+        if !tag_attach_output.status.success() {
+            return Err(ProviderError::new_with_context(
+                *resources,
+                format!(
+                    "Failed to tag VM template '{}': {}",
+                    vm_template_name,
+                    String::from_utf8_lossy(&tag_attach_output.stderr)
+                ),
+            ));
+        }
+    }
+
+    // Set up EKS-A vSphere cluster spec file
+    let clusterspec_path = format!("{}/vsphere-k8s-clusterspec.yaml", WORKING_DIR);
+    write_vsphere_clusterspec(config, vm_template_name, resources, &clusterspec_path, memo).await?;
+
+    // Call eksctl-anywhere to create cluster with existing mgmt cluster in vsphere
+    let status = Command::new("eksctl")
+        .args(["anywhere", "create", "cluster"])
+        .args(["--kubeconfig", mgmt_kubeconfig_path])
+        .args(["-f", &clusterspec_path])
+        .args(["-v", "4"])
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .context(*resources, "Failed to launch eksctl process")?;
+    if !status.success() {
+        return Err(ProviderError::new_with_context(
+            Resources::Remaining,
+            format!(
+                "Failed to create EKS-A vSphere cluster with status code {}",
+                status
+            ),
+        ));
+    }
+
+    // Scale the default NodeGroup's MachineDeployment to '0' since we're going to launch fresh
+    // instances during tests.
+    // FIXME: When Cluster API has a Rust library for its CRDs, switch to using that instead of 'kubectl'
+    info!("Scaling default NodeGroup machinedeployments replicas to 0");
+    let default_md = format!("machinedeployments/{}-md-0", config.name);
+    let status = Command::new("kubectl")
+        .args(["--kubeconfig", mgmt_kubeconfig_path])
+        .args(["scale", &default_md, "--replicas=0"])
+        .args(["-n", "eksa-system"])
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .context(*resources, "Failed to launch kubectl process")?;
+    if !status.success() {
+        return Err(ProviderError::new_with_context(
+            Resources::Remaining,
+            format!(
+                "Failed to scale # of machines in NodeGroup '{}'",
+                default_md
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+async fn write_vsphere_clusterspec(
+    config: &VSphereK8sClusterConfig,
+    vm_template_name: String,
+    resources: &Resources,
+    clusterspec_path: &str,
+    memo: &mut ProductionMemo,
+) -> ProviderResult<()> {
+    let cluster_name = config.name.to_owned();
+    let cluster_version = config.version.unwrap_or_default().major_minor_without_v();
+    let endpoint_ip = config.control_plane_endpoint_ip.to_owned();
+    let vcenter_datacenter = config.vcenter_datacenter.to_owned();
+    let vcenter_network = config.vcenter_network.to_owned();
+    let vcenter_host_url = config.vcenter_host_url.to_owned();
+    let vcenter_datastore = config.vcenter_datastore.to_owned();
+    let vcenter_workload_folder = config.vcenter_workload_folder.to_owned();
+    let vcenter_resource_pool = config.vcenter_resource_pool.to_owned();
+
+    let about_cert_output = Command::new("govc")
+        .args(["about.cert", "-k", "-json"])
+        .output()
+        .context(*resources, "Failed to launch govc process")?;
+    if !about_cert_output.status.success() {
+        return Err(ProviderError::new_with_context(
+            resources,
+            format!(
+                "Failed to query vCenter server certificate for '{}': {}",
+                vcenter_host_url,
+                String::from_utf8_lossy(&about_cert_output.stderr)
+            ),
+        ));
+    }
+    let about_cert: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&about_cert_output.stdout))
+            .context(*resources, "Failed to deserialize 'govc about.cert' output")?;
+    let vcenter_thumbprint = about_cert
+        .get("ThumbprintSHA1")
+        .and_then(|t| t.as_str())
+        .context(
+            resources,
+            format!(
+                "Failed to get the SHA1 thumbprint from vCenter server certificate for '{}'",
+                vcenter_host_url
+            ),
+        )?;
+
+    let clusterspec = format!(
+        r###"apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: Cluster
+metadata:
+  name: {cluster_name}
+spec:
+  clusterNetwork:
+    cniConfig:
+      cilium: {{}}
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    services:
+      cidrBlocks:
+      - 10.96.0.0/12
+  controlPlaneConfiguration:
+    count: 2
+    endpoint:
+      host: "{endpoint_ip}"
+    machineGroupRef:
+      kind: VSphereMachineConfig
+      name: {cluster_name}-node
+  datacenterRef:
+    kind: VSphereDatacenterConfig
+    name: {cluster_name}
+  externalEtcdConfiguration:
+    count: 3
+    machineGroupRef:
+      kind: VSphereMachineConfig
+      name: {cluster_name}-node
+  kubernetesVersion: "{cluster_version}"
+  workerNodeGroupConfigurations:
+  - count: 1
+    machineGroupRef:
+      kind: VSphereMachineConfig
+      name: {cluster_name}-node
+    name: md-0
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereDatacenterConfig
+metadata:
+  name: {cluster_name}
+spec:
+  datacenter: "{vcenter_datacenter}"
+  insecure: false
+  network: "{vcenter_network}"
+  server: "{vcenter_host_url}"
+  thumbprint: "{vcenter_thumbprint}"
+---
+apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+kind: VSphereMachineConfig
+metadata:
+  name: {cluster_name}-node
+spec:
+  diskGiB: 25
+  memoryMiB: 8192
+  numCPUs: 2
+  osFamily: bottlerocket
+  datastore: "{vcenter_datastore}"
+  folder: "{vcenter_workload_folder}"
+  template: "{vm_template_name}"
+  resourcePool: "{vcenter_resource_pool}"
+"###
+    );
+    debug!("{}", &clusterspec);
+    memo.encoded_clusterspec = base64::encode(&clusterspec);
+    fs::write(clusterspec_path, clusterspec).context(
+        resources,
+        format!(
+            "Failed to write vSphere cluster spec to '{}'",
+            clusterspec_path
+        ),
+    )
+}
+
+/// Retrieve the kubeconfig for the vSphere K8s workload cluster from the CAPI mgmt cluster
+async fn retrieve_workload_cluster_kubeconfig(
+    mgmt_k8s_client: kube::client::Client,
+    cluster_name: &str,
+    resources: &Resources,
+) -> ProviderResult<String> {
+    let k8s_secrets: Api<Secret> = Api::namespaced(mgmt_k8s_client, "eksa-system");
+    let kubeconfig_secret = k8s_secrets
+        .get(&format!("{}-kubeconfig", cluster_name))
+        .await
+        .context(
+            resources,
+            format!(
+                "vSphere K8s cluster '{}' does not exist in CAPI mgmt cluster",
+                cluster_name
+            ),
+        )?;
+    let encoded_kubeconfig = kubeconfig_secret
+        .data
+        .context(resources, "Missing kubeconfig secret")?
+        .get("value")
+        .context(resources, "Missing base64-encoded kubeconfig secret value")?
+        .to_owned();
+    Ok(serde_json::to_string(&encoded_kubeconfig)
+        .context(
+            resources,
+            "Unable to serialize kubeconfig secret ByteString to String",
+        )?
+        .trim_matches('"')
+        .to_string())
+}
+
+/// This is the object that will destroy vSphere K8s clusters.
+pub struct VSphereK8sClusterDestroyer {}
+
+#[async_trait::async_trait]
+impl Destroy for VSphereK8sClusterDestroyer {
+    type Config = VSphereK8sClusterConfig;
+    type Info = ProductionMemo;
+    type Resource = CreatedVSphereK8sCluster;
+
+    async fn destroy<I>(
+        &self,
+        spec: Option<Spec<Self::Config>>,
+        resource: Option<Self::Resource>,
+        client: &I,
+    ) -> ProviderResult<()>
+    where
+        I: InfoClient,
+    {
+        let mut memo: ProductionMemo = client.get_info().await.map_err(|e| {
+            ProviderError::new_with_source_and_context(
+                Resources::Unknown,
+                "Unable to get info from client",
+                e,
+            )
+        })?;
+        let resources = if memo.cluster_name.is_some() || !memo.vm_template.is_empty() {
+            Resources::Remaining
+        } else {
+            Resources::Clear
+        };
+        let spec = spec.context(resources, "Missing vSphere K8s cluster resource agent spec")?;
+        let resource = resource.context(resources, "Missing created resource information")?;
+
+        // Get vSphere credentials to authenticate to vCenter via govmomi
+        let secret_name = spec
+            .secrets
+            .get(VSPHERE_CREDENTIALS_SECRET_NAME)
+            .context(resources, "Unable to fetch vSphere credentials")?;
+        vsphere_credentials(client, secret_name, &resources).await?;
+
+        // Set up environment variables for govc cli
+        set_govc_env_vars(&spec.configuration);
+
+        // Set current directory to somewhere other than '/' so eksctl-anywhere won't try to mount
+        // it in a container.
+        fs::create_dir_all(WORKING_DIR).context(
+            resources,
+            format!("Failed to create working directory '{}'", WORKING_DIR),
+        )?;
+        env::set_current_dir(Path::new(WORKING_DIR)).context(
+            resources,
+            format!("Failed to change current directory to {}", WORKING_DIR),
+        )?;
+
+        // Delete the VM template
+        let vm_destroy_output = Command::new("govc")
+            .arg("vm.destroy")
+            .arg(&memo.vm_template)
+            .output()
+            .context(resources, "Failed to start govc")?;
+        if !vm_destroy_output.status.success() {
+            return Err(ProviderError::new_with_context(
+                resources,
+                format!(
+                    "Failed to VM template '{}': {}",
+                    &memo.vm_template,
+                    String::from_utf8_lossy(&vm_destroy_output.stderr)
+                ),
+            ));
+        }
+        memo.vm_template = "".to_string();
+
+        let mgmt_kubeconfig_path = format!("{}/mgmt.kubeconfig", WORKING_DIR);
+        debug!("Decoding and writing out kubeconfig for the CAPI management cluster");
+        base64_decode_write_file(
+            &spec.configuration.mgmt_cluster_kubeconfig_base64,
+            &mgmt_kubeconfig_path,
+        )
+        .await
+        .context(
+            resources,
+            "Failed to write out kubeconfig for the CAPI management cluster",
+        )?;
+
+        // For cluster deletion, EKS-A needs the workload cluster's kubeconfig at
+        // './${CLUSTER_NAME}/${CLUSTER_NAME}-eks-a-cluster.kubeconfig'
+        let cluster_dir = format!("{}/{}/", WORKING_DIR, &spec.configuration.name);
+        fs::create_dir_all(&cluster_dir).context(
+            resources,
+            format!(
+                "Failed to create EKS-A cluster directory '{}'",
+                &cluster_dir
+            ),
+        )?;
+        debug!("Decoding and writing out kubeconfig for workload cluster");
+        base64_decode_write_file(
+            &resource.encoded_kubeconfig,
+            &format!(
+                "{}/{}-eks-a-cluster.kubeconfig",
+                &cluster_dir, &spec.configuration.name
+            ),
+        )
+        .await
+        .context(
+            resources,
+            "Failed to write out kubeconfig for workload cluster",
+        )?;
+
+        debug!("Decoding and writing out EKS-A clusterspec");
+        base64_decode_write_file(
+            &memo.encoded_clusterspec,
+            &format!(
+                "{}/{}-eks-a-cluster.yaml",
+                &cluster_dir, &spec.configuration.name
+            ),
+        )
+        .await
+        .context(resources, "Failed to write out EKS-A clusterspec")?;
+
+        // Delete the cluster with EKS-A
+        info!(
+            "Deleting vSphere K8s cluster '{}'",
+            &spec.configuration.name
+        );
+        let status = Command::new("eksctl")
+            .args(["anywhere", "delete", "cluster"])
+            .args(["--kubeconfig", &mgmt_kubeconfig_path])
+            .arg(spec.configuration.name)
+            .args(["-v", "4"])
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()
+            .context(resources, "Failed to run eksctl-anywhere delete command")?;
+        if !status.success() {
+            return Err(ProviderError::new_with_context(
+                Resources::Orphaned,
+                format!("Failed to delete cluster with status code {}", status),
+            ));
+        }
+        memo.cluster_name = None;
+
+        memo.current_status = "vSphere K8s cluster deleted".into();
+        client.send_info(memo.clone()).await.map_err(|e| {
+            ProviderError::new_with_source_and_context(
+                Resources::Clear,
+                "Error sending final destruction message",
+                e,
+            )
+        })?;
+
+        Ok(())
+    }
+}
+
+pub fn set_govc_env_vars(config: &VSphereK8sClusterConfig) {
+    env::set_var("GOVC_URL", &config.vcenter_host_url);
+    env::set_var("GOVC_DATACENTER", &config.vcenter_datacenter);
+    env::set_var("GOVC_DATASTORE", &config.vcenter_datastore);
+    env::set_var("GOVC_NETWORK", &config.vcenter_network);
+    env::set_var("GOVC_RESOURCE_POOL", &config.vcenter_resource_pool);
+    env::set_var("GOVC_FOLDER", &config.vcenter_workload_folder);
+}

--- a/bottlerocket/agents/src/bin/vsphere-vm-resource-agent/main.rs
+++ b/bottlerocket/agents/src/bin/vsphere-vm-resource-agent/main.rs
@@ -5,7 +5,6 @@ Provides Bottlerocket VMWare vSphere VMs to serve as Kubernetes nodes via `govc`
 !*/
 
 mod aws;
-mod tuf;
 mod vsphere_vm_provider;
 
 use crate::vsphere_vm_provider::{VMCreator, VMDestroyer};

--- a/bottlerocket/agents/src/bin/vsphere-vm-resource-agent/vsphere_vm_provider.rs
+++ b/bottlerocket/agents/src/bin/vsphere-vm-resource-agent/vsphere_vm_provider.rs
@@ -136,14 +136,15 @@ impl Create for VMCreator {
 
         let vsphere_cluster = spec.configuration.cluster.clone();
         debug!("Decoding and writing out kubeconfig for vSphere cluster");
-        if let Some(kubeconfig_base64) = vsphere_cluster.kubeconfig_base64 {
-            base64_decode_write_file(&kubeconfig_base64, TEST_CLUSTER_KUBECONFIG_PATH)
-                .await
-                .context(
-                    Resources::Clear,
-                    "Failed to write out kubeconfig for vSphere cluster",
-                )?;
-        }
+        base64_decode_write_file(
+            &vsphere_cluster.kubeconfig_base64,
+            TEST_CLUSTER_KUBECONFIG_PATH,
+        )
+        .await
+        .context(
+            Resources::Clear,
+            "Failed to write out kubeconfig for vSphere cluster",
+        )?;
         let kubeconfig_arg = vec!["--kubeconfig", TEST_CLUSTER_KUBECONFIG_PATH];
         let kubeconfig = Kubeconfig::read_from(TEST_CLUSTER_KUBECONFIG_PATH)
             .context(resources, "Unable to read kubeconfig")?;

--- a/bottlerocket/agents/src/bin/vsphere-vm-resource-agent/vsphere_vm_provider.rs
+++ b/bottlerocket/agents/src/bin/vsphere-vm-resource-agent/vsphere_vm_provider.rs
@@ -1,10 +1,11 @@
 use crate::aws::{create_ssm_activation, ensure_ssm_service_role, wait_for_ssm_ready};
-use crate::tuf::download_target;
 use agent_utils::aws::aws_resource_config;
 use agent_utils::base64_decode_write_file;
 use bottlerocket_agents::constants::TEST_CLUSTER_KUBECONFIG_PATH;
+use bottlerocket_agents::tuf::{download_target, tuf_repo_urls};
+use bottlerocket_agents::vsphere::vsphere_credentials;
 use bottlerocket_types::agent_config::{
-    TufRepoConfig, VSphereVmConfig, AWS_CREDENTIALS_SECRET_NAME, VSPHERE_CREDENTIALS_SECRET_NAME,
+    VSphereVmConfig, AWS_CREDENTIALS_SECRET_NAME, VSPHERE_CREDENTIALS_SECRET_NAME,
 };
 use k8s_openapi::api::core::v1::Service;
 use kube::api::ListParams;
@@ -26,7 +27,6 @@ use std::fs::File;
 use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
-use url::Url;
 
 /// The default number of VMs to spin up.
 const DEFAULT_VM_COUNT: i32 = 2;
@@ -136,15 +136,14 @@ impl Create for VMCreator {
 
         let vsphere_cluster = spec.configuration.cluster.clone();
         debug!("Decoding and writing out kubeconfig for vSphere cluster");
-        base64_decode_write_file(
-            &vsphere_cluster.kubeconfig_base64,
-            TEST_CLUSTER_KUBECONFIG_PATH,
-        )
-        .await
-        .context(
-            Resources::Clear,
-            "Failed to write out kubeconfig for vSphere cluster",
-        )?;
+        if let Some(kubeconfig_base64) = vsphere_cluster.kubeconfig_base64 {
+            base64_decode_write_file(&kubeconfig_base64, TEST_CLUSTER_KUBECONFIG_PATH)
+                .await
+                .context(
+                    Resources::Clear,
+                    "Failed to write out kubeconfig for vSphere cluster",
+                )?;
+        }
         let kubeconfig_arg = vec!["--kubeconfig", TEST_CLUSTER_KUBECONFIG_PATH];
         let kubeconfig = Kubeconfig::read_from(TEST_CLUSTER_KUBECONFIG_PATH)
             .context(resources, "Unable to read kubeconfig")?;
@@ -401,24 +400,6 @@ impl Create for VMCreator {
     }
 }
 
-fn tuf_repo_urls(tuf_repo: &TufRepoConfig, resources: &Resources) -> ProviderResult<(Url, Url)> {
-    let metadata_url = Url::parse(&tuf_repo.metadata_url).context(
-        resources,
-        format!(
-            "Failed to parse TUF repo's metadata URL '{}'",
-            tuf_repo.metadata_url
-        ),
-    )?;
-    let targets_url = Url::parse(&tuf_repo.targets_url).context(
-        resources,
-        format!(
-            "Failed to parse TUF repo's targets URL '{}'",
-            tuf_repo.targets_url
-        ),
-    )?;
-    Ok((metadata_url, targets_url))
-}
-
 fn userdata(
     endpoint: &str,
     cluster_dns_ip: &str,
@@ -572,52 +553,7 @@ impl Destroy for VMDestroyer {
     }
 }
 
-// Helper for getting the vsphere credentials and setting up GOVC_USERNAME and GOVC_PASSWORD env vars
-async fn vsphere_credentials<I>(
-    client: &I,
-    vsphere_secret_name: &SecretName,
-    resource: &Resources,
-) -> ProviderResult<()>
-where
-    I: InfoClient,
-{
-    let vsphere_secret = client.get_secret(vsphere_secret_name).await.context(
-        Resources::Clear,
-        format!("Error getting secret '{}'", vsphere_secret_name),
-    )?;
-
-    let username = String::from_utf8(
-        vsphere_secret
-            .get("username")
-            .context(
-                resource,
-                format!(
-                    "vsphere username missing from secret '{}'",
-                    vsphere_secret_name
-                ),
-            )?
-            .to_owned(),
-    )
-    .context(resource, "Could not convert vsphere username to String")?;
-    let password = String::from_utf8(
-        vsphere_secret
-            .get("password")
-            .context(
-                resource,
-                format!(
-                    "vsphere password missing from secret '{}'",
-                    vsphere_secret_name
-                ),
-            )?
-            .to_owned(),
-    )
-    .context(resource, "Could not convert secret-access-key to String")?;
-    env::set_var("GOVC_USERNAME", username);
-    env::set_var("GOVC_PASSWORD", password);
-    Ok(())
-}
-
-fn set_govc_env_vars(config: &VSphereVmConfig) {
+pub fn set_govc_env_vars(config: &VSphereVmConfig) {
     env::set_var("GOVC_URL", &config.vcenter_host_url);
     env::set_var("GOVC_DATACENTER", &config.vcenter_datacenter);
     env::set_var("GOVC_DATASTORE", &config.vcenter_datastore);

--- a/bottlerocket/agents/src/lib.rs
+++ b/bottlerocket/agents/src/lib.rs
@@ -9,3 +9,5 @@ This `lib.rs` provides code that is used by multiple agent binaries or used by t
 pub mod constants;
 pub mod error;
 pub mod sonobuoy;
+pub mod tuf;
+pub mod vsphere;

--- a/bottlerocket/agents/src/lib.rs
+++ b/bottlerocket/agents/src/lib.rs
@@ -6,8 +6,51 @@ This `lib.rs` provides code that is used by multiple agent binaries or used by t
 
 !*/
 
+use bottlerocket_types::agent_config::CreationPolicy;
+use resource_agent::provider::{ProviderError, ProviderResult, Resources};
+
 pub mod constants;
 pub mod error;
 pub mod sonobuoy;
 pub mod tuf;
 pub mod vsphere;
+
+/// Determines whether a cluster resource needs to be created given its creation policy
+pub async fn is_cluster_creation_required(
+    cluster_exists: &bool,
+    cluster_name: &str,
+    creation_policy: &CreationPolicy,
+) -> ProviderResult<(bool, String)> {
+    match creation_policy {
+        CreationPolicy::Create if *cluster_exists =>
+            Err(
+                ProviderError::new_with_context(
+                    Resources::Clear, format!(
+                        "The cluster '{}' already existed and creation policy '{:?}' requires that it not exist",
+                        cluster_name,
+                        creation_policy
+                    )
+                )
+            ),
+        CreationPolicy::Never if !*cluster_exists =>
+            Err(
+                ProviderError::new_with_context(
+                    Resources::Clear, format!(
+                        "The cluster '{}' does not exist and creation policy '{:?}' requires that it exist",
+                        cluster_name,
+                        creation_policy
+                    )
+                )
+            ),
+        CreationPolicy::Create  =>{
+            Ok((true, format!("Creation policy is '{:?}' and cluster '{}' does not exist: creating cluster", creation_policy, cluster_name)))
+        },
+        CreationPolicy::IfNotExists if !*cluster_exists => {
+            Ok((true, format!("Creation policy is '{:?}' and cluster '{}' does not exist: creating cluster", creation_policy, cluster_name)))
+        },
+        CreationPolicy::IfNotExists |
+        CreationPolicy::Never => {
+            Ok((false, format!("Creation policy is '{:?}' and cluster '{}' exists: not creating cluster", creation_policy, cluster_name)))
+        },
+    }
+}

--- a/bottlerocket/agents/src/tuf.rs
+++ b/bottlerocket/agents/src/tuf.rs
@@ -1,3 +1,4 @@
+use bottlerocket_types::agent_config::TufRepoConfig;
 use resource_agent::provider::{IntoProviderError, ProviderResult, Resources};
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -6,7 +7,29 @@ use url::Url;
 
 const ROOT_FILE_NAME: &str = "1.root.json";
 
-pub(crate) fn download_target(
+/// Parse both TUF urls for downloading OVAs
+pub fn tuf_repo_urls(
+    tuf_repo: &TufRepoConfig,
+    resources: &Resources,
+) -> ProviderResult<(Url, Url)> {
+    let metadata_url = Url::parse(&tuf_repo.metadata_url).context(
+        resources,
+        format!(
+            "Failed to parse TUF repo's metadata URL '{}'",
+            tuf_repo.metadata_url
+        ),
+    )?;
+    let targets_url = Url::parse(&tuf_repo.targets_url).context(
+        resources,
+        format!(
+            "Failed to parse TUF repo's targets URL '{}'",
+            tuf_repo.targets_url
+        ),
+    )?;
+    Ok((metadata_url, targets_url))
+}
+
+pub fn download_target(
     resources: Resources,
     metadata_url: &Url,
     targets_url: &Url,
@@ -41,7 +64,7 @@ pub(crate) fn download_target(
     Ok(())
 }
 
-fn download_root<P>(
+pub fn download_root<P>(
     resources: Resources,
     metadata_base_url: &Url,
     outdir: P,

--- a/bottlerocket/agents/src/vsphere.rs
+++ b/bottlerocket/agents/src/vsphere.rs
@@ -1,0 +1,49 @@
+use model::SecretName;
+use resource_agent::clients::InfoClient;
+use resource_agent::provider::{IntoProviderError, ProviderResult, Resources};
+use std::env;
+
+// Helper for getting the vsphere credentials and setting up GOVC_USERNAME and GOVC_PASSWORD env vars
+pub async fn vsphere_credentials<I>(
+    client: &I,
+    vsphere_secret_name: &SecretName,
+    resource: &Resources,
+) -> ProviderResult<()>
+where
+    I: InfoClient,
+{
+    let vsphere_secret = client.get_secret(vsphere_secret_name).await.context(
+        Resources::Clear,
+        format!("Error getting secret '{}'", vsphere_secret_name),
+    )?;
+
+    let username = String::from_utf8(
+        vsphere_secret
+            .get("username")
+            .context(
+                resource,
+                format!(
+                    "vsphere username missing from secret '{}'",
+                    vsphere_secret_name
+                ),
+            )?
+            .to_owned(),
+    )
+    .context(resource, "Could not convert vsphere username to String")?;
+    let password = String::from_utf8(
+        vsphere_secret
+            .get("password")
+            .context(
+                resource,
+                format!(
+                    "vsphere password missing from secret '{}'",
+                    vsphere_secret_name
+                ),
+            )?
+            .to_owned(),
+    )
+    .context(resource, "Could not convert secret-access-key to String")?;
+    env::set_var("GOVC_USERNAME", username);
+    env::set_var("GOVC_PASSWORD", password);
+    Ok(())
+}

--- a/bottlerocket/agents/src/vsphere.rs
+++ b/bottlerocket/agents/src/vsphere.rs
@@ -43,7 +43,9 @@ where
             .to_owned(),
     )
     .context(resource, "Could not convert secret-access-key to String")?;
-    env::set_var("GOVC_USERNAME", username);
-    env::set_var("GOVC_PASSWORD", password);
+    env::set_var("GOVC_USERNAME", &username);
+    env::set_var("GOVC_PASSWORD", &password);
+    env::set_var("EKSA_VSPHERE_USERNAME", username);
+    env::set_var("EKSA_VSPHERE_PASSWORD", password);
     Ok(())
 }

--- a/bottlerocket/testsys/src/run_vmware.rs
+++ b/bottlerocket/testsys/src/run_vmware.rs
@@ -1,6 +1,6 @@
 use crate::error::{self, Result};
 use bottlerocket_types::agent_config::{
-    MigrationConfig, SonobuoyConfig, SonobuoyMode, TufRepoConfig, VSphereClusterInfo,
+    MigrationConfig, SonobuoyConfig, SonobuoyMode, TufRepoConfig, VSphereK8sClusterInfo,
     VSphereVmConfig, AWS_CREDENTIALS_SECRET_NAME, VSPHERE_CREDENTIALS_SECRET_NAME,
 };
 use kube::ResourceExt;
@@ -330,7 +330,7 @@ impl RunVmware {
             vcenter_network: self.network.clone(),
             vcenter_resource_pool: self.resource_pool.clone(),
             vcenter_workload_folder: self.workload_folder.clone(),
-            cluster: VSphereClusterInfo {
+            cluster: VSphereK8sClusterInfo {
                 name: self.cluster_name.clone(),
                 control_plane_endpoint_ip: self.cluster_endpoint.clone(),
                 kubeconfig_base64: encoded_kubeconfig.to_string(),

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -15,7 +15,7 @@ pub const VSPHERE_CREDENTIALS_SECRET_NAME: &str = "vsphereCredentials";
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
-pub struct VSphereClusterInfo {
+pub struct VSphereK8sClusterInfo {
     pub name: String,
     pub control_plane_endpoint_ip: String,
     pub kubeconfig_base64: String,
@@ -68,7 +68,7 @@ pub struct SonobuoyConfig {
     pub assume_role: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TufRepoConfig {
     pub metadata_url: String,
@@ -125,6 +125,54 @@ impl Default for EksctlConfig {
             encoded_config: "".to_string(),
         }
     }
+}
+
+/// The configuration information for a vSphere K8s cluster provider.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default, Configuration, Builder)]
+#[serde(rename_all = "camelCase")]
+#[crd("Resource")]
+pub struct VSphereK8sClusterConfig {
+    /// vSphere K8s cluster name.
+    pub name: String,
+
+    /// Cluster's control plane endpoint IP
+    pub control_plane_endpoint_ip: String,
+
+    /// Base64-encoded Kubeconfig for the K8s cluster if it already exists
+    pub kubeconfig_base64: Option<String>,
+
+    /// Whether this agent will create the cluster or not
+    pub creation_policy: Option<CreationPolicy>,
+
+    /// Version of the the K8s cluster (e.g. "1.22", "1.23")
+    pub version: Option<K8sVersion>,
+
+    /// Name of the OVA to download from TUF for creating the VMs to host cluster components
+    pub ova_name: String,
+
+    /// TUF repository where the OVA can be found
+    pub tuf_repo: TufRepoConfig,
+
+    /// URL of the vCenter instance to connect to
+    pub vcenter_host_url: String,
+
+    /// vCenter datacenter
+    pub vcenter_datacenter: String,
+
+    /// vCenter datastore
+    pub vcenter_datastore: String,
+
+    /// vCenter network
+    pub vcenter_network: String,
+
+    /// vCenter resource pool
+    pub vcenter_resource_pool: String,
+
+    /// Workloads folder to create the K8s cluster control plane in
+    pub vcenter_workload_folder: String,
+
+    /// Base64-encoded Kubeconfig for the CAPI management cluster
+    pub mgmt_cluster_kubeconfig_base64: String,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -407,7 +455,7 @@ pub struct VSphereVmConfig {
     pub vcenter_workload_folder: String,
 
     /// vSphere cluster information
-    pub cluster: VSphereClusterInfo,
+    pub cluster: VSphereK8sClusterInfo,
 
     /// The role that should be assumed when creating the vms.
     pub assume_role: Option<String>,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Resolves https://github.com/bottlerocket-os/bottlerocket-test-system/issues/35


**Description of changes:**

```
    vsphere-vm-resource: refactor out functions for shared use
    
    This refactors out some functions needed for implementing the vSphere K8s
    cluster provider so they can be shared between the two crates

```
```
    bottlerocket-agents: new 'vsphere-k8s-cluster-provider' agent
    
    This adds a new resource agent for provisioning vSphere K8s clusters via
    EKS-A.

```

**Testing done:**
Applied the following resource spec for a vSphere K8s cluster:
```
apiVersion: testsys.bottlerocket.aws/v1
kind: Resource
metadata:
  name: vsphere-k8s-cluster-1-23
  namespace: testsys-bottlerocket-aws
spec:
  agent:
    name: vsphere-k8s-cluster-resource-agent
    image: <>.dkr.ecr.us-west-2.amazonaws.com/vsphere-k8s-cluster-resource-agent:latest
    keepRunning: false
    privileged: true
    timeout: 20d
    secrets:
      vsphereCredentials: <>
    configuration:
      name: br-eksa-123
      controlPlaneEndpointIp: <>
      creation_policy: IfNotExists
      version: v1.23
      ovaName: "bottlerocket-vmware-k8s-1.23-x86_64-v1.10.1.ova"
      tufRepo:
        metadataUrl: "https://updates.bottlerocket.aws/2020-07-07/vmware-k8s-1.23/x86_64/"
        targetsUrl: "https://updates.bottlerocket.aws/targets"
      vcenterHostUrl: <>
      vcenterDatacenter: <>
      vcenterDatastore: <>
      vcenterNetwork: <>
      vcenterResourcePool: <>
      vcenterWorkloadFolder: <>
      mgmtClusterKubeconfigBase64: <>
      destructionPolicy: OnDeletion

```

Creation pod runs to completion without problem:
<details>

```bash
$ kubectl logs -f vsphere-k8s-clu70916266-4155-478e-9689-2b5dcead3c56-creatiwnkx6 -n testsys-bottlerocket-aws
[2022-10-21T18:53:07Z INFO  resource_agent::agent] Initializing Agent
[2022-10-21T18:53:07Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Creation policy is 'Create' and cluster 'br-eksa-123' does not exist: creating cluster
[2022-10-21T18:53:08Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Downloading OVA 'bottlerocket-vmware-k8s-1.23-x86_64-v1.10.1.ova'
[2022-10-21T18:53:10Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Importing OVA and creating a VM template out of it
[2022-10-21T18:53:22Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Tagging VM template
2022-10-21T18:53:49.895Z        V4      Logger init completed   {"vlevel": 4}
2022-10-21T18:53:50.012Z        V4      Reading bundles manifest        {"url": "https://anywhere-assets.eks.amazonaws.com/releases/bundles/18/manifest.yaml"}
2022-10-21T18:53:50.072Z        V4      Relative network path specified, using path /SDDC-Datacenter/network/sddc-cgw-network-2
2022-10-21T18:53:50.131Z        V2      Pulling docker image    {"image": "public.ecr.aws/eks-anywhere/cli-tools:v0.11.4-eks-a-18"}
2022-10-21T18:53:56.618Z        V3      Initializing long running container     {"name": "eksa_1666378430131231140", "image": "public.ecr.aws/eks-anywhere/cli-tools:v0.11.4-eks-a-18"}
2022-10-21T18:53:58.588Z        V4      Task start      {"task_name": "setup-validate"}
2022-10-21T18:53:58.588Z        V0      Performing setup and validations
2022-10-21T18:53:58.588Z        V4      Relative network path specified, using path /SDDC-Datacenter/network/sddc-cgw-network-2
2022-10-21T18:53:58.605Z        V0      ✅ Connected to server
2022-10-21T18:53:58.881Z        V0      ✅ Authenticated to vSphere
2022-10-21T18:53:59.481Z        V0      ✅ Datacenter validated
2022-10-21T18:53:59.786Z        V0      ✅ Network validated
2022-10-21T18:53:59.786Z        V1      SSHUsername is not set or is empty for VSphereMachineConfig, using default      {"machineConfig": "br-eksa-123-node", "user": "ec2-user"}
2022-10-21T18:54:00.363Z        V0      Warning: Your VM template has no snapshots. Defaulting to FullClone mode. VM provisioning might take longer.
2022-10-21T18:54:00.648Z        V0      ✅ Datastore validated
2022-10-21T18:54:00.935Z        V0      ✅ Folder validated
2022-10-21T18:54:01.224Z        V0      ✅ Resource pool validated
2022-10-21T18:54:02.329Z        V0      ✅ Control plane and Workload templates validated
2022-10-21T18:54:03.190Z        V0      Provided control plane sshAuthorizedKey is not set or is empty, auto-generating new key pair...
2022-10-21T18:54:04.517Z        V0      Private key saved to br-eksa-123/eks-a-id_rsa. Use 'ssh -i br-eksa-123/eks-a-id_rsa <username>@<Node-IP-Address>' to login to your cluster node
2022-10-21T18:54:16.033Z        V0      ✅ cloudadmin@vmc.local user vSphere privileges validated
2022-10-21T18:54:16.033Z        V0      ✅ Vsphere Provider setup is valid
2022-10-21T18:54:17.184Z        V0      ✅ Validate certificate for registry mirror
2022-10-21T18:54:17.184Z        V0      ✅ Validate authentication for git provider
2022-10-21T18:54:17.184Z        V0      ✅ Validate cluster name
2022-10-21T18:54:17.184Z        V0      ✅ Validate gitops
2022-10-21T18:54:17.184Z        V0      ✅ Validate identity providers' name
2022-10-21T18:54:17.184Z        V0      ✅ Validate management cluster has eksa crds
2022-10-21T18:54:17.184Z        V0      ✅ Create preflight validations pass
2022-10-21T18:54:17.184Z        V4      Task finished   {"task_name": "setup-validate", "duration": "18.595666711s"}
2022-10-21T18:54:17.184Z        V4      ----------------------------------
2022-10-21T18:54:17.184Z        V4      Task start      {"task_name": "bootstrap-cluster-init"}
2022-10-21T18:54:17.184Z        V4      Task finished   {"task_name": "bootstrap-cluster-init", "duration": "2.243µs"}
2022-10-21T18:54:17.184Z        V4      ----------------------------------
2022-10-21T18:54:17.184Z        V4      Task start      {"task_name": "workload-cluster-init"}
2022-10-21T18:54:17.184Z        V0      Creating new workload cluster
2022-10-21T18:54:18.398Z        V3      Waiting for external etcd to be ready   {"cluster": "br-eksa-123"}
2022-10-21T18:56:18.609Z        V3      External etcd is ready
2022-10-21T18:56:18.609Z        V3      Waiting for control plane to be ready
2022-10-21T18:58:48.500Z        V3      Waiting for workload kubeconfig generation      {"cluster": "br-eksa-123"}
2022-10-21T18:58:49.060Z        V3      Waiting for controlplane and worker machines to be ready
2022-10-21T18:58:49.365Z        V4      Nodes are not ready yet {"total": 3, "ready": 2, "cluster name": "br-eksa-123"}
2022-10-21T18:58:49.672Z        V4      Nodes are not ready yet {"total": 3, "ready": 2, "cluster name": "br-eksa-123"}
2022-10-21T18:58:51.001Z        V4      Nodes ready     {"total": 3}
2022-10-21T18:58:51.001Z        V0      Installing networking on workload cluster
2022-10-21T18:58:52.910Z        V0      Installing storage class on cluster
2022-10-21T18:58:53.290Z        V4      Installing machine health checks on bootstrap cluster
2022-10-21T18:58:53.809Z        V4      Task finished   {"task_name": "workload-cluster-init", "duration": "4m36.62540685s"}
2022-10-21T18:58:53.809Z        V4      ----------------------------------
2022-10-21T18:58:53.809Z        V4      Task start      {"task_name": "install-resources-on-management-cluster"}
2022-10-21T18:58:53.809Z        V4      Task finished   {"task_name": "install-resources-on-management-cluster", "duration": "1.816µs"}
2022-10-21T18:58:53.809Z        V4      ----------------------------------
2022-10-21T18:58:53.809Z        V4      Task start      {"task_name": "capi-management-move"}
2022-10-21T18:58:53.809Z        V4      Task finished   {"task_name": "capi-management-move", "duration": "834ns"}
2022-10-21T18:58:53.809Z        V4      ----------------------------------
2022-10-21T18:58:53.809Z        V4      Task start      {"task_name": "eksa-components-install"}
2022-10-21T18:58:53.809Z        V0      Creating EKS-A CRDs instances on workload cluster
2022-10-21T18:58:53.812Z        V4      Applying eksa yaml resources to cluster
2022-10-21T18:58:54.339Z        V1      Applying Bundles to cluster
2022-10-21T18:58:55.001Z        V4      Applying eksd manifest to cluster
2022-10-21T18:58:57.201Z        V4      Task finished   {"task_name": "eksa-components-install", "duration": "3.391983322s"}
2022-10-21T18:58:57.201Z        V4      ----------------------------------
2022-10-21T18:58:57.201Z        V4      Task start      {"task_name": "gitops-manager-install"}
2022-10-21T18:58:57.201Z        V0      Installing GitOps Toolkit on workload cluster
2022-10-21T18:58:57.201Z        V0      GitOps field not specified, bootstrap flux skipped
2022-10-21T18:58:57.201Z        V4      Task finished   {"task_name": "gitops-manager-install", "duration": "11.854µs"}
2022-10-21T18:58:57.201Z        V4      ----------------------------------
2022-10-21T18:58:57.201Z        V4      Task start      {"task_name": "write-cluster-config"}
2022-10-21T18:58:57.201Z        V0      Writing cluster config file
2022-10-21T18:58:57.203Z        V4      Task finished   {"task_name": "write-cluster-config", "duration": "2.052509ms"}
2022-10-21T18:58:57.203Z        V4      ----------------------------------
2022-10-21T18:58:57.203Z        V4      Task start      {"task_name": "delete-kind-cluster"}
2022-10-21T18:58:57.203Z        V0      🎉 Cluster created!
2022-10-21T18:58:57.203Z        V4      Task finished   {"task_name": "delete-kind-cluster", "duration": "7.66µs"}
2022-10-21T18:58:57.203Z        V4      ----------------------------------
2022-10-21T18:58:57.203Z        V4      Task start      {"task_name": "install-curated-packages"}
--------------------------------------------------------------------------------------
The Amazon EKS Anywhere Curated Packages are only available to customers with the
Amazon EKS Anywhere Enterprise Subscription
--------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------
Curated packages cannot be installed as cert-manager is not present in the cluster.
This is most likely caused by an action to install curated packages at a workload
cluster. Refer to https://anywhere.eks.amazonaws.com/docs/tasks/troubleshoot/packages/
for how to resolve this issue.
--------------------------------------------------------------------------------------
2022-10-21T18:58:57.494Z        V0      ❌ Curated Packages Installation Failed...
2022-10-21T18:58:57.494Z        V4      Task finished   {"task_name": "install-curated-packages", "duration": "290.286471ms"}
2022-10-21T18:58:57.494Z        V4      ----------------------------------
2022-10-21T18:58:57.494Z        V4      Tasks completed {"duration": "4m58.905757983s"}
2022-10-21T18:58:57.494Z        V3      Logging out from current govc session
2022-10-21T18:58:58.119Z        V3      Cleaning up long running container      {"name": "eksa_1666378430131231140"}
[2022-10-21T18:58:58Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Scaling default NodeGroup machinedeployments replicas to 0 machinedeployment.cluster.x-k8s.io/br-eksa-123-md-0 scaled
```

</details>

Destruction runs to completion without problem after deleting the resource:
<details>

```bash
$ kubectl logs -f vsphere-k8s-clu70916266-4155-478e-9689-2b5dcead3c56-destruktfkr -n testsys-bottlerocket-aws
[2022-10-21T18:59:57Z INFO  resource_agent::agent] Initializing Agent
2022-10-21T18:59:58.418Z        V4      Logger init completed   {"vlevel": 4}
2022-10-21T18:59:58.533Z        V4      Reading bundles manifest        {"url": "https://anywhere-assets.eks.amazonaws.com/releases/bundles/18/manifest.yaml"}
2022-10-21T18:59:58.562Z        V4      Relative network path specified, using path /SDDC-Datacenter/network/sddc-cgw-network-2
2022-10-21T18:59:58.611Z        V2      Pulling docker image    {"image": "public.ecr.aws/eks-anywhere/cli-tools:v0.11.4-eks-a-18"}
2022-10-21T19:00:04.009Z        V3      Initializing long running container     {"name": "eksa_1666378798611379528", "image": "public.ecr.aws/eks-anywhere/cli-tools:v0.11.4-eks-a-18"}
2022-10-21T19:00:06.077Z        V4      Task start      {"task_name": "setup-and-validate"}
2022-10-21T19:00:06.077Z        V0      Performing provider setup and validations
2022-10-21T19:00:06.077Z        V4      Task finished   {"task_name": "setup-and-validate", "duration": "33.101µs"}
2022-10-21T19:00:06.077Z        V4      ----------------------------------
2022-10-21T19:00:06.077Z        V4      Task start      {"task_name": "management-cluster-init"}
2022-10-21T19:00:06.077Z        V4      Task finished   {"task_name": "management-cluster-init", "duration": "1.049µs"}
2022-10-21T19:00:06.077Z        V4      ----------------------------------
2022-10-21T19:00:06.077Z        V4      Task start      {"task_name": "delete-workload-cluster"}
2022-10-21T19:00:06.077Z        V0      Deleting workload cluster
2022-10-21T19:00:33.606Z        V4      Task finished   {"task_name": "delete-workload-cluster", "duration": "27.528800824s"}
2022-10-21T19:00:33.606Z        V4      ----------------------------------
2022-10-21T19:00:33.606Z        V4      Task start      {"task_name": "clean-up-git-repo"}
2022-10-21T19:00:33.606Z        V0      Clean up Git Repo
2022-10-21T19:00:33.606Z        V0      GitOps field not specified, clean up git repo skipped
2022-10-21T19:00:33.606Z        V4      Task finished   {"task_name": "clean-up-git-repo", "duration": "9.966µs"}
2022-10-21T19:00:33.606Z        V4      ----------------------------------
2022-10-21T19:00:33.606Z        V4      Task start      {"task_name": "kind-cluster-delete"}
2022-10-21T19:00:33.606Z        V0      Bootstrap cluster information missing - skipping delete kind cluster
2022-10-21T19:00:33.606Z        V0      🎉 Cluster deleted!
2022-10-21T19:00:33.606Z        V4      Task finished   {"task_name": "kind-cluster-delete", "duration": "9.076µs"}
2022-10-21T19:00:33.606Z        V4      ----------------------------------
2022-10-21T19:00:33.606Z        V4      Tasks completed {"duration": "27.528983342s"}
2022-10-21T19:00:33.606Z        V3      Logging out from current govc session
2022-10-21T19:00:34.198Z        V3      Cleaning up long running container      {"name": "eksa_1666378798611379528"}
rpc error: code = NotFound desc = an error occurred when try to find container "b0624db8aa5f5349c38be241495784d597bd56e975fdc4064b635dbfaa782c50": not found

```
</details>

With `testsys run vmware`, the cluster can be used to run migration tests/conformance tests:

<details>

```bash
$ testsys run vmware \
   --cluster-endpoint 198.19.11.123 \
   --cluster-name br-eksa-123 \
   --target-cluster-kubeconfig-path br-eksa-123-eks-a-cluster.kubeconfig \
   --test-agent-image <>.dkr.ecr.us-west-2.amazonaws.com/sonobuoy-test-agent:latest \
   --network sddc-cgw-network-2 \
   --name vmware-123-quick \
   --ova-name bottlerocket-vmware-k8s-1.23-x86_64-v1.10.0.ova \
   --vcenter-url <> \
   --vm-count 2 \
   --vm-provider-image <>.dkr.ecr.us-west-2.amazonaws.com/vsphere-vm-resource-agent:latest \
   --vsphere-secret vcentercreds \
   --workload-folder etung \
   --upgrade-downgrade \
   --migration-agent-image <>.dkr.ecr.us-west-2.amazonaws.com/migration-test-agent:latest \
   --starting-version v1.10.0 \
   --upgrade-version v1.10.1 \
   --tuf-repo-metadata-url https://updates.bottlerocket.aws/2020-07-07/vmware-k8s-1.22/x86_64/ \
   --tuf-repo-targets-url https://updates.bottlerocket.aws/targets/
Created resource object 'br-eksa-123-vms'
Created test object 'vmware-123-quick-1-initial'
Created test object 'vmware-123-quick-2-migrate'
Created test object 'vmware-123-quick-3-migrated'
Created test object 'vmware-123-quick-4-migrate'
Created test object 'vmware-123-quick-5-final'
$ testsys status -c -r
 NAME                          TYPE         STATE       PASSED   SKIPPED   FAILED 
 Controller                    Controller   Running                               
 br-eksa-123-vms               Resource     completed                             
 vmware-123-quick-1-initial    Test         passed      1        7049      0      
 vmware-123-quick-2-migrate    Test         passed      2        0         0      
 vmware-123-quick-3-migrated   Test         passed      1        7049      0      
 vmware-123-quick-4-migrate    Test         passed      2        0         0      
 vmware-123-quick-5-final      Test         passed      1        7049      0      
 vsphere-k8s-cluster-1-23      Resource     completed 
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
