### PR TITLE
clean up cargo toml files

### DIFF
--- a/agent/builder-derive/Cargo.toml
+++ b/agent/builder-derive/Cargo.toml
@@ -6,9 +6,9 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-syn = "1.0"
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = "1"
+quote = "1"
+proc-macro2 = "1"
 serde = "1"
 
 [lib]

--- a/agent/configuration-derive/Cargo.toml
+++ b/agent/configuration-derive/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-syn = "1.0"
-quote = "1.0"
+syn = "1"
+quote = "1"
 
 [lib]
 proc-macro = true

--- a/agent/resource-agent/Cargo.toml
+++ b/agent/resource-agent/Cargo.toml
@@ -16,6 +16,6 @@ snafu = "0.7"
 tokio = { version = "1", default-features = false, features = ["time"] }
 
 [dev-dependencies]
-env_logger = "0"
+env_logger = "0.9"
 nonzero_ext = "0.3"
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"] }

--- a/agent/test-agent-cli/Cargo.toml
+++ b/agent/test-agent-cli/Cargo.toml
@@ -19,11 +19,11 @@ async-trait = "0.1"
 tempfile = "3"
 serde_json = "1"
 env_logger = "0.9"
-serde_plain = "1.0"
+serde_plain = "1"
 serde_derive = "1"
 serde = "1"
 tar = "0.4"
 
 [dev-dependencies]
-assert_cmd = "2.0"
+assert_cmd = "2"
 selftest = { version = "0.0.2", path = "../../selftest" }

--- a/agent/utils/Cargo.toml
+++ b/agent/utils/Cargo.toml
@@ -11,7 +11,7 @@ aws-config = "0.49"
 aws-types = "0.49"
 aws-sdk-sts = "0.19"
 aws-smithy-types = "0.49"
-base64 = "0.13.1"
+base64 = "0.13"
 env_logger = "0.9"
 log = "0.4"
 model = { version = "0.0.2", path = "../../model" }

--- a/bottlerocket/agents/Cargo.toml
+++ b/bottlerocket/agents/Cargo.toml
@@ -19,15 +19,15 @@ aws-sdk-iam = "0.19"
 aws-sdk-ssm = "0.19"
 aws-sdk-sts = "0.19"
 aws-smithy-types = "0.49"
-base64 = "0.13.1"
+base64 = "0.13"
 env_logger = "0.9"
-hex ="0.4.3"
+hex ="0.4"
 k8s-openapi = { version = "0.16", default-features = false, features = ["v1_20"] }
 kube = { version = "0.75", default-features = false, features = ["config", "derive", "client"] }
 log = "0.4"
-maplit = "1.0.2"
+maplit = "1"
 model = { version = "0.0.2", path = "../../model" }
-reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "blocking"] }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "blocking"] }
 resource-agent = { version = "0.0.2", path = "../../agent/resource-agent" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -38,5 +38,5 @@ snafu = "0.7"
 test-agent = { version = "0.0.2", path = "../../agent/test-agent" }
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
 tough = { version = "0.12", features = ["http"] }
-url = "2.3"
-uuid = { version = "1.2", default-features = false, features = ["serde", "v4"] }
+url = "2"
+uuid = { version = "1", default-features = false, features = ["serde", "v4"] }

--- a/bottlerocket/testsys/Cargo.toml
+++ b/bottlerocket/testsys/Cargo.toml
@@ -9,27 +9,27 @@ license = "MIT OR Apache-2.0"
 base64 = "0.13.1"
 bottlerocket-types = { version = "0.0.2", path = "../types" }
 env_logger = "0.9"
-futures = "0.3.25"
+futures = "0.3"
 http = "0"
 k8s-openapi = { version = "0.16", features = ["v1_20", "api"], default-features = false }
 kube = { version = "0.75", default-features = true, features = ["config", "derive", "ws"] }
 log = "0.4"
 maplit = "1"
 model = { version = "0.0.2", path = "../../model" }
-serde = "1.0.147"
+serde = "1"
 serde_plain = "1"
-serde_json = "1.0.86"
+serde_json = "1"
 serde_yaml = "0.8"
 snafu = "0.7"
 structopt = "0.3"
 tabled = "0.4"
-termion = "2.0"
+termion = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
 tokio-util = "0.7"
 topological-sort = "0.2"
 
 [dev-dependencies]
-assert_cmd = "2.0"
+assert_cmd = "2"
 selftest = { version = "0.0.2", path = "../../selftest" }
 
 [features]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 env_logger = "0.9"
-futures = "0.3.25"
+futures = "0.3"
 log = "0.4"
 model = { path = "../model" }
 serde = "1"
@@ -19,7 +19,7 @@ terminal_size = "0.2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
 
 [dev-dependencies]
-assert_cmd = "2.0"
+assert_cmd = "2"
 selftest = { path = "../selftest" }
 
 [features]

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = "0.1"
 base64 = "0.13"
 bytes = "1.2"
 futures = "0.3"
-http = "0"
+http = "0.2"
 json-patch = "0.2"
 k8s-openapi = { version = "0.16", default-features = false, features = ["v1_20"] }
 kube = { version = "0.75", default-features = false, features = ["config", "derive", "jsonpatch", "client", "native-tls", "ws"] }

--- a/selftest/Cargo.toml
+++ b/selftest/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow = "1"
 envy = "0"
-futures = "0.3.25"
+futures = "0.3"
 k8s-openapi = { version = "0.16", default-features = false, features = ["v1_20"] }
 kube = { version = "0.75", default-features = true }
 lazy_static = "1"


### PR DESCRIPTION

**Issue number:**

N/A

**Description of changes:**

Specifying the minor version does not actually do anything since cargo does this by default "An update is allowed if the new version number does not modify the left-most non-zero digit in the major, minor, patch grouping"

Thus, all we really get by specifying minor versions and patch versions is churn in the Cargo.toml files when dependabot does updates, and possible cognitive confusion about what version is actually being used (you have to look at Cargo.lock).

If we need to specify an exact version or specific range, we can use operators like >=, =, etc. in combination with relevant minor and patch version numbers in the future.

**Testing done:**

If it builds in CI then nothing has been changed. That is, we use --locked, and if I actually changed anything then CI will fail because `Cargo.lock` isn't correct.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
