### PR TITLE
TestManager, cli, Agent: Improvements to `status`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
  "http",
  "hyper",
  "ring",
- "time",
+ "time 0.3.15",
  "tokio",
  "tower",
  "tracing",
@@ -404,7 +404,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "ring",
- "time",
+ "time 0.3.15",
  "tracing",
 ]
 
@@ -507,7 +507,7 @@ dependencies = [
  "itoa",
  "num-integer",
  "ryu",
- "time",
+ "time 0.3.15",
 ]
 
 [[package]]
@@ -691,9 +691,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
+ "time 0.1.45",
+ "wasm-bindgen",
  "winapi 0.3.9",
 ]
 
@@ -1161,7 +1164,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1717,7 +1720,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.36.1",
 ]
 
@@ -1729,6 +1732,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bytes",
+ "chrono",
  "futures",
  "http",
  "json-patch",
@@ -2865,6 +2869,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
@@ -3294,6 +3309,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/cli/src/status.rs
+++ b/cli/src/status.rs
@@ -21,6 +21,10 @@ pub(crate) struct Status {
     /// Include the `Test` status, too. Requires `--progress`
     #[clap(long, short = 't', requires("progress"))]
     with_test: bool,
+
+    /// Include the time the CRD was last updated
+    #[clap(long, short = 'u')]
+    with_time: bool,
 }
 
 impl Status {
@@ -34,6 +38,10 @@ impl Status {
             status.with_progress(StatusProgress::WithTests);
         } else if self.progress {
             status.with_progress(StatusProgress::Resources);
+        }
+
+        if self.with_time {
+            status.with_time();
         }
 
         if self.json {

--- a/cli/src/status.rs
+++ b/cli/src/status.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use model::test_manager::TestManager;
+use model::test_manager::{StatusProgress, TestManager};
 use terminal_size::{Height, Width};
 
 /// Check the status of a TestSys object.
@@ -13,14 +13,28 @@ pub(crate) struct Status {
     /// Check the status of the testsys controller
     #[clap(long, short = 'c')]
     controller: bool,
+
+    /// Include the status of resources when reporting status
+    #[clap(long, short = 'p')]
+    progress: bool,
+
+    /// Include the `Test` status, too. Requires `--progress`
+    #[clap(long, short = 't', requires("progress"))]
+    with_test: bool,
 }
 
 impl Status {
     pub(crate) async fn run(self, client: TestManager) -> Result<()> {
-        let status = client
+        let mut status = client
             .status(&Default::default(), self.controller)
             .await
             .context("Unable to get status")?;
+
+        if self.with_test {
+            status.with_progress(StatusProgress::WithTests);
+        } else if self.progress {
+            status.with_progress(StatusProgress::Resources);
+        }
 
         if self.json {
             println!(

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -10,6 +10,7 @@ async-recursion = "1"
 async-trait = "0.1"
 base64 = "0.13"
 bytes = "1.3"
+chrono = { version = "0.4", features = ["clock"]}
 futures = "0.3"
 http = "0.2"
 json-patch = "0.2"

--- a/model/src/clients/resource_client.rs
+++ b/model/src/clients/resource_client.rs
@@ -64,7 +64,10 @@ impl ResourceClient {
         trace!("patching agent info for resource '{}'", name);
         self.patch_status(
             name,
-            vec![JsonPatch::new_add_operation("/status/agentInfo", info)],
+            vec![
+                JsonPatch::new_timestamp(),
+                JsonPatch::new_add_operation("/status/agentInfo", info),
+            ],
             "send agent info",
         )
         .await
@@ -113,6 +116,7 @@ impl ResourceClient {
         self.patch_status(
             name,
             vec![
+                JsonPatch::new_timestamp(),
                 JsonPatch::new_add_operation("/status/creation/taskState", TaskState::Completed),
                 JsonPatch::new_add_operation("/status/createdResource", created_resource),
             ],
@@ -153,6 +157,7 @@ impl ResourceClient {
         self.patch_status(
             name,
             vec![
+                JsonPatch::new_timestamp(),
                 JsonPatch::new_add_operation(error_path, error),
                 JsonPatch::new_add_operation(task_state_path, TaskState::Error),
             ],
@@ -181,7 +186,10 @@ impl ResourceClient {
 
         self.patch_status(
             name,
-            vec![JsonPatch::new_add_operation(path, state)],
+            vec![
+                JsonPatch::new_timestamp(),
+                JsonPatch::new_add_operation(path, state),
+            ],
             "send task state",
         )
         .await

--- a/model/src/clients/test_client.rs
+++ b/model/src/clients/test_client.rs
@@ -52,10 +52,10 @@ impl TestClient {
     pub async fn send_resource_error(&self, test_name: &str, error: &str) -> Result<Test> {
         self.patch_status(
             test_name,
-            vec![JsonPatch::new_add_operation(
-                "/status/controller/resourceError",
-                error,
-            )],
+            vec![
+                JsonPatch::new_timestamp(),
+                JsonPatch::new_add_operation("/status/controller/resourceError", error),
+            ],
             "send resource error",
         )
         .await
@@ -64,10 +64,10 @@ impl TestClient {
     pub async fn send_agent_task_state(&self, name: &str, task_state: TaskState) -> Result<Test> {
         self.patch_status(
             name,
-            vec![JsonPatch::new_add_operation(
-                "/status/agent/taskState",
-                task_state,
-            )],
+            vec![
+                JsonPatch::new_timestamp(),
+                JsonPatch::new_add_operation("/status/agent/taskState", task_state),
+            ],
             "send agent task state",
         )
         .await
@@ -76,10 +76,10 @@ impl TestClient {
     pub async fn send_test_results(&self, name: &str, results: TestResults) -> Result<Test> {
         self.patch_status(
             name,
-            vec![JsonPatch::new_add_operation(
-                "/status/agent/results/-",
-                results,
-            )],
+            vec![
+                JsonPatch::new_timestamp(),
+                JsonPatch::new_add_operation("/status/agent/results/-", results),
+            ],
             "send test results",
         )
         .await
@@ -89,6 +89,7 @@ impl TestClient {
         self.patch_status(
             name,
             vec![
+                JsonPatch::new_timestamp(),
                 JsonPatch::new_add_operation("/status/agent/taskState", TaskState::Completed),
                 JsonPatch::new_add_operation("/status/agent/results/-", results),
             ],
@@ -101,6 +102,7 @@ impl TestClient {
         self.patch_status(
             name,
             vec![
+                JsonPatch::new_timestamp(),
                 JsonPatch::new_add_operation("/status/agent/taskState", TaskState::Error),
                 JsonPatch::new_add_operation("/status/agent/error", error),
             ],

--- a/model/src/resource.rs
+++ b/model/src/resource.rs
@@ -202,6 +202,9 @@ pub struct ResourceStatus {
     /// A description of the resource that has been created by the resource agent.
     #[schemars(schema_with = "config_schema")]
     pub created_resource: Option<Map<String, Value>>,
+
+    /// The time of the last change to this CRD.
+    pub last_update: Option<String>,
 }
 
 impl CrdExt for Resource {

--- a/model/src/test.rs
+++ b/model/src/test.rs
@@ -47,6 +47,8 @@ pub struct TestStatus {
     pub controller: ControllerStatus,
     /// Information written by the test agent.
     pub agent: AgentStatus,
+    /// The time of the last change to this CRD.
+    pub last_update: Option<String>,
 }
 
 /// The `Outcome` of a test run, reported by the test agent.

--- a/model/src/test_manager/mod.rs
+++ b/model/src/test_manager/mod.rs
@@ -61,3 +61,10 @@ pub enum ResourceState {
 }
 
 derive_fromstr_from_deserialize!(ResourceState);
+
+/// `StatusProgress` represents whether a `Test`'s `other_info` should be included or not.
+#[derive(Debug)]
+pub enum StatusProgress {
+    WithTests,
+    Resources,
+}

--- a/model/src/test_manager/status.rs
+++ b/model/src/test_manager/status.rs
@@ -101,10 +101,11 @@ impl StatusSnapshot {
     }
 
     fn progress_column(&self) -> Option<Table> {
+        let mut crds = self.crds.clone();
+        crds.sort_by_key(|crd| crd.name());
         self.with_progress.as_ref().map(|with_progress| {
             // Convert the CRDs to an iterator
-            self.crds
-                .iter()
+            crds.iter()
                 // For each CRD create a `Vec` containing the status for that CRD
                 // It needs to be a `Vec` because each `TestResults` is displayed in it's own
                 // row. `flat_map` will automatically flatten the `Iterator<Vec>` to
@@ -150,10 +151,11 @@ impl StatusSnapshot {
     }
 
     fn time_column(&self) -> Option<Table> {
+        let mut crds = self.crds.clone();
+        crds.sort_by_key(|crd| crd.name());
         self.with_time.then(|| {
             // Convert the CRDs to an iterator
-            self.crds
-                .iter()
+            crds.iter()
                 // For each CRD create a `Vec` containing the status for that CRD
                 // It needs to be a `Vec` because each `TestResults` is displayed in it's own
                 // row. `flat_map` will automatically flatten the `Iterator<Vec>` to

--- a/model/src/test_manager/status.rs
+++ b/model/src/test_manager/status.rs
@@ -164,7 +164,7 @@ impl StatusSnapshot {
                 // Convert the `Option<String>` to `String`
                 .map(Option::unwrap_or_default)
                 .table()
-                .with(MaxWidth::wrapping(50))
+                .with(MinWidth::new(20))
                 .with(Extract::segment(1.., 0..))
                 .with(Header("LAST UPDATE"))
         })


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to #679 
Closes #658 

**Description of changes:**

```
commit 75e173d2fa131244823cb337731cd2142a4f136d (HEAD -> testsys-status, origin/testsys-status)
Author: ecpullen <ecpullen@aol.com>
Date:   Mon Dec 5 18:41:17 2022 +0000

    TestManager: Don't truncate `Last Update`
    
    This sets the `MinWidth` for the `LAST UPDATE` column to 20 chars (the
    exact number required).

commit 318c88c5ccdb3430ead02e1295e087acff08b3e4
Author: ecpullen <ecpullen@aol.com>
Date:   Mon Dec 5 18:28:28 2022 +0000

    TestManager: Fix some columns out of order
    
    When `with_progress` and `with_time` were added, the order of crds was
    allowed to change. This caused the columns to be out of order. The crds
    are now resorted in each function.

commit cc26f55cb4a7a213054cf6f74776823648edb614
Author: ecpullen <ecpullen@aol.com>
Date:   Mon Dec 5 17:59:02 2022 +0000

    Controller, Agent: Report the last time of update
    
    Adds a new field to both `Test` and `Resource` status.
    All json patches now add `new_timestamp()` which adds the `SystemTime`
    to the `status/lastUpdate`.

commit ae036a83496dff45b02e97de419912a36775b2b5
Author: ecpullen <ecpullen@aol.com>
Date:   Fri Dec 2 18:26:44 2022 +0000

    TestManager: Additional column duplication
    
    This fixes a bug where a test with retries would cause additional column
    to not be aligned because the values were not duplicated for each result
    row.

commit d50efaac1d70f5802929553e2fdaee1b2a4225e7
Author: ecpullen <ecpullen@aol.com>
Date:   Fri Dec 2 18:07:39 2022 +0000

    TestManager: Add optional `STATUS` column
    
    A new optonal status column was added that displays the `currentStatus`
    of a resource or optionally the `other_info` of a test.
    `StatusProgress::Resources` will only show the status of resources while
    `StatusProgress::WithTests` will also include test status.
```

**Testing done:**

Tested with `cargo make test`

Initial status
```bash
$ cli status -pu
 NAME                                TYPE       STATE     PASSED   SKIPPED   FAILED  STATUS            LAST UPDATE           
 x86-64-aws-k8s-123                  Resource   unknown                                                 2022-12-05T18:47:44Z 
 x86-64-aws-k8s-123-instances-quic   Resource   unknown                                                 2022-12-05T18:47:44Z 
 x86-64-aws-k8s-123-test             Test       waiting                               No test results   2022-12-05T18:47:44Z 
```

After cluster creation
```bash
$ cli status -pu
 NAME                                TYPE      STATE      PASSE   SKIPPE   FAILE  STATUS               LAST UPDATE           
 x86-64-aws-k8s-123                  Resourc   complete                            Cluster ready        2022-12-05T18:47:47Z 
 x86-64-aws-k8s-123-instances-quic   Resourc   complete                            Instance(s) Create   2022-12-05T18:47:55Z 
 x86-64-aws-k8s-123-test             Test      running                             No test results      2022-12-05T18:48:00Z 
```

After testing is complete
```bash
$ cli status -pu
 NAME                                TYPE      STATE      PASSE   SKIPPE   FAILED  STATUS              LAST UPDATE           
 x86-64-aws-k8s-123                  Resourc   complete                             Cluster ready       2022-12-05T18:47:47Z 
 x86-64-aws-k8s-123-instances-quic   Resourc   running                              Instances deleted   2022-12-05T18:48:47Z 
 x86-64-aws-k8s-123-test             Test      passed     1       7051     0                            2022-12-05T18:48:36Z 
```

`with-tests`
```bash
$ cli status -put
 NAME                            TYP   STATE   PA   SKI   FA  STATUS                                       LAST UPDATE       
 x86-64-aws-k8s-123              Res   compl                   Cluster ready                                2022-12-05T18:47 
 x86-64-aws-k8s-123-instances-   Res   runni                   Instances deleted                            2022-12-05T18:48 
 x86-64-aws-k8s-123-test         Tes   passe   1    705   0    {"name":"e2e","node":"global","timestamp":   2022-12-05T18:48 
```

Without any flags (unchanged by this pr)
```
NAME                               TYPE               STATE               PASSED           SKIPPED           FAILED         
 x86-64-aws-k8s-123                 Resource           completed                                                             
 x86-64-aws-k8s-123-test            Test               passed              1                7051              0              
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
