### PR TITLE
tools: fix Dockerfile build

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -95,11 +95,13 @@ RUN mkdir eksctl-anywhere && curl -L ${EKSA_SOURCE_URL} \
     grep eksctl_anywhere_${EKSA_VERSION}.tar.gz \
       /hashes/eksctl | sha512sum --check - && \
     tar -xf eksctl_anywhere_${EKSA_VERSION}.tar.gz --strip-components 1 -C eksctl-anywhere && \
-    rm eksctl_anywhere_${EKSA_VERSION}.tar.gz
+    rm eksctl_anywhere_${EKSA_VERSION}.tar.gz && \
+    sed -i 's/v0.2.0-alpha.6/v0.2.1/' eksctl-anywhere/go.mod && \
+    rm eksctl-anywhere/go.sum
 
 USER root
 WORKDIR /home/builder/eksctl-anywhere/
-RUN go mod vendor
+RUN go mod tidy && go mod vendor
 RUN cp -p LICENSE /usr/share/licenses/eksctl-anywhere && \
     /usr/libexec/tools/bottlerocket-license-scan \
       --clarify /clarify.toml \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -15,7 +15,7 @@ ENV PATH="${GOROOT}/bin:${PATH}"
 ENV GOPROXY="${GOPROXY}"
 
 ADD ./hashes /hashes
-COPY ./clarify.toml clarify.toml
+COPY ./clarify.toml /clarify.toml
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 # Shared build stage used to build Rust binaries.

--- a/tools/clarify.toml
+++ b/tools/clarify.toml
@@ -84,6 +84,13 @@ license-files = [
     { path = "LICENSE", hash = 0x709001e3 },
 ]
 
+[clarify."gopkg.in/yaml.v1"]
+expression = "MIT AND Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0x9c545105 },
+    { path = "LICENSE.libyaml", hash = 0xa2e4ce3 },
+]
+
 [clarify."honnef.co/go/tools"]
 expression = "MIT AND BSD-3-Clause"
 license-files = [


### PR DESCRIPTION
**Description of changes:**

- Make sure that `clarify.toml` is in the expected root location and add some missing clarifications.

- Patch missing tag of **eksctl-anywhere** dependency.

**Testing done:**

Ran `make tools`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
