### PR TITLE
controller: moved parse_duration to utils.rs

### DIFF
--- a/controller/src/constants.rs
+++ b/controller/src/constants.rs
@@ -1,10 +1,5 @@
-use crate::error::Result;
-use anyhow::Context;
 use kube_runtime::controller::Action;
-use std::collections::VecDeque;
 use std::time::Duration;
-
-const UNITS: [(char, u64); 3] = [('d', 86400), ('h', 3600), ('m', 60)];
 
 /// Tell the controller to reconcile the object again after some duration.
 pub(crate) fn requeue() -> Action {
@@ -19,97 +14,4 @@ pub(crate) fn requeue_slow() -> Action {
 /// Do not requeue the object.
 pub(crate) fn no_requeue() -> Action {
     Action::await_change()
-}
-
-/// Parse a Duration string into a Duration object.
-pub(crate) fn parse_duration(input: &str) -> Result<Duration> {
-    let mut secs: u64 = 0;
-    let mut duration_string = input;
-    for unit in UNITS {
-        let mut vec: VecDeque<&str> = duration_string.split(unit.0).collect();
-        if vec.len() > 1 {
-            secs += vec
-                .pop_front()
-                .context("Failed to parse input")?
-                .parse::<u64>()?
-                * unit.1;
-        }
-        duration_string = vec.pop_front().context("Failed to parse input")?;
-    }
-    let mut vec: VecDeque<&str> = duration_string.split('s').collect();
-    let seconds = vec.pop_front().context("Failed to parse input")?;
-    if !seconds.is_empty() {
-        secs += seconds.parse::<u64>()?;
-    }
-    Ok(Duration::from_secs(secs))
-}
-
-#[test]
-fn all_units() {
-    let input = "1d2h3m4s";
-    assert!(
-        parse_duration(input).is_ok()
-            && parse_duration(input).unwrap() == Duration::from_secs(93784)
-    )
-}
-
-#[test]
-fn some_units() {
-    let input = "1d3m4s";
-    assert!(
-        parse_duration(input).is_ok()
-            && parse_duration(input).unwrap() == Duration::from_secs(86584)
-    )
-}
-
-#[test]
-fn only_seconds() {
-    let input = "500s";
-    assert!(
-        parse_duration(input).is_ok() && parse_duration(input).unwrap() == Duration::from_secs(500)
-    )
-}
-
-#[test]
-fn no_seconds() {
-    let input = "1h5m";
-    assert!(
-        parse_duration(input).is_ok()
-            && parse_duration(input).unwrap() == Duration::from_secs(3900)
-    )
-}
-
-#[test]
-fn one_unit() {
-    let input = "10m";
-    assert!(
-        parse_duration(input).is_ok() && parse_duration(input).unwrap() == Duration::from_secs(600)
-    )
-}
-
-#[test]
-fn no_units() {
-    let input = "5123";
-    assert!(
-        parse_duration(input).is_ok()
-            && parse_duration(input).unwrap() == Duration::from_secs(5123)
-    )
-}
-
-#[test]
-fn wrong_order() {
-    let input = "10d5m3h2s";
-    assert!(parse_duration(input).is_err())
-}
-
-#[test]
-fn invalid_unit() {
-    let input = "5y40s";
-    assert!(parse_duration(input).is_err())
-}
-
-#[test]
-fn missing_value() {
-    let input = "5hm4s";
-    assert!(parse_duration(input).is_err())
 }

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -29,6 +29,7 @@ mod error;
 mod job;
 mod resource_controller;
 mod test_controller;
+mod utils;
 
 #[tokio::main]
 async fn main() {

--- a/controller/src/resource_controller/action.rs
+++ b/controller/src/resource_controller/action.rs
@@ -1,7 +1,7 @@
-use crate::constants::parse_duration;
 use crate::error::Result;
 use crate::job::{JobState, TEST_START_TIME_LIMIT};
 use crate::resource_controller::context::ResourceInterface;
+use crate::utils::parse_duration;
 use kube::core::object::HasSpec;
 use kube::ResourceExt;
 use log::{debug, trace};

--- a/controller/src/test_controller/action.rs
+++ b/controller/src/test_controller/action.rs
@@ -1,7 +1,7 @@
-use crate::constants::parse_duration;
 use crate::error::Result;
 use crate::job::{JobState, TEST_START_TIME_LIMIT};
 use crate::test_controller::context::TestInterface;
+use crate::utils::parse_duration;
 use anyhow::Context;
 use kube::{Api, ResourceExt};
 use log::trace;

--- a/controller/src/utils.rs
+++ b/controller/src/utils.rs
@@ -1,0 +1,99 @@
+use crate::error::Result;
+use anyhow::Context;
+use std::collections::VecDeque;
+use std::time::Duration;
+
+const UNITS: [(char, u64); 3] = [('d', 86400), ('h', 3600), ('m', 60)];
+
+/// Parse a Duration string into a Duration object.
+pub(crate) fn parse_duration(input: &str) -> Result<Duration> {
+    let mut secs: u64 = 0;
+    let mut duration_string = input;
+    for unit in UNITS {
+        let mut vec: VecDeque<&str> = duration_string.split(unit.0).collect();
+        if vec.len() > 1 {
+            secs += vec
+                .pop_front()
+                .context("Failed to parse input")?
+                .parse::<u64>()?
+                * unit.1;
+        }
+        duration_string = vec.pop_front().context("Failed to parse input")?;
+    }
+    let mut vec: VecDeque<&str> = duration_string.split('s').collect();
+    let seconds = vec.pop_front().context("Failed to parse input")?;
+    if !seconds.is_empty() {
+        secs += seconds.parse::<u64>()?;
+    }
+    Ok(Duration::from_secs(secs))
+}
+
+#[test]
+fn all_units() {
+    let input = "1d2h3m4s";
+    assert!(
+        parse_duration(input).is_ok()
+            && parse_duration(input).unwrap() == Duration::from_secs(93784)
+    )
+}
+
+#[test]
+fn some_units() {
+    let input = "1d3m4s";
+    assert!(
+        parse_duration(input).is_ok()
+            && parse_duration(input).unwrap() == Duration::from_secs(86584)
+    )
+}
+
+#[test]
+fn only_seconds() {
+    let input = "500s";
+    assert!(
+        parse_duration(input).is_ok() && parse_duration(input).unwrap() == Duration::from_secs(500)
+    )
+}
+
+#[test]
+fn no_seconds() {
+    let input = "1h5m";
+    assert!(
+        parse_duration(input).is_ok()
+            && parse_duration(input).unwrap() == Duration::from_secs(3900)
+    )
+}
+
+#[test]
+fn one_unit() {
+    let input = "10m";
+    assert!(
+        parse_duration(input).is_ok() && parse_duration(input).unwrap() == Duration::from_secs(600)
+    )
+}
+
+#[test]
+fn no_units() {
+    let input = "5123";
+    assert!(
+        parse_duration(input).is_ok()
+            && parse_duration(input).unwrap() == Duration::from_secs(5123)
+    )
+}
+
+#[test]
+fn wrong_order() {
+    let input = "10d5m3h2s";
+    assert!(parse_duration(input).is_err())
+}
+
+#[test]
+fn invalid_unit() {
+    let input = "5y40s";
+    assert!(parse_duration(input).is_err())
+}
+
+#[test]
+fn missing_value() {
+    let input = "5hm4s";
+    assert!(parse_duration(input).is_err())
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Moved the `parse_duration` function from `constants.rs` to a new file `utils.rs`, since it does not really belong with `constants`.

**Testing done:**

`make build`, all unit tests passed

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
