### PR TITLE
Correct sonobuoy test yaml field names

### DIFF
--- a/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
@@ -20,13 +20,13 @@ metadata:
 spec:
   agent:
     configuration:
-      kubeconfig_base64: <Base64 encoded kubeconfig for the test cluster sonobuoy runs the tests in>
+      kubeconfigBase64: <Base64 encoded kubeconfig for the test cluster sonobuoy runs the tests in>
       plugin: e2e
       mode: certified-conformance
       kubernetes_version: v1.21.2
     image: <your sonobuoy-test-agent image URI>
     name: sonobuoy-test-agent
-    keep_running: true
+    keepRunning: true
   resources: {}
 ```
 


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Since we use `#[serde(rename_all = "camelCase")]` in the configuration sruct, the Rust native names are changed from snake case to camel case in the result serialized YAML.

The example YAML shown in the comments of the sonobuoy-test-agent code did not make this translation, so if the example is copy/pasted and attempted to be used as-is, the deserialization to a CRD fails because of missing and mismatched fields.

This updates the example YAML to be the correct modified names.

**Testing done:**

Validated YAML was correct.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
