### PR TITLE
agent: set dependency versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "builder-derive"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "configuration-derive",
  "model",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "configuration-derive"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "quote",
  "syn",

--- a/agent/builder-derive/Cargo.toml
+++ b/agent/builder-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "builder-derive"
-version = "0.0.1"
+version = "0.0.3"
 edition = "2018"
 publish = false
 license = "MIT OR Apache-2.0"
@@ -17,5 +17,5 @@ proc-macro = true
 [dev-dependencies]
 serde = "1"
 serde_json= "1"
-model = { path = "../../model"}
-configuration-derive = { path = "../configuration-derive"}
+model = { version = "0.0.3", path = "../../model" }
+configuration-derive = { version = "0.0.3", path = "../configuration-derive" }

--- a/agent/configuration-derive/Cargo.toml
+++ b/agent/configuration-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "configuration-derive"
-version = "0.0.1"
+version = "0.0.3"
 edition = "2018"
 publish = false
 license = "MIT OR Apache-2.0"

--- a/bottlerocket/types/Cargo.toml
+++ b/bottlerocket/types/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-configuration-derive = { path = "../../agent/configuration-derive"}
-builder-derive = { path = "../../agent/builder-derive"}
+configuration-derive = { version = "0.0.3", path = "../../agent/configuration-derive" }
+builder-derive = { version = "0.0.3", path = "../../agent/builder-derive" }
 model = { version = "0.0.3", path = "../../model" }
 serde = "1"
 serde_plain = "1"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #640 

**Description of changes:**

Specified the version of `configuration-derive`, `model`, and `builder-derive` instead of leaving it as a wildcard.

**Testing done:**

Removed `bottlerocket-types` from `skip-tree` in Bottlerocket's `deny.toml` and ran `cargo make` which finished successfully.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
