### PR TITLE
tools: prepare tools-v0.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TOP := $(dir $(firstword $(MAKEFILE_LIST)))
 # Variables we update as newer versions are released
 BOTTLEROCKET_SDK_VERSION = v0.26.0
 BOTTLEROCKET_SDK_ARCH = $(TESTSYS_BUILD_HOST_UNAME_ARCH)
-BOTTLEROCKET_TOOLS_VERSION ?= v0.1.0
+BOTTLEROCKET_TOOLS_VERSION ?= v0.2.0
 
 BUILDER_IMAGE = public.ecr.aws/bottlerocket/bottlerocket-sdk-$(BOTTLEROCKET_SDK_ARCH):$(BOTTLEROCKET_SDK_VERSION)
 TOOLS_IMAGE ?= public.ecr.aws/bottlerocket-test-system/bottlerocket-test-tools:$(BOTTLEROCKET_TOOLS_VERSION)

--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -6,16 +6,18 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0
 Since this project is only a vessel for packaging a few binary tools, its adherence to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) is loose at best.
 
-## [0.2.0] - 2022-09-20
+## [0.2.0] - 2022-10-24
 
-Update eksctl and sonobuoy.
+Update eksctl, sonobuoy, kubeadm
+Add kubectl, eksctl-anywhere
 
 ### Contents
 
 - boringtun v0.4.0 was removed
 - eksctl 0.112.0
-- kubeadm v1.21.6
+- kubeadm v1.23.13
 - sonobuoy v0.56.4
+- eksctl-anywhere 0.11.4-21
 
 ## [0.1.0] - 2022-05-11
 


### PR DESCRIPTION
Tagging and pushing new bottlerocket-test-tools:v0.2.0 image

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```
    tools: prepare tools-v0.2.0
    
    Tagging and pushing new bottlerocket-test-tools:v0.2.0 image
```

**Testing done:**
Ran `make images` and all agent images gets built without problems.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
