### PR TITLE
testsys: shorten default namespace and CRD API group

### DIFF
--- a/agent/test-agent-cli/tests/data/deploy_test.yaml
+++ b/agent/test-agent-cli/tests/data/deploy_test.yaml
@@ -2,7 +2,7 @@ apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-world-cli
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   retries: 5
   agent:

--- a/agent/test-agent-cli/tests/data/deploy_test.yaml
+++ b/agent/test-agent-cli/tests/data/deploy_test.yaml
@@ -1,4 +1,4 @@
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-world-cli

--- a/agent/test-agent/examples/example_test_agent/main.rs
+++ b/agent/test-agent/examples/example_test_agent/main.rs
@@ -13,7 +13,7 @@ root directory of this repository.
 An example manifest for deploying the test definition for this test-agent to a K8s cluster:
 
 ```yaml
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-world

--- a/agent/test-agent/examples/example_test_agent/main.rs
+++ b/agent/test-agent/examples/example_test_agent/main.rs
@@ -17,7 +17,7 @@ apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-world
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   image: "<CONTAINER IMAGE URL>"
   configuration:

--- a/bottlerocket/agents/src/bin/migration-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/migration-test-agent/main.rs
@@ -14,7 +14,7 @@ cluster. This can also be done without YAML using the `testsys` command line int
 
 
 ```yaml
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: upgrade-ec2-test

--- a/bottlerocket/agents/src/bin/migration-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/migration-test-agent/main.rs
@@ -18,7 +18,7 @@ apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: upgrade-ec2-test
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     configuration:

--- a/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
@@ -16,7 +16,7 @@ apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: sonobuoy-e2e-full
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     configuration:

--- a/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
@@ -12,7 +12,7 @@ root directory of this repository.
 Here is an example manifest for deploying the test definition for the sonobuoy test agent to a K8s cluster:
 
 ```yaml
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: sonobuoy-e2e-full

--- a/bottlerocket/agents/src/bin/vsphere-k8s-cluster-resource-agent/README.md
+++ b/bottlerocket/agents/src/bin/vsphere-k8s-cluster-resource-agent/README.md
@@ -9,7 +9,7 @@ apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: my-vsphere-cluster
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: vsphere-k8s-cluster-resource-agent

--- a/bottlerocket/agents/src/bin/vsphere-k8s-cluster-resource-agent/README.md
+++ b/bottlerocket/agents/src/bin/vsphere-k8s-cluster-resource-agent/README.md
@@ -5,7 +5,7 @@ This TestSys resource agent is responsible for provisioning vSphere K8s clusters
 ## Example configuration for the resource agent
 
 ```yaml
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: my-vsphere-cluster

--- a/bottlerocket/testsys/tests/data/example-resource-provider.yaml
+++ b/bottlerocket/testsys/tests/data/example-resource-provider.yaml
@@ -1,4 +1,4 @@
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: robot-provider

--- a/bottlerocket/testsys/tests/data/example-resource-provider.yaml
+++ b/bottlerocket/testsys/tests/data/example-resource-provider.yaml
@@ -2,7 +2,7 @@ apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: robot-provider
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   dependsOn: []
   agent:

--- a/bottlerocket/testsys/tests/data/integ-test-depended-on.yaml
+++ b/bottlerocket/testsys/tests/data/integ-test-depended-on.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: dup-2
@@ -13,7 +13,7 @@ spec:
       info: 3
   dependsOn: []
 ---
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones-2

--- a/bottlerocket/testsys/tests/data/integ-test-depended-on.yaml
+++ b/bottlerocket/testsys/tests/data/integ-test-depended-on.yaml
@@ -3,7 +3,7 @@ apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: dup-2
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: dup-2-agent
@@ -17,7 +17,7 @@ apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones-2
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: hello-agent

--- a/bottlerocket/testsys/tests/data/integ-test-dependent.yaml
+++ b/bottlerocket/testsys/tests/data/integ-test-dependent.yaml
@@ -1,4 +1,4 @@
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones-1
@@ -16,7 +16,7 @@ spec:
   resources: []
   dependsOn: [hello-bones-2]
 ---
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: dup-1

--- a/bottlerocket/testsys/tests/data/integ-test-dependent.yaml
+++ b/bottlerocket/testsys/tests/data/integ-test-dependent.yaml
@@ -2,7 +2,7 @@ apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones-1
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: hello-agent
@@ -20,7 +20,7 @@ apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: dup-1
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: dup-1-agent

--- a/bottlerocket/testsys/tests/data/resource-destruction-never.yaml
+++ b/bottlerocket/testsys/tests/data/resource-destruction-never.yaml
@@ -1,4 +1,4 @@
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: never-destroy

--- a/bottlerocket/testsys/tests/data/resource-destruction-never.yaml
+++ b/bottlerocket/testsys/tests/data/resource-destruction-never.yaml
@@ -2,7 +2,7 @@ apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: never-destroy
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   dependsOn: []
   destructionPolicy: never

--- a/bottlerocket/testsys/tests/data/resource-test.yaml
+++ b/bottlerocket/testsys/tests/data/resource-test.yaml
@@ -2,7 +2,7 @@ apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: hello-agent

--- a/bottlerocket/testsys/tests/data/resource-test.yaml
+++ b/bottlerocket/testsys/tests/data/resource-test.yaml
@@ -1,4 +1,4 @@
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones

--- a/bottlerocket/testsys/tests/data/template-test.yaml
+++ b/bottlerocket/testsys/tests/data/template-test.yaml
@@ -2,7 +2,7 @@ apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: hello-agent

--- a/bottlerocket/testsys/tests/data/template-test.yaml
+++ b/bottlerocket/testsys/tests/data/template-test.yaml
@@ -1,4 +1,4 @@
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones

--- a/cli/tests/data/example-resource-provider.yaml
+++ b/cli/tests/data/example-resource-provider.yaml
@@ -1,4 +1,4 @@
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: robot-provider

--- a/cli/tests/data/example-resource-provider.yaml
+++ b/cli/tests/data/example-resource-provider.yaml
@@ -2,7 +2,7 @@ apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: robot-provider
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   dependsOn: []
   agent:

--- a/cli/tests/data/integ-test-depended-on.yaml
+++ b/cli/tests/data/integ-test-depended-on.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: dup-2
@@ -13,7 +13,7 @@ spec:
       info: 3
   dependsOn: []
 ---
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones-2

--- a/cli/tests/data/integ-test-depended-on.yaml
+++ b/cli/tests/data/integ-test-depended-on.yaml
@@ -3,7 +3,7 @@ apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: dup-2
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: dup-2-agent
@@ -17,7 +17,7 @@ apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones-2
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: hello-agent

--- a/cli/tests/data/integ-test-dependent.yaml
+++ b/cli/tests/data/integ-test-dependent.yaml
@@ -1,4 +1,4 @@
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones-1
@@ -16,7 +16,7 @@ spec:
   resources: []
   dependsOn: [hello-bones-2]
 ---
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: dup-1

--- a/cli/tests/data/integ-test-dependent.yaml
+++ b/cli/tests/data/integ-test-dependent.yaml
@@ -2,7 +2,7 @@ apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones-1
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: hello-agent
@@ -20,7 +20,7 @@ apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: dup-1
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: dup-1-agent

--- a/cli/tests/data/resource-destruction-never.yaml
+++ b/cli/tests/data/resource-destruction-never.yaml
@@ -1,4 +1,4 @@
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: never-destroy

--- a/cli/tests/data/resource-destruction-never.yaml
+++ b/cli/tests/data/resource-destruction-never.yaml
@@ -2,7 +2,7 @@ apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: never-destroy
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   dependsOn: []
   destructionPolicy: never

--- a/cli/tests/data/resource-test.yaml
+++ b/cli/tests/data/resource-test.yaml
@@ -2,7 +2,7 @@ apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: hello-agent

--- a/cli/tests/data/resource-test.yaml
+++ b/cli/tests/data/resource-test.yaml
@@ -1,4 +1,4 @@
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones

--- a/cli/tests/data/template-test.yaml
+++ b/cli/tests/data/template-test.yaml
@@ -2,7 +2,7 @@ apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: hello-agent

--- a/cli/tests/data/template-test.yaml
+++ b/cli/tests/data/template-test.yaml
@@ -1,4 +1,4 @@
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -160,7 +160,7 @@ The yaml file tells the controller and the test agent how the test should be run
 
 ```bash
 echo '---
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones
@@ -312,7 +312,7 @@ Any field can be configured to take values from other resources by using `${<res
 
 ```bash
 echo '---
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: duplicator
@@ -326,7 +326,7 @@ spec:
       info: 3
   dependsOn: []
 ---
-apiVersion: testsys.bottlerocket.aws/v1
+apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -164,7 +164,7 @@ apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: hello-agent
@@ -316,7 +316,7 @@ apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: duplicator
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: dup-agent
@@ -330,7 +330,7 @@ apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: hello-bones
-  namespace: testsys-bottlerocket-aws
+  namespace: testsys
 spec:
   agent:
     name: hello-agent

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -61,7 +61,7 @@ We also set our kubeconfig context to the testsys namespace for convenience.
 
 ```shell
 testsys install --controller-uri controller:eks
-kubectl config set-context --current --namespace="testsys-bottlerocket-aws"
+kubectl config set-context --current --namespace="testsys"
 ```
 
 We will be creating an EKS cluster and EC2 instances, so we need to create a Kubernetes secret with our AWS credentials.

--- a/model/src/clients/resource_client.rs
+++ b/model/src/clients/resource_client.rs
@@ -424,7 +424,7 @@ mod test {
             .unwrap();
         cluster
             .wait_for_object::<CustomResourceDefinition>(
-                "resources.testsys.bottlerocket.aws",
+                "resources.testsys.system",
                 cluster.api().await.unwrap(),
                 tokio::time::Duration::from_secs(10),
             )

--- a/model/src/clients/test_client.rs
+++ b/model/src/clients/test_client.rs
@@ -204,7 +204,7 @@ mod test {
             .unwrap();
         cluster
             .wait_for_object::<CustomResourceDefinition>(
-                "tests.testsys.bottlerocket.aws",
+                "tests.testsys.system",
                 cluster.api().await.unwrap(),
                 tokio::time::Duration::from_secs(10),
             )

--- a/model/src/constants.rs
+++ b/model/src/constants.rs
@@ -3,7 +3,7 @@
 /// the system. When given a string literal parameter it adds `/parameter` to the end.
 macro_rules! testsys {
     () => {
-        "testsys.bottlerocket.aws"
+        "testsys.system"
     };
     ($s:literal) => {
         concat!(testsys!(), "/", $s)
@@ -64,7 +64,7 @@ pub const TRUNC_LEN: usize = 15;
 
 #[test]
 fn testsys_constants_macro_test() {
-    assert_eq!("testsys.bottlerocket.aws", testsys!());
-    assert_eq!("testsys.bottlerocket.aws/v1", API_VERSION);
-    assert_eq!("testsys.bottlerocket.aws/foo", testsys!("foo"));
+    assert_eq!("testsys.system", testsys!());
+    assert_eq!("testsys.system/v1", API_VERSION);
+    assert_eq!("testsys.system/foo", testsys!("foo"));
 }

--- a/model/src/constants.rs
+++ b/model/src/constants.rs
@@ -12,7 +12,7 @@ macro_rules! testsys {
 
 // System identifiers
 pub const API_VERSION: &str = testsys!("v1");
-pub const NAMESPACE: &str = "testsys-bottlerocket-aws";
+pub const NAMESPACE: &str = "testsys";
 pub const TESTSYS: &str = testsys!();
 pub const TESTSYS_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/model/src/resource.rs
+++ b/model/src/resource.rs
@@ -19,7 +19,7 @@ use std::fmt::{Display, Formatter};
 #[kube(
     derive = "Default",
     derive = "PartialEq",
-    group = "testsys.bottlerocket.aws",
+    group = "testsys.system",
     kind = "Resource",
     namespaced,
     plural = "resources",

--- a/model/src/test.rs
+++ b/model/src/test.rs
@@ -15,7 +15,7 @@ use std::borrow::Cow;
 #[kube(
     derive = "Default",
     derive = "PartialEq",
-    group = "testsys.bottlerocket.aws",
+    group = "testsys.system",
     kind = "Test",
     namespaced,
     plural = "tests",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Resolves https://github.com/bottlerocket-os/bottlerocket-test-system/issues/628


**Description of changes:**
```

    testsys: shorten default namespace to 'testsys'
    
    This shortens TestSys default namespace from 'testsys-bottlerocket-aws'
    to 'testsys'
```
```
    testsys: change CRD API group to 'testsys.system'
    
    This changes the TestSys CRD API group from 'testsys.bottlerocket.aws'
    to 'testsys.system'. This makes it less specific to Bottlerocket when
    TestSys can be used to test other OSes in any K8s cluster.
```


**Testing done:**
All testsys images built fine, testsys CLI installs fine.

Deployed testsys to K8s cluster, testsys api-resources are created in the `testsys` namespace as expected.
TestSys CRD group/APIVersion is as expected:
```bash
$ kubectl api-resources 
...
resources                                      testsys.system/v1                      true         Resource
tests                                          testsys.system/v1                      true         Test


$ kubectl get pods -A
NAMESPACE     NAME                                  READY   STATUS    RESTARTS   AGE
...
testsys       testsys-controller-5595cc7b94-g8npd   1/1     Running   0          60s


$ kubectl get crds
NAME                                         CREATED AT
eniconfigs.crd.k8s.amazonaws.com             2022-08-10T21:55:07Z
resources.testsys.system                     2022-10-31T19:38:35Z
securitygrouppolicies.vpcresources.k8s.aws   2022-08-10T21:55:10Z
tests.testsys.system                         2022-10-31T19:38:35Z


```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
