### PR TITLE
builder: Keep config's serde attributes

### DIFF
--- a/agent/builder-derive/src/derive.rs
+++ b/agent/builder-derive/src/derive.rs
@@ -42,9 +42,9 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
 
     // Get a list of fields and their types
     let fields = data.fields.iter().filter_map(|field| {
-        let doc = field.attrs.iter().filter(|v| {
+        let attrs = field.attrs.iter().filter(|v| {
             v.parse_meta()
-                .map(|meta| meta.path().is_ident("doc"))
+                .map(|meta| meta.path().is_ident("doc") || meta.path().is_ident("serde"))
                 .unwrap_or(false)
         });
         let field_name = match field.ident.as_ref() {
@@ -54,7 +54,7 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
         let field_ident = Ident::new(&field_name, Span::call_site());
         let ty = field.ty.clone();
         Some(quote! {
-            #(#doc)*
+            #(#attrs)*
             #field_ident: model::ConfigValue<#ty>,
         })
     });


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

#642 

**Description of changes:**

If a configuration uses serde to flatten an enum, the builder would create the configuration without flattening the enum creating a type that could not be serialized as the original config. This pr attaches all serde attributes to the builder.

**Testing done:**

```
testsys run aws-k8s \
       --name k8s-123 \
       --test-agent-image "public.ecr.aws/bottlerocket-test-system/sonobuoy-test-agent:v0.0.3" \
       --keep-running \
       --sonobuoy-mode "quick" \
       --region "us-west-2" \
       --cluster-name "x86-64-aws-k8s-123" \
       --cluster-creation-policy "ifNotExists" \
       --cluster-destruction-policy "never" \
       --cluster-provider-image "public.ecr.aws/bottlerocket-test-system/eks-resource-agent:v0.0.3" \
       --cluster-version "1.23" \
       --ami <AMI> \
       --ec2-provider-image "public.ecr.aws/bottlerocket-test-system/ec2-resource-agent:v0.0.3"
```

Test now runs successfully
```
 NAME                          TYPE      STATE      PASSED   SKIPPED   FAILED
 k8s-123                       Test      passed     1        7051      0
 x86-64-aws-k8s-123            Resourc   complete
 x86-64-aws-k8s-123-instance   Resourc   complete
 ```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
