### PR TITLE
builder: `build()` error type `Sync + Send`

### DIFF
--- a/agent/builder-derive/src/derive.rs
+++ b/agent/builder-derive/src/derive.rs
@@ -250,7 +250,7 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
                         self
                     }
 
-                    pub fn build<S1>(&self, name: S1) -> Result<model::Test, Box<dyn std::error::Error>>
+                    pub fn build<S1>(&self, name: S1) -> Result<model::Test, Box<dyn std::error::Error + Sync + Send>>
                     where
                     S1: Into<String>,
                     {
@@ -432,7 +432,7 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
                         self
                     }
 
-                    pub fn build<S1>(&self, name: S1) -> Result<model::Resource, Box<dyn std::error::Error>>
+                    pub fn build<S1>(&self, name: S1) -> Result<model::Resource, Box<dyn std::error::Error + Sync + Send>>
                     where
                     S1: Into<String>,
                     {

--- a/bottlerocket/testsys/src/error.rs
+++ b/bottlerocket/testsys/src/error.rs
@@ -17,7 +17,7 @@ pub(crate) enum Error {
     #[snafu(display("Unable to build '{}': {}", what, source))]
     Build {
         what: String,
-        source: Box<dyn std::error::Error>,
+        source: Box<dyn std::error::Error + Sync + Send>,
     },
 
     #[snafu(display("Unable to create client: {}", source))]


### PR DESCRIPTION
A user using the builder macro with async functions and snafu was unable to use `context()` because the error type of the `build()` function was not `Sync + Send`.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

#654 

**Description of changes:**

A user using the builder macro with async functions and snafu was unable
to use `context()` because the error type of the `build()` function was
not `Sync + Send`.

**Testing done:**

Used with `Bottlerocket` repo to ensure `context()` could be used.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
