### PR TITLE
ec2-agent/vsphere-vm-agent: allow custom userdata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,6 +602,7 @@ dependencies = [
  "snafu",
  "test-agent",
  "tokio",
+ "toml",
  "tough",
  "url",
  "uuid",
@@ -3008,6 +3009,15 @@ dependencies = [
  "slab",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/bottlerocket/agents/Cargo.toml
+++ b/bottlerocket/agents/Cargo.toml
@@ -37,6 +37,7 @@ sha2 = "0.10"
 snafu = "0.7"
 test-agent = { version = "0.0.3", path = "../../agent/test-agent" }
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
+toml = "0.5"
 tough = { version = "0.12", features = ["http"] }
 url = "2"
 uuid = { version = "1", default-features = false, features = ["serde", "v4"] }

--- a/bottlerocket/agents/src/bin/vsphere-vm-resource-agent/vsphere_vm_provider.rs
+++ b/bottlerocket/agents/src/bin/vsphere-vm-resource-agent/vsphere_vm_provider.rs
@@ -3,9 +3,10 @@ use agent_utils::aws::aws_config;
 use agent_utils::base64_decode_write_file;
 use bottlerocket_agents::constants::TEST_CLUSTER_KUBECONFIG_PATH;
 use bottlerocket_agents::tuf::{download_target, tuf_repo_urls};
+use bottlerocket_agents::userdata::{decode_to_string, merge_values};
 use bottlerocket_agents::vsphere::vsphere_credentials;
 use bottlerocket_types::agent_config::{
-    VSphereVmConfig, AWS_CREDENTIALS_SECRET_NAME, VSPHERE_CREDENTIALS_SECRET_NAME,
+    CustomUserData, VSphereVmConfig, AWS_CREDENTIALS_SECRET_NAME, VSPHERE_CREDENTIALS_SECRET_NAME,
 };
 use k8s_openapi::api::core::v1::Service;
 use kube::api::ListParams;
@@ -27,6 +28,7 @@ use std::fs::File;
 use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
+use toml::Value;
 
 /// The default number of VMs to spin up.
 const DEFAULT_VM_COUNT: i32 = 2;
@@ -268,6 +270,8 @@ impl Create for VMCreator {
         let encoded_control_host_ctr_userdata =
             base64::encode(control_host_ctr_userdata.to_string());
 
+        let custom_user_data = spec.configuration.custom_user_data;
+
         // Base64 encode userdata
         let userdata = userdata(
             &vsphere_cluster.control_plane_endpoint_ip,
@@ -275,7 +279,8 @@ impl Create for VMCreator {
             bootstrap_token,
             cluster_certificate,
             &encoded_control_host_ctr_userdata,
-        );
+            &custom_user_data,
+        )?;
 
         info!("Launching {} Bottlerocket worker nodes", vm_count);
         for i in 0..vm_count {
@@ -403,6 +408,47 @@ impl Create for VMCreator {
 }
 
 fn userdata(
+    endpoint: &str,
+    cluster_dns_ip: &str,
+    bootstrap_token: &str,
+    certificate: &str,
+    control_container_userdata: &str,
+    custom_user_data: &Option<CustomUserData>,
+) -> ProviderResult<String> {
+    let default_userdata = default_userdata(
+        endpoint,
+        cluster_dns_ip,
+        bootstrap_token,
+        certificate,
+        control_container_userdata,
+    );
+
+    let custom_userdata = if let Some(value) = custom_user_data {
+        value
+    } else {
+        return Ok(default_userdata);
+    };
+
+    match custom_userdata {
+        CustomUserData::Replace { encoded_userdata } => Ok(encoded_userdata.to_string()),
+        CustomUserData::Merge { encoded_userdata } => {
+            let merge_into = &mut decode_to_string(&default_userdata)?
+                .parse::<Value>()
+                .context(Resources::Clear, "Failed to parse TOML")?;
+            let merge_from = decode_to_string(encoded_userdata)?
+                .parse::<Value>()
+                .context(Resources::Clear, "Failed to parse TOML")?;
+            merge_values(&merge_from, merge_into)
+                .context(Resources::Clear, "Failed to merge TOML")?;
+            Ok(base64::encode(toml::to_string(merge_into).context(
+                Resources::Clear,
+                "Failed to serialize merged TOML",
+            )?))
+        }
+    }
+}
+
+fn default_userdata(
     endpoint: &str,
     cluster_dns_ip: &str,
     bootstrap_token: &str,

--- a/bottlerocket/agents/src/lib.rs
+++ b/bottlerocket/agents/src/lib.rs
@@ -13,6 +13,7 @@ pub mod constants;
 pub mod error;
 pub mod sonobuoy;
 pub mod tuf;
+pub mod userdata;
 pub mod vsphere;
 
 /// Determines whether a cluster resource needs to be created given its creation policy

--- a/bottlerocket/agents/src/userdata.rs
+++ b/bottlerocket/agents/src/userdata.rs
@@ -1,0 +1,158 @@
+// Heavily borrowed from Bottlerocket's merge-toml crate.
+// See https://github.com/bottlerocket-os/bottlerocket/blob/v1.11.1/sources/api/storewolf/merge-toml/src/lib.rs
+
+use base64::decode;
+use resource_agent::provider::{IntoProviderError, ProviderError, ProviderResult, Resources};
+use std::str::from_utf8;
+use toml::{map::Entry, Value};
+
+/// This modifies the first given toml Value by inserting any values from the second Value.
+///
+/// This is done recursively.  Any time a scalar or array is seen, the left side is set to match
+/// the right side.  Any time a table is seen, we iterate through the keys of the tables; if the
+/// left side does not have the key from the right side, it's inserted, otherwise we recursively
+/// merge the values in each table for that key.
+///
+/// If at any point in the recursion the data types of the two values does not match, we error.
+pub fn merge_values<'a>(merge_from: &'a Value, merge_into: &'a mut Value) -> ProviderResult<()> {
+    // If the types of left and right don't match, we have inconsistent models, and shouldn't try
+    // to merge them.
+    if !merge_into.same_type(merge_from) {
+        IntoProviderError::context(
+            None,
+            Resources::Clear,
+            "Cannot merge mismatched data types in given TOML",
+        )?
+    }
+
+    match merge_from {
+        // If we see a scalar, we replace the left with the right.  We treat arrays like scalars so
+        // behavior is clear - no question about whether we're appending right onto left, etc.
+        Value::String(_)
+        | Value::Integer(_)
+        | Value::Float(_)
+        | Value::Boolean(_)
+        | Value::Datetime(_)
+        | Value::Array(_) => *merge_into = merge_from.clone(),
+
+        // If we see a table, we recursively merge each key.
+        Value::Table(from) => {
+            // We know the other side is a table because of the `ensure` above.
+            let to = merge_into.as_table_mut().ok_or_else(|| {
+                ProviderError::new_with_context(
+                    Resources::Clear,
+                    "Cannot merge mismatched data types in given TOML",
+                )
+            })?;
+            for (k_from, v_from) in from.iter() {
+                // Check if the left has the same key as the right.
+                match to.entry(k_from) {
+                    // If not, we can just insert the value.
+                    Entry::Vacant(e) => {
+                        e.insert(v_from.clone());
+                    }
+                    // If so, we need to recursively merge; we don't want to replace an entire
+                    // table, for example, because the left may have some distinct inner keys.
+                    Entry::Occupied(ref mut e) => {
+                        merge_values(v_from, e.get_mut())?;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn decode_to_string(encoded_userdata: &String) -> ProviderResult<String> {
+    Ok(from_utf8(
+        &decode(encoded_userdata).context(Resources::Clear, "Failed to decode base64 TOML")?,
+    )
+    .context(Resources::Clear, "Failed to decode base64 TOML")?
+    .to_string())
+}
+
+#[cfg(test)]
+mod test {
+    use super::merge_values;
+    use toml::toml;
+
+    #[test]
+    fn merge_1() {
+        let mut left = toml! {
+            top1 = "left top1"
+            top2 = "left top2"
+            [settings.inner]
+            inner_setting1 = "left inner_setting1"
+            inner_setting2 = "left inner_setting2"
+        };
+        let right = toml! {
+            top1 = "right top1"
+            [settings]
+            setting = "right setting"
+            [settings.inner]
+            inner_setting1 = "right inner_setting1"
+            inner_setting3 = "right inner_setting3"
+        };
+        // Can't comment inside this toml, unfortunately.
+        // "top1" is being overwritten from right.
+        // "top2" is only in the left and remains.
+        // "setting" is only in the right side.
+        // "inner" tests that recursion works; inner_setting1 is replaced, 2 is untouched, and
+        // 3 is new.
+        let expected = toml! {
+            top1 = "right top1"
+            top2 = "left top2"
+            [settings]
+            setting = "right setting"
+            [settings.inner]
+            inner_setting1 = "right inner_setting1"
+            inner_setting2 = "left inner_setting2"
+            inner_setting3 = "right inner_setting3"
+        };
+        merge_values(&right, &mut left).unwrap();
+        assert_eq!(left, expected);
+    }
+
+    #[test]
+    fn merge_2() {
+        let mut left = toml! {
+            top1 = "left top1"
+            top2 = "left top2"
+            [settings]
+            setting = "left setting"
+            [settings.inner]
+            inner_setting1 = "left inner_setting1"
+            inner_setting2 = "left inner_setting2"
+        };
+        let right = toml! {
+            top1 = "right top1"
+            [settings.inner]
+            inner_setting1 = "right inner_setting1"
+            inner_setting3 = "right inner_setting3"
+        };
+        let expected = toml! {
+            top1 = "right top1"
+            top2 = "left top2"
+            [settings]
+            setting = "left setting"
+            [settings.inner]
+            inner_setting1 = "right inner_setting1"
+            inner_setting2 = "left inner_setting2"
+            inner_setting3 = "right inner_setting3"
+        };
+        merge_values(&right, &mut left).unwrap();
+        assert_eq!(left, expected);
+    }
+
+    #[test]
+    fn merge_3() {
+        let mut left = toml! {
+            top1 = "left top1"
+        };
+        let right = toml! {
+            top1 = 12
+        };
+        assert!(merge_values(&right, &mut left).is_err());
+    }
+}

--- a/bottlerocket/testsys/src/error.rs
+++ b/bottlerocket/testsys/src/error.rs
@@ -109,6 +109,12 @@ pub(crate) enum Error {
     #[snafu(display("Error patching {}: {}", what, source))]
     Patch { what: String, source: kube::Error },
 
+    #[snafu(display("Error parsing TOML file '{}': {}", path, source))]
+    ParseToml {
+        path: String,
+        source: std::io::Error,
+    },
+
     #[snafu(display("Error getting data from reader: {}", source))]
     Read { source: std::io::Error },
 

--- a/bottlerocket/testsys/src/run_aws_ecs.rs
+++ b/bottlerocket/testsys/src/run_aws_ecs.rs
@@ -1,7 +1,7 @@
 use crate::error::{self, Result};
 use bottlerocket_types::agent_config::{
-    ClusterType, Ec2Config, EcsClusterConfig, EcsTestConfig, MigrationConfig, TufRepoConfig,
-    AWS_CREDENTIALS_SECRET_NAME,
+    ClusterType, CustomUserData, Ec2Config, EcsClusterConfig, EcsTestConfig, MigrationConfig,
+    TufRepoConfig, AWS_CREDENTIALS_SECRET_NAME,
 };
 use kube::ResourceExt;
 use kube::{api::ObjectMeta, Client};
@@ -14,7 +14,28 @@ use model::{
 use serde_json::Value;
 use snafu::ResultExt;
 use std::collections::BTreeMap;
+use std::fs::read_to_string;
+use std::str::FromStr;
 use structopt::StructOpt;
+
+#[derive(Clone, Debug)]
+enum CustomUserDataMode {
+    Merge,
+    Replace,
+}
+
+impl FromStr for CustomUserDataMode {
+    type Err = error::Error;
+    fn from_str(custom_user_data_mode: &str) -> Result<Self> {
+        match custom_user_data_mode {
+            "merge" => Ok(CustomUserDataMode::Merge),
+            "replace" => Ok(CustomUserDataMode::Replace),
+            _ => Err(error::Error::InvalidArguments {
+                why: "Invalid user data mode".to_string(),
+            }),
+        }
+    }
+}
 
 /// Create an EKS resource, EC2 resource and run Sonobuoy.
 #[derive(Debug, StructOpt)]
@@ -151,6 +172,15 @@ pub(crate) struct RunAwsEcs {
     /// provided, then the ECS test agent will attempt to create an IAM instance profile.
     #[structopt(long)]
     iam_instance_profile_name: Option<String>,
+
+    /// The path to a TOML file containing custom userdata.
+    #[structopt(long, requires("custom-user-data-mode"))]
+    custom_user_data: Option<String>,
+
+    /// The way custom userdata should interact with the default userdata.
+    /// The possible values are `merge` and `replace`.
+    #[structopt(long, requires("custom-user-data"))]
+    custom_user_data_mode: Option<CustomUserDataMode>,
 }
 
 impl RunAwsEcs {
@@ -350,6 +380,21 @@ impl RunAwsEcs {
         secrets: Option<BTreeMap<String, SecretName>>,
         cluster_resource_name: &str,
     ) -> Result<Resource> {
+        let user_data = &self
+            .custom_user_data
+            .clone()
+            .map(read_to_string)
+            .transpose()
+            .context(error::ReadSnafu {})?
+            .map(base64::encode);
+
+        let user_data = match (self.custom_user_data_mode.clone(), user_data) {
+            (Some(_), None) | (None, Some(_)) => return Err(error::Error::InvalidArguments { why: "Either both or neither of custom-user-data-mode and custom-user-data must be provided.".to_string() }),
+            (Some(CustomUserDataMode::Merge), Some(userdata)) => Some(CustomUserData::Merge { encoded_userdata: userdata.to_owned() }),
+            (Some(CustomUserDataMode::Replace), Some(userdata)) => Some(CustomUserData::Replace { encoded_userdata: userdata.to_owned() }),
+            (None, None) => None
+        };
+
         let mut ec2_config = Ec2Config {
             node_ami: self.ami.clone(),
             // TODO - configurable
@@ -368,6 +413,7 @@ impl RunAwsEcs {
             subnet_ids: vec![],
             cluster_type: ClusterType::Ecs,
             assume_role: self.assume_role.clone(),
+            custom_user_data: user_data,
             ..Default::default()
         }
         .into_map()

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -21,6 +21,13 @@ pub struct VSphereK8sClusterInfo {
     pub kubeconfig_base64: String,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CustomUserData {
+    Replace { encoded_userdata: String },
+    Merge { encoded_userdata: String },
+}
+
 /// What mode to run the e2e plugin in. Valid modes are `non-disruptive-conformance`,
 /// `certified-conformance` and `quick`.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
@@ -238,6 +245,9 @@ pub struct Ec2Config {
 
     /// The role that should be assumed when launching instances.
     pub assume_role: Option<String>,
+
+    /// Custom TOML data that should be inserted into user-data settings.
+    pub custom_user_data: Option<CustomUserData>,
 
     // Eks specific instance information.
     /// The security groups that should be attached to the instances.
@@ -459,6 +469,9 @@ pub struct VSphereVmConfig {
 
     /// The role that should be assumed when creating the vms.
     pub assume_role: Option<String>,
+
+    /// Custom TOML data that should be inserted into user-data settings.
+    pub custom_user_data: Option<CustomUserData>,
 }
 
 #[test]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #627 

**Description of changes:**

The `Ec2Config` and `VSphereVmConfig` are modified to allow an optional `CustomUserData` field. This field contains either a `Merge` or a `Replace` value with encoded userdata. The userdata either replaces the default userdata (if the `Replace` mode is used) or is parsed into `toml::Value` and merged with the default userdata (if the `Merge` mode is used).

**Testing done:**

- Unit tests for `merge_values`
- Ran an ECS test with this TOML file as custom userdata (in merge mode):
```
[settings.ecs]
loglevel = "warn"

[settings]
motd = "Custom userdata"
```

Test passed and instance userdata looks like this:
```
[settings]
motd = "Custom userdata"

[settings.ecs]
cluster = "external-cluster"
loglevel = "warn"
```
- Ran an EKS test with this TOML file as custom userdata (in merge mode):
```
[settings.kubernetes]
log-level = 3

[settings]
motd = "Custom userdata"
```

Test passed and instance userdata looks like this:
```
[settings]
motd = "Custom userdata"

[settings.kubernetes]
api-server = "https://ECEE40E694F1EA9026E6415225549739.gr7.us-east-1.eks.amazonaws.com"
cluster-certificate = "****************"
cluster-dns-ip = "10.100.0.10"
cluster-name = "eks-test-cluster"
log-level = 3

[settings.updates]
ignore-waves = true
```
- Ran a VMware test with this TOML file as custom userdata (in merge mode):
```
[settings.updates]
ignore-waves = true

[settings]
motd = "Custom userdata"
```

Test passed and userdata looks like this:
```
[settings]
motd = "Custom userdata"
[settings.host-containers.control]
enabled = true
user-data = "eyJzc20iOnsiYWN0aXZhdGlvbi1pZCI6IjY5YmY5YzgzLWEwYTktNDA5My04M2M2LTQxM2FhZTRiNDI1ZiIsImFjdGl2YXRpb24tY29kZSI6IlpyOGJ4ZVA5Q1h6SzJSZ0ZsZXlsIiwicmVnaW9uIjoidXMtd2VzdC0yIn19"

[settings.kubernetes]
api-server = "https://***.**.**.***:****/"
bootstrap-token = "****************"
cluster-certificate = "****************"
cluster-dns-ip = "**.**.*.**"

[settings.updates]
ignore-waves = true
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
