### PR TITLE
agent: use Credentials instead of env variables

### DIFF
--- a/agent/utils/src/aws.rs
+++ b/agent/utils/src/aws.rs
@@ -1,35 +1,28 @@
-use crate::constants::DEFAULT_REGION;
+use crate::constants::{DEFAULT_ASSUME_ROLE_SESSION_DURATION, DEFAULT_REGION};
 use crate::error::{self, Error};
-use aws_config::meta::region::RegionProviderChain;
+use agent_common::secrets::SecretsReader;
+use aws_config::default_provider::credentials::default_provider;
+use aws_config::sts::AssumeRoleProvider;
 use aws_config::RetryConfig;
 use aws_sdk_sts::Region;
 use aws_smithy_types::retry::RetryMode;
+use aws_types::credentials::{Credentials, SharedCredentialsProvider};
 use aws_types::SdkConfig;
 use log::info;
 use model::SecretName;
-use resource_agent::clients::InfoClient;
-use resource_agent::provider::{ProviderResult, Resources};
 use snafu::{OptionExt, ResultExt};
 use std::env;
-use test_agent::Runner;
+use std::time::Duration;
 
 /// Set up the config for aws calls using `aws_secret_name` if provided and `sts::assume_role`
-/// if a role arn is provided.
-pub async fn aws_test_config<R>(
-    runner: &R,
-    aws_secret_name: &Option<SecretName>,
+/// if a role arn is provided. Set credentials as environment variables if `setup_env` is true
+pub async fn aws_config(
+    aws_secret_name: &Option<&SecretName>,
     assume_role: &Option<String>,
     assume_role_session_duration: &Option<i32>,
     region: &Option<String>,
-) -> Result<SdkConfig, Error>
-where
-    R: Runner,
-{
-    if let Some(aws_secret_name) = aws_secret_name {
-        info!("Adding secret '{}' to the environment", aws_secret_name);
-        setup_test_env(runner, aws_secret_name).await?;
-    }
-
+    setup_env: bool,
+) -> Result<SdkConfig, Error> {
     let region = region
         .as_ref()
         .unwrap_or(&DEFAULT_REGION.to_string())
@@ -38,19 +31,49 @@ where
         "Creating a custom region provider for '{}' to be used in the aws config.",
         region
     );
-    let region_provider = RegionProviderChain::first_try(Region::new(region.clone()));
 
-    let mut config = aws_config::from_env()
-        .retry_config(
-            RetryConfig::standard()
-                .with_retry_mode(RetryMode::Adaptive)
-                .with_max_attempts(15),
-        )
-        .region(region_provider)
+    let mut config_loader = aws_config::from_env().retry_config(
+        RetryConfig::standard()
+            .with_retry_mode(RetryMode::Adaptive)
+            .with_max_attempts(15),
+    );
+    let base_provider = match aws_secret_name {
+        Some(aws_secret_name) => {
+            let (access_key_id, secret_access_key, session_token) =
+                get_secret_values(aws_secret_name)?;
+            if setup_env && assume_role.is_none() {
+                set_environment_variables(&access_key_id, &secret_access_key, &session_token);
+            }
+            SharedCredentialsProvider::new(Credentials::new(
+                access_key_id,
+                secret_access_key,
+                session_token,
+                None,
+                "aws_secret",
+            ))
+        }
+        None => SharedCredentialsProvider::new(default_provider().await),
+    };
+
+    config_loader = match assume_role {
+        Some(role_arn) => config_loader.credentials_provider(SharedCredentialsProvider::new(
+            AssumeRoleProvider::builder(role_arn)
+                .region(Region::new(region.clone()))
+                .session_name("testsys")
+                .session_length(Duration::from_secs(
+                    assume_role_session_duration.unwrap_or(DEFAULT_ASSUME_ROLE_SESSION_DURATION)
+                        as u64,
+                ))
+                .build(base_provider.clone()),
+        )),
+        None => config_loader.credentials_provider(base_provider),
+    };
+
+    let config = config_loader
+        .region(Region::new(region.clone()))
         .load()
         .await;
-
-    if let Some(role_arn) = assume_role {
+    if let (Some(role_arn), true) = (assume_role, setup_env) {
         info!("Getting credentials for assumed role '{}'.", role_arn);
         let sts_client = aws_sdk_sts::Client::new(&config);
         let credentials = sts_client
@@ -64,49 +87,34 @@ where
             .credentials()
             .context(error::CredentialsMissingSnafu { role_arn })?
             .clone();
-        // Set the env variables for our assumed role.
-        env::set_var(
-            "AWS_ACCESS_KEY_ID",
-            credentials
-                .access_key_id()
-                .context(error::CredentialsMissingSnafu { role_arn })?,
-        );
-        env::set_var(
-            "AWS_SECRET_ACCESS_KEY",
-            credentials
-                .secret_access_key()
-                .context(error::CredentialsMissingSnafu { role_arn })?,
-        );
-        env::set_var(
-            "AWS_SESSION_TOKEN",
-            credentials
-                .session_token()
-                .context(error::CredentialsMissingSnafu { role_arn })?,
-        );
-        let region_provider = RegionProviderChain::first_try(Region::new(region.clone()));
-        config = aws_config::from_env()
-            .retry_config(
-                RetryConfig::standard()
-                    .with_retry_mode(RetryMode::Adaptive)
-                    .with_max_attempts(15),
-            )
-            .region(region_provider)
-            .load()
-            .await;
+        set_environment_variables(
+            &String::from(
+                credentials
+                    .access_key_id()
+                    .context(error::CredentialsMissingSnafu { role_arn })?,
+            ),
+            &String::from(
+                credentials
+                    .secret_access_key()
+                    .context(error::CredentialsMissingSnafu { role_arn })?,
+            ),
+            &Some(String::from(
+                credentials
+                    .session_token()
+                    .context(error::CredentialsMissingSnafu { role_arn })?,
+            )),
+        )
     }
-
     Ok(config)
 }
 
-/// Set up AWS credential secrets in a runner's process's environment
-pub async fn setup_test_env<R>(runner: &R, aws_secret_name: &SecretName) -> Result<(), Error>
-where
-    R: Runner,
-{
-    let aws_secret = runner
+fn get_secret_values(
+    aws_secret_name: &SecretName,
+) -> Result<(String, String, Option<String>), Error> {
+    let reader = SecretsReader::new();
+    let aws_secret = reader
         .get_secret(aws_secret_name)
         .context(error::SecretMissingSnafu)?;
-
     let access_key_id = String::from_utf8(
         aws_secret
             .get("access-key-id")
@@ -132,167 +140,25 @@ where
     .context(error::ConversionSnafu {
         what: "access-key-id",
     })?;
-
-    if let Some(token) = aws_secret.get("session-token") {
-        env::set_var(
-            "AWS_SESSION_TOKEN",
-            String::from_utf8(token.to_owned()).context(error::ConversionSnafu {
+    let session_token = match aws_secret.get("session-token") {
+        Some(token) => Some(String::from_utf8(token.to_owned()).context(
+            error::ConversionSnafu {
                 what: "session-token",
-            })?,
-        );
+            },
+        )?),
+        None => None,
     };
-
-    env::set_var("AWS_ACCESS_KEY_ID", access_key_id);
-    env::set_var("AWS_SECRET_ACCESS_KEY", secret_access_key);
-
-    Ok(())
+    Ok((access_key_id, secret_access_key, session_token))
 }
 
-/// Set up the config for aws calls using `aws_secret_name` if provided and `sts::assume_role`
-/// if a role arn is provided.
-pub async fn aws_resource_config<I>(
-    client: &I,
-    aws_secret_name: &Option<&SecretName>,
-    assume_role: &Option<String>,
-    region: &Option<String>,
-    resources: Resources,
-) -> ProviderResult<SdkConfig>
-where
-    I: InfoClient,
-{
-    let region = region
-        .as_ref()
-        .unwrap_or(&DEFAULT_REGION.to_string())
-        .to_string();
-
-    if let Some(aws_secret_name) = aws_secret_name {
-        info!("Adding secret '{}' to the environment", aws_secret_name);
-        setup_resource_env(client, aws_secret_name, resources).await?;
-    }
-    let region_provider = RegionProviderChain::first_try(Region::new(region.clone()));
-    let mut config = aws_config::from_env()
-        .retry_config(
-            RetryConfig::standard()
-                .with_retry_mode(RetryMode::Adaptive)
-                .with_max_attempts(15),
-        )
-        .region(region_provider)
-        .load()
-        .await;
-
-    if let Some(role_arn) = assume_role {
-        info!("Getting credentials for assumed role '{}'.", role_arn);
-        let sts_client = aws_sdk_sts::Client::new(&config);
-        let assume_role_output = resource_agent::provider::IntoProviderError::context(
-            sts_client
-                .assume_role()
-                .role_arn(role_arn)
-                .role_session_name("testsys")
-                .send()
-                .await,
-            resources,
-            format!("Unable to get credentials for role '{}'", role_arn),
-        )?;
-        let credentials = resource_agent::provider::IntoProviderError::context(
-            assume_role_output.credentials(),
-            resources,
-            format!("Credentials missing for assumed role '{}'", role_arn),
-        )?;
-        // Set the env variables for our assumed role.
-        env::set_var(
-            "AWS_ACCESS_KEY_ID",
-            resource_agent::provider::IntoProviderError::context(
-                credentials.access_key_id(),
-                resources,
-                "Credentials missing `access_key_id`",
-            )?,
-        );
-        env::set_var(
-            "AWS_SECRET_ACCESS_KEY",
-            resource_agent::provider::IntoProviderError::context(
-                credentials.secret_access_key(),
-                resources,
-                "Credentials missing `secret_access_key`",
-            )?,
-        );
-        env::set_var(
-            "AWS_SESSION_TOKEN",
-            resource_agent::provider::IntoProviderError::context(
-                credentials.session_token(),
-                resources,
-                "Credentials missing `session_token`",
-            )?,
-        );
-        let region_provider = RegionProviderChain::first_try(Region::new(region.clone()));
-        config = aws_config::from_env()
-            .retry_config(
-                RetryConfig::standard()
-                    .with_retry_mode(RetryMode::Adaptive)
-                    .with_max_attempts(15),
-            )
-            .region(region_provider)
-            .load()
-            .await;
-    }
-
-    Ok(config)
-}
-
-/// Set up AWS credential secrets in a resource's process's environment
-pub async fn setup_resource_env<I>(
-    client: &I,
-    aws_secret_name: &SecretName,
-    resources: Resources,
-) -> ProviderResult<()>
-where
-    I: InfoClient,
-{
-    let aws_secret = resource_agent::provider::IntoProviderError::context(
-        client.get_secret(aws_secret_name).await,
-        resources,
-        format!("Error getting secret '{}'", aws_secret_name),
-    )?;
-
-    let access_key_id = resource_agent::provider::IntoProviderError::context(
-        String::from_utf8(
-            resource_agent::provider::IntoProviderError::context(
-                aws_secret.get("access-key-id"),
-                resources,
-                format!("access-key-id missing from secret '{}'", aws_secret_name),
-            )?
-            .to_owned(),
-        ),
-        resources,
-        "Could not convert access-key-id to String",
-    )?;
-    let secret_access_key = resource_agent::provider::IntoProviderError::context(
-        String::from_utf8(
-            resource_agent::provider::IntoProviderError::context(
-                aws_secret.get("secret-access-key"),
-                resources,
-                format!(
-                    "secret-access-key missing from secret '{}'",
-                    aws_secret_name
-                ),
-            )?
-            .to_owned(),
-        ),
-        resources,
-        "Could not convert secret-access-key to String",
-    )?;
-    if let Some(token) = aws_secret.get("session-token") {
-        env::set_var(
-            "AWS_SESSION_TOKEN",
-            resource_agent::provider::IntoProviderError::context(
-                String::from_utf8(token.to_owned()),
-                resources,
-                "Could not convert session-token to String",
-            )?,
-        );
-    };
-
+fn set_environment_variables(
+    access_key_id: &String,
+    secret_access_key: &String,
+    session_token: &Option<String>,
+) {
     env::set_var("AWS_ACCESS_KEY_ID", access_key_id);
     env::set_var("AWS_SECRET_ACCESS_KEY", secret_access_key);
-
-    Ok(())
+    if let Some(session_token) = session_token {
+        env::set_var("AWS_SESSION_TOKEN", session_token);
+    }
 }

--- a/agent/utils/src/constants.rs
+++ b/agent/utils/src/constants.rs
@@ -2,3 +2,4 @@ use log::LevelFilter;
 
 pub const DEFAULT_REGION: &str = "us-west-2";
 pub const DEFAULT_AGENT_LEVEL_FILTER: LevelFilter = LevelFilter::Info;
+pub const DEFAULT_ASSUME_ROLE_SESSION_DURATION: i32 = 3600;

--- a/bottlerocket/agents/src/bin/ecs-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/ecs-test-agent/main.rs
@@ -4,7 +4,7 @@ Tests whether an ECS task runs successfully.
 
 !*/
 
-use agent_utils::aws::aws_test_config;
+use agent_utils::aws::aws_config;
 use agent_utils::init_agent_logger;
 use async_trait::async_trait;
 use aws_sdk_ec2::types::SdkError;
@@ -39,12 +39,12 @@ impl Runner for EcsTestRunner {
     }
 
     async fn run(&mut self) -> Result<TestResults, Self::E> {
-        let config = aws_test_config(
-            self,
-            &self.aws_secret_name,
+        let config = aws_config(
+            &self.aws_secret_name.as_ref(),
             &self.config.assume_role,
             &None,
             &self.config.region,
+            false,
         )
         .await?;
         let ecs_client = aws_sdk_ecs::Client::new(&config);

--- a/bottlerocket/agents/src/bin/migration-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/migration-test-agent/main.rs
@@ -41,7 +41,7 @@ mod ssm;
 use crate::ssm::{
     create_or_update_ssm_document, ssm_run_command, wait_for_os_version_change, wait_for_ssm_ready,
 };
-use agent_utils::aws::aws_test_config;
+use agent_utils::aws::aws_config;
 use agent_utils::init_agent_logger;
 use async_trait::async_trait;
 use bottlerocket_agents::error::{self, Error};
@@ -78,12 +78,12 @@ impl test_agent::Runner for MigrationTestRunner {
     }
 
     async fn run(&mut self) -> Result<TestResults, Self::E> {
-        let shared_config = aws_test_config(
-            self,
-            &self.aws_secret_name,
+        let shared_config = aws_config(
+            &self.aws_secret_name.as_ref(),
             &self.config.assume_role,
             &None,
             &Some(self.config.aws_region.clone()),
+            false,
         )
         .await?;
         let ssm_client = aws_sdk_ssm::Client::new(&shared_config);

--- a/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
@@ -32,7 +32,7 @@ spec:
 
 !*/
 
-use agent_utils::aws::aws_test_config;
+use agent_utils::aws::aws_config;
 use agent_utils::{base64_decode_write_file, init_agent_logger};
 use async_trait::async_trait;
 use bottlerocket_agents::constants::{E2E_REPO_CONFIG_PATH, TEST_CLUSTER_KUBECONFIG_PATH};
@@ -65,12 +65,12 @@ impl test_agent::Runner for SonobuoyTestRunner {
     }
 
     async fn run(&mut self) -> Result<TestResults, Self::E> {
-        aws_test_config(
-            self,
-            &self.aws_secret_name,
+        aws_config(
+            &self.aws_secret_name.as_ref(),
             &self.config.assume_role,
             &None,
             &None,
+            true,
         )
         .await?;
 
@@ -99,12 +99,12 @@ impl test_agent::Runner for SonobuoyTestRunner {
 
     async fn rerun_failed(&mut self, _prev_results: &TestResults) -> Result<TestResults, Self::E> {
         // Set up the aws credentials if they were provided.
-        aws_test_config(
-            self,
-            &self.aws_secret_name,
+        aws_config(
+            &self.aws_secret_name.as_ref(),
             &self.config.assume_role,
             &None,
             &None,
+            true,
         )
         .await?;
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #583 

**Description of changes:**

Merged `aws_test_config` and `aws_resource_config` into one method `aws_config` and modified them to store and pass credentials using `Credentials` instead of environment variables. Added bool `setup_env` to both methods to determine whether or not the credentials should be set as environment variables (which should happen when, for example, running `sonobuoy` tests). Added `assume_role_session_duration` argument to `aws_config` which was previously only used in `aws_test_config`. Refactored `aws.rs` to reduce code duplication.

**Testing done:**

Ran an ECS test and an EKS test, with and without assumed role, all 4 of which passed.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
