### PR TITLE
test-manager: delete TestSys CRDs when uninstalling

### DIFF
--- a/model/src/test_manager/install.rs
+++ b/model/src/test_manager/install.rs
@@ -8,7 +8,8 @@ use crate::system::{
 use crate::test_manager::TestManager;
 use crate::{Resource, Test};
 use k8s_openapi::api::core::v1::Namespace;
-use kube::{Api, CustomResourceExt};
+use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
+use kube::{Api, CustomResourceExt, ResourceExt};
 use snafu::ResultExt;
 
 impl TestManager {
@@ -130,7 +131,20 @@ impl TestManager {
             .delete(NAMESPACE, &Default::default())
             .await
             .context(error::KubeSnafu {
-                action: "delete testsys namespace",
+                action: "delete TestSys namespace",
+            })?;
+        let crd_api: Api<CustomResourceDefinition> = self.api();
+        crd_api
+            .delete(&Test::crd().name_any(), &Default::default())
+            .await
+            .context(error::KubeSnafu {
+                action: "delete TestSys Test CRD",
+            })?;
+        crd_api
+            .delete(&Resource::crd().name_any(), &Default::default())
+            .await
+            .context(error::KubeSnafu {
+                action: "delete TestSys Resource CRD",
             })?;
         Ok(())
     }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Resolves https://github.com/bottlerocket-os/bottlerocket-test-system/issues/634


**Description of changes:**
```
    test-manager: delete TestSys CRDs when uninstalling
    
    This makes 'uninstall' also clean up the TestSys CRDs for Tests and
    Resources.
```


**Testing done:**
TestSys CLI now properly cleans up the TestSys CRDs when `uninstall`ing:
```bash

$ kubectl get crds
NAME                                         CREATED AT
eniconfigs.crd.k8s.amazonaws.com             2022-08-10T21:55:07Z
resources.testsys.system                     2022-10-31T19:38:35Z
securitygrouppolicies.vpcresources.k8s.aws   2022-08-10T21:55:10Z
tests.testsys.system                         2022-10-31T19:38:35Z

$ cli uninstall
testsys components were successfully uninstalled.

$ kubectl get crds
NAME                                         CREATED AT
eniconfigs.crd.k8s.amazonaws.com             2022-08-10T21:55:07Z
securitygrouppolicies.vpcresources.k8s.aws   2022-08-10T21:55:10Z

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
