### PR TITLE
builder: Small bug-fixes

### DIFF
--- a/agent/builder-derive/src/derive.rs
+++ b/agent/builder-derive/src/derive.rs
@@ -106,15 +106,25 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
                 #[serde(rename_all = "camelCase")]
                 pub struct #build_ident{
                     #(#fields)*
+                    #[serde(skip)]
                     depends_on: Vec<String>,
+                    #[serde(skip)]
                     resources: Vec<String>,
+                    #[serde(skip)]
                     labels: std::collections::BTreeMap<String,String>,
+                    #[serde(skip)]
                     image: Option<String>,
+                    #[serde(skip)]
                     image_pull_secret: Option<String>,
+                    #[serde(skip)]
                     secrets: std::collections::BTreeMap<String, model::SecretName>,
+                    #[serde(skip)]
                     retries: Option<u32>,
+                    #[serde(skip)]
                     keep_running: Option<bool>,
+                    #[serde(skip)]
                     capabilities: Vec<String>,
+                    #[serde(skip)]
                     privileged: Option<bool>,
                 }
 
@@ -278,15 +288,25 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
                 #[serde(rename_all = "camelCase")]
                 pub struct #build_ident{
                     #(#fields)*
+                    #[serde(skip)]
                     depends_on: Vec<String>,
+                    #[serde(skip)]
                     conflicts_with: Vec<String>,
+                    #[serde(skip)]
                     labels: std::collections::BTreeMap<String,String>,
+                    #[serde(skip)]
                     image: Option<String>,
+                    #[serde(skip)]
                     image_pull_secret: Option<String>,
+                    #[serde(skip)]
                     secrets: std::collections::BTreeMap<String, model::SecretName>,
+                    #[serde(skip)]
                     keep_running: Option<bool>,
+                    #[serde(skip)]
                     capabilities: Vec<String>,
+                    #[serde(skip)]
                     destruction_policy: Option<model::DestructionPolicy>,
+                    #[serde(skip)]
                     privileged: Option<bool>,
                 }
 

--- a/agent/builder-derive/src/derive.rs
+++ b/agent/builder-derive/src/derive.rs
@@ -198,7 +198,7 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
                         self
                     }
 
-                    pub fn retries<S1>(&mut self, retries: u32) -> &mut Self {
+                    pub fn retries(&mut self, retries: u32) -> &mut Self {
                         self.retries = Some(retries);
                         self
                     }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

```
There was an extra type in the `retries` setter that needed to be
removed.
```

```
builder: Remove unnecessary fields from config
The builder originally just deserialized everything from itself into the
crd's config. Now all of the agent fields are skipped during
serialization.
```

**Testing done:**

```
testsys run aws-k8s \
       --name k8s-123 \
       --test-agent-image "public.ecr.aws/bottlerocket-test-system/sonobuoy-test-agent:v0.0.3" \
       --keep-running \
       --sonobuoy-mode "quick" \
       --region "us-west-2" \
       --cluster-name "x86-64-aws-k8s-123" \
       --cluster-creation-policy "ifNotExists" \
       --cluster-destruction-policy "never" \
       --cluster-provider-image "public.ecr.aws/bottlerocket-test-system/eks-resource-agent:v0.0.3" \
       --cluster-version "1.23" \
       --ami <AMI> \
       --ec2-provider-image "public.ecr.aws/bottlerocket-test-system/ec2-resource-agent:v0.0.3"
```

```
 NAME                                  TYPE              STATE              PASSED         SKIPPED         FAILED
 k8s-123                               Test              passed             1              7051            0
 x86-64-aws-k8s-123                    Resource          completed
 x86-64-aws-k8s-123-instances          Resource          completed
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
