### PR TITLE
Add k8s workload testing agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ TESTSYS_BUILD_GOPROXY ?= direct
 # The set of bottlerocket images to create. Add new artifacts here when added
 # to the project.
 IMAGES = controller sonobuoy-test-agent ec2-resource-agent eks-resource-agent ecs-resource-agent \
-	migration-test-agent vsphere-vm-resource-agent vsphere-k8s-cluster-resource-agent ecs-test-agent
+	migration-test-agent vsphere-vm-resource-agent vsphere-k8s-cluster-resource-agent ecs-test-agent \
+	k8s-workload-agent
 
 # Store targets for tagging images
 TAG_IMAGES = $(addprefix tag-, $(IMAGES))
@@ -138,7 +139,7 @@ tools:
 		./tools
 
 # Build the container image for a testsys agent
-eks-resource-agent ec2-resource-agent ecs-resource-agent vsphere-vm-resource-agent vsphere-k8s-cluster-resource-agent sonobuoy-test-agent migration-test-agent ecs-test-agent: show-variables fetch
+eks-resource-agent ec2-resource-agent ecs-resource-agent vsphere-vm-resource-agent vsphere-k8s-cluster-resource-agent sonobuoy-test-agent migration-test-agent ecs-test-agent k8s-workload-agent: show-variables fetch
 	docker build $(DOCKER_BUILD_FLAGS) \
 		--build-arg ARCH="$(TESTSYS_BUILD_HOST_UNAME_ARCH)" \
 		--build-arg BUILDER_IMAGE="$(BUILDER_IMAGE)" \

--- a/bottlerocket/agents/src/bin/k8s-workload-agent/main.rs
+++ b/bottlerocket/agents/src/bin/k8s-workload-agent/main.rs
@@ -1,0 +1,111 @@
+/*!
+
+This is a test-agent for running workload tests on Kubernetes.
+It expects to be run in a pod launched by the TestSys controller.
+
+You can configure the workload agent to run different types of plugins and tests.
+See `WorkloadConfig` for the different configuration values.
+
+To build the container for the workload test agent, run `make k8s-workload-agent-image` from the
+root directory of this repository.
+
+Here is an example manifest for deploying the test definition for the workload test agent to a K8s cluster:
+
+```yaml
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: workload-full
+  namespace: testsys
+spec:
+  agent:
+    configuration:
+      kubeconfigBase64: <Base64 encoded kubeconfig for the test cluster workload runs the tests in>
+      plugins:
+      - name: nvidia-workload
+        image: testsys-nvidia-workload-test:v0.0.3
+    image: <your k8s-workload-agent image URI>
+    name: workload-test-agent
+    keepRunning: true
+  resources: {}
+```
+
+!*/
+
+use agent_utils::{base64_decode_write_file, init_agent_logger};
+use async_trait::async_trait;
+use bottlerocket_agents::constants::TEST_CLUSTER_KUBECONFIG_PATH;
+use bottlerocket_agents::error::Error;
+use bottlerocket_agents::workload::{delete_workload, rerun_failed_workload, run_workload};
+use bottlerocket_types::agent_config::WorkloadConfig;
+use log::info;
+use model::TestResults;
+use std::path::PathBuf;
+use test_agent::{BootstrapData, ClientError, DefaultClient, Spec, TestAgent};
+
+struct WorkloadTestRunner {
+    config: WorkloadConfig,
+    results_dir: PathBuf,
+}
+
+#[async_trait]
+impl test_agent::Runner for WorkloadTestRunner {
+    type C = WorkloadConfig;
+    type E = Error;
+
+    async fn new(spec: Spec<Self::C>) -> Result<Self, Self::E> {
+        info!("Initializing Workload test agent...");
+        Ok(Self {
+            config: spec.configuration,
+            results_dir: spec.results_dir,
+        })
+    }
+
+    async fn run(&mut self) -> Result<TestResults, Self::E> {
+        info!("Decoding kubeconfig for test cluster");
+        base64_decode_write_file(&self.config.kubeconfig_base64, TEST_CLUSTER_KUBECONFIG_PATH)
+            .await?;
+        info!("Stored kubeconfig in {}", TEST_CLUSTER_KUBECONFIG_PATH);
+
+        run_workload(
+            TEST_CLUSTER_KUBECONFIG_PATH,
+            &self.config,
+            &self.results_dir,
+        )
+        .await
+    }
+
+    async fn rerun_failed(&mut self, _prev_results: &TestResults) -> Result<TestResults, Self::E> {
+        delete_workload(TEST_CLUSTER_KUBECONFIG_PATH).await?;
+
+        info!("Decoding kubeconfig for test cluster");
+        base64_decode_write_file(&self.config.kubeconfig_base64, TEST_CLUSTER_KUBECONFIG_PATH)
+            .await?;
+        info!("Stored kubeconfig in {}", TEST_CLUSTER_KUBECONFIG_PATH);
+
+        rerun_failed_workload(TEST_CLUSTER_KUBECONFIG_PATH, &self.results_dir).await
+    }
+
+    async fn terminate(&mut self) -> Result<(), Self::E> {
+        delete_workload(TEST_CLUSTER_KUBECONFIG_PATH).await
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    init_agent_logger(env!("CARGO_CRATE_NAME"), None);
+    if let Err(e) = run().await {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), test_agent::error::Error<ClientError, Error>> {
+    let mut agent = TestAgent::<DefaultClient, WorkloadTestRunner>::new(
+        BootstrapData::from_env().unwrap_or_else(|_| BootstrapData {
+            test_name: "workload_test".to_string(),
+        }),
+    )
+    .await?;
+    agent.run().await
+}

--- a/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
@@ -127,7 +127,6 @@ impl test_agent::Runner for SonobuoyTestRunner {
         rerun_failed_sonobuoy(
             TEST_CLUSTER_KUBECONFIG_PATH,
             e2e_repo_config,
-            &self.config,
             &self.results_dir,
         )
         .await

--- a/bottlerocket/agents/src/error.rs
+++ b/bottlerocket/agents/src/error.rs
@@ -98,6 +98,18 @@ pub enum Error {
     #[snafu(display("Failed to read file: {}", source))]
     FileRead { source: std::io::Error },
 
+    #[snafu(display("Failed to write file: {path}"))]
+    FileWrite {
+        source: std::io::Error,
+        path: String,
+    },
+
+    #[snafu(display("Invalid path: {path}"))]
+    BadPath {
+        source: std::io::Error,
+        path: String,
+    },
+
     #[snafu(display("Results location is invalid"))]
     ResultsLocation,
 
@@ -157,4 +169,31 @@ pub enum Error {
     #[snafu(context(false))]
     #[snafu(display("{}", source))]
     Utils { source: agent_utils::Error },
+
+    #[snafu(display("Failed to create workload process: {}", source))]
+    WorkloadProcess { source: std::io::Error },
+
+    #[snafu(display(
+        "Failed to run workload test\nCode: {exit_code}\nStdout:\n{stdout}\nStderr:\n{stderr}"
+    ))]
+    WorkloadRun {
+        exit_code: i32,
+        stdout: String,
+        stderr: String,
+    },
+
+    #[snafu(display("Failed to initialize workload test plugin: {}", plugin))]
+    WorkloadPlugin { plugin: String },
+
+    #[snafu(display(
+        "Failed to write workload test plugin configuration yaml for: {}",
+        plugin
+    ))]
+    WorkloadWritePlugin { plugin: String },
+
+    #[snafu(display("Failed to clean-up workload resources"))]
+    WorkloadDelete,
+
+    #[snafu(display("Missing '{}' field from workload status", field))]
+    MissingWorkloadStatusField { field: String },
 }

--- a/bottlerocket/agents/src/lib.rs
+++ b/bottlerocket/agents/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub mod sonobuoy;
 pub mod tuf;
 pub mod vsphere;
+pub mod workload;
 
 /// Determines whether a cluster resource needs to be created given its creation policy
 pub async fn is_cluster_creation_required(

--- a/bottlerocket/agents/src/workload.rs
+++ b/bottlerocket/agents/src/workload.rs
@@ -1,0 +1,182 @@
+use crate::error;
+use crate::sonobuoy::process_sonobuoy_test_results;
+use bottlerocket_types::agent_config::{WorkloadConfig, SONOBUOY_RESULTS_FILENAME};
+use log::{info, trace};
+use model::TestResults;
+use snafu::{ensure, ResultExt};
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SONOBUOY_BIN_PATH: &str = "/usr/bin/sonobuoy";
+
+/// Runs the workload conformance tests according to the provided configuration and returns a test
+/// result at the end.
+pub async fn run_workload(
+    kubeconfig_path: &str,
+    workload_config: &WorkloadConfig,
+    results_dir: &Path,
+) -> Result<TestResults, error::Error> {
+    info!("Processing workload test plugins");
+    let mut plugin_test_args: Vec<String> = Vec::new();
+    for (id, plugin) in workload_config.plugins.iter().enumerate() {
+        info!("Initializing test {}-{}", id, plugin.name);
+        let output = Command::new(SONOBUOY_BIN_PATH)
+            .arg("gen")
+            .arg("plugin")
+            .arg("--name")
+            .arg(plugin.name.clone())
+            .arg("--image")
+            .arg(plugin.image.clone())
+            .output()
+            .context(error::WorkloadProcessSnafu)?;
+        ensure!(
+            output.status.success(),
+            error::WorkloadPluginSnafu {
+                plugin: plugin.name.clone()
+            }
+        );
+
+        // Write out the output to a file we can reference later
+        let file_name = format!("{}-plugin.yaml", plugin.name);
+        let plugin_yaml = PathBuf::from(".")
+            .join(&file_name)
+            .canonicalize()
+            .context(error::BadPathSnafu { path: &file_name })?;
+        let mut f = File::create(&plugin_yaml).context(error::FileWriteSnafu {
+            path: plugin_yaml.display().to_string(),
+        })?;
+        f.write_all(&output.stdout)
+            .context(error::WorkloadProcessSnafu)?;
+
+        // Add plugin to the arguments to be passed to sonobuoy run
+        plugin_test_args.append(&mut vec![
+            "--plugin".to_string(),
+            plugin_yaml.display().to_string(),
+        ]);
+    }
+
+    info!("Running workload");
+    let kubeconfig_arg = vec!["--kubeconfig", kubeconfig_path];
+    let output = Command::new(SONOBUOY_BIN_PATH)
+        .args(kubeconfig_arg.to_owned())
+        .arg("run")
+        .arg("--wait")
+        .arg("--namespace")
+        .arg("testsys-workload")
+        .args(plugin_test_args)
+        .output()
+        .context(error::WorkloadProcessSnafu)?;
+    info!("Workload testing has completed, checking results");
+
+    ensure!(
+        output.status.success(),
+        error::WorkloadRunSnafu {
+            exit_code: output.status.code().unwrap_or_default(),
+            stdout: &String::from_utf8(output.stdout).unwrap_or_else(|_| "".to_string()),
+            stderr: &String::from_utf8(output.stderr).unwrap_or_else(|_| "".to_string()),
+        }
+    );
+
+    results_workload(kubeconfig_path, results_dir)
+}
+
+/// Reruns the the failed tests from workload conformance that has already run in this agent.
+pub async fn rerun_failed_workload(
+    kubeconfig_path: &str,
+    results_dir: &Path,
+) -> Result<TestResults, error::Error> {
+    let kubeconfig_arg = vec!["--kubeconfig", kubeconfig_path];
+    let results_filepath = results_dir.join(SONOBUOY_RESULTS_FILENAME);
+
+    info!("Rerunning workload");
+    let output = Command::new(SONOBUOY_BIN_PATH)
+        .args(kubeconfig_arg.to_owned())
+        .arg("run")
+        .arg("--wait")
+        .arg("--namespace")
+        .arg("testsys-workload")
+        .arg("--rerun-failed")
+        .arg(results_filepath.as_os_str())
+        .output()
+        .context(error::WorkloadProcessSnafu)?;
+    info!("Workload testing has completed, checking results");
+
+    ensure!(
+        output.status.success(),
+        error::WorkloadRunSnafu {
+            exit_code: output.status.code().unwrap_or_default(),
+            stdout: &String::from_utf8(output.stdout).unwrap_or_else(|_| "".to_string()),
+            stderr: &String::from_utf8(output.stderr).unwrap_or_else(|_| "".to_string()),
+        }
+    );
+
+    results_workload(kubeconfig_path, results_dir)
+}
+
+/// Retrieve the results from a workload test and convert them into `TestResults`.
+pub fn results_workload(
+    kubeconfig_path: &str,
+    results_dir: &Path,
+) -> Result<TestResults, error::Error> {
+    let kubeconfig_arg = vec!["--kubeconfig", kubeconfig_path];
+
+    info!("Running workload retrieve");
+    let results_filepath = results_dir.join(SONOBUOY_RESULTS_FILENAME);
+    let output = Command::new(SONOBUOY_BIN_PATH)
+        .args(kubeconfig_arg.to_owned())
+        .arg("retrieve")
+        .arg("--namespace")
+        .arg("testsys-workload")
+        .arg("--filename")
+        .arg(results_filepath.as_os_str())
+        .output()
+        .context(error::WorkloadProcessSnafu)?;
+
+    ensure!(
+        output.status.success(),
+        error::WorkloadRunSnafu {
+            exit_code: output.status.code().unwrap_or_default(),
+            stdout: &String::from_utf8(output.stdout).unwrap_or_else(|_| "".to_string()),
+            stderr: &String::from_utf8(output.stderr).unwrap_or_else(|_| "".to_string()),
+        }
+    );
+
+    info!("Getting Workload status");
+    let run_result = Command::new(SONOBUOY_BIN_PATH)
+        .args(kubeconfig_arg)
+        .arg("status")
+        .arg("--json")
+        .arg("--namespace")
+        .arg("testsys-workload")
+        .output()
+        .context(error::WorkloadProcessSnafu)?;
+
+    let stdout = String::from_utf8_lossy(&run_result.stdout);
+    info!("Parsing the following workload results output:\n{}", stdout);
+
+    trace!("Parsing workload results as json");
+    let run_status: serde_json::Value =
+        serde_json::from_str(&stdout).context(error::DeserializeJsonSnafu)?;
+    trace!("The workload results are valid json");
+
+    process_sonobuoy_test_results(&run_status)
+}
+
+/// Deletes all workload namespaces and associated resources in the target K8s cluster
+pub async fn delete_workload(kubeconfig_path: &str) -> Result<(), error::Error> {
+    let kubeconfig_arg = vec!["--kubeconfig", kubeconfig_path];
+    info!("Deleting workload resources from cluster");
+    let status = Command::new(SONOBUOY_BIN_PATH)
+        .args(kubeconfig_arg)
+        .arg("delete")
+        .arg("--namespace")
+        .arg("testsys-workload")
+        .arg("--wait")
+        .status()
+        .context(error::WorkloadProcessSnafu)?;
+    ensure!(status.success(), error::WorkloadDeleteSnafu);
+
+    Ok(())
+}

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -477,3 +477,17 @@ fn k8s_version_valid() {
     assert_eq!("v1.21.3", k8s_version.full_version_with_v());
     assert_eq!("1.21.3", k8s_version.full_version_without_v());
 }
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WorkloadTest {
+    pub name: String,
+    pub image: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Configuration, Builder)]
+#[serde(rename_all = "camelCase")]
+#[crd("Test")]
+pub struct WorkloadConfig {
+    pub kubeconfig_base64: String,
+    pub plugins: Vec<WorkloadTest>,
+}


### PR DESCRIPTION
**Issue number:**

Closes: #616 

**Description of changes:**

This adds a test agent for running cluster workload tests. These are tests that run some sort of workload on the cluster to verify system functionality.

**Testing done:**

- Created test container image, manually stepped through the sonobuoy commands in the agent and verified the job runs and is successful on aws-k8s-nvidia nodes.
- Followed the [developer instructions for running a test](https://github.com/bottlerocket-os/bottlerocket-test-system/blob/develop/docs/DEVELOPER.md#running-a-test), replacing `example-test-agent` with `k8s-workload-agent` and its settings. Unable to run the NVIDIA tests against a local kind cluster, but this verified things were deployed and status reported back. This along with the previous step that verified the workload test itself indicates things would perform correctly in an actual test (non-kind) cluster.
- More testing to come!

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
