### PR TITLE
model: add constant for TestSys version

### DIFF
--- a/model/src/constants.rs
+++ b/model/src/constants.rs
@@ -14,6 +14,7 @@ macro_rules! testsys {
 pub const API_VERSION: &str = testsys!("v1");
 pub const NAMESPACE: &str = "testsys-bottlerocket-aws";
 pub const TESTSYS: &str = testsys!();
+pub const TESTSYS_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // Component names
 pub const CONTROLLER: &str = "controller";


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #542 

**Description of changes:**

Added a public constant to `model/src/constants.rs` that stores the TestSys version. The constant is populated at compile-time and available at runtime.

**Testing done:**

Printed the constant from TestManager: output was `0.0.2`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
