### PR TITLE
Agents: Allow continuous updates by test agents

### DIFF
--- a/agent/test-agent/examples/example_test_agent/main.rs
+++ b/agent/test-agent/examples/example_test_agent/main.rs
@@ -28,11 +28,10 @@ spec:
 
 !*/
 
-use async_trait::async_trait;
 use model::{Outcome, TestResults};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use test_agent::{BootstrapData, Configuration, Spec};
+use test_agent::{BootstrapData, Configuration, InfoClient, Spec};
 use tokio::time::{sleep, Duration};
 
 struct ExampleTestRunner {
@@ -57,34 +56,54 @@ struct Nested {
 
 impl Configuration for ExampleConfig {}
 
-#[async_trait]
-impl test_agent::Runner for ExampleTestRunner {
+#[async_trait::async_trait]
+impl<I> test_agent::Runner<I> for ExampleTestRunner
+where
+    I: InfoClient,
+{
     type C = ExampleConfig;
     type E = String;
 
-    async fn new(spec: Spec<Self::C>) -> Result<Self, Self::E> {
+    async fn new(spec: Spec<Self::C>, _info_client: &I) -> Result<Self, Self::E> {
         println!("Initializing example testsys agent...");
         Ok(Self {
             config: spec.configuration,
         })
     }
 
-    async fn run(&mut self) -> Result<TestResults, Self::E> {
+    async fn run(&mut self, info_client: &I) -> Result<TestResults, Self::E> {
         println!("ExampleTestRunner::run");
+        let mut results = TestResults {
+            outcome: Outcome::InProgress,
+            num_passed: 0,
+            num_failed: 0,
+            num_skipped: 0,
+            other_info: Some("Running Test".to_string()),
+        };
+
+        info_client
+            .send_test_update(results.clone())
+            .await
+            .map_err(|e| format!("{:?}", e))?;
+
         for i in 1..=self.config.hello_count {
             println!("hello #{} to {}", i, self.config.person);
             sleep(Duration::from_millis(
                 self.config.hello_duration_milliseconds.into(),
             ))
-            .await
+            .await;
+            results.num_passed += 1;
+            info_client
+                .send_test_update(results.clone())
+                .await
+                .map_err(|e| format!("{:?}", e))?;
         }
         if let Some(nested) = &self.config.nested {
             println!("Nested Data:\n {:?}", nested.data);
         }
-        Ok(TestResults {
-            outcome: Outcome::Pass,
-            ..TestResults::default()
-        })
+        results.outcome = Outcome::Pass;
+        results.other_info = Some("All Tests Passed".to_string());
+        Ok(results)
     }
 
     async fn terminate(&mut self) -> Result<(), Self::E> {
@@ -95,11 +114,12 @@ impl test_agent::Runner for ExampleTestRunner {
 
 #[tokio::main]
 async fn main() {
-    let mut agent_main =
-        test_agent::TestAgent::<test_agent::DefaultClient, ExampleTestRunner>::new(
-            BootstrapData::from_env().unwrap(),
-        )
-        .await
-        .unwrap();
+    let mut agent_main = test_agent::TestAgent::<
+        test_agent::DefaultClient,
+        ExampleTestRunner,
+        test_agent::DefaultInfoClient,
+    >::new(BootstrapData::from_env().unwrap())
+    .await
+    .unwrap();
     agent_main.run().await.unwrap();
 }

--- a/agent/test-agent/src/bootstrap.rs
+++ b/agent/test-agent/src/bootstrap.rs
@@ -8,6 +8,7 @@ container environment to construct the [`Agent`] and all of its parts.
 use model::constants::ENV_TEST_NAME;
 use snafu::{ResultExt, Snafu};
 
+#[derive(Clone)]
 /// Data that is read from the TestPod's container environment and filesystem.
 pub struct BootstrapData {
     /// The name of the TestSys Test.

--- a/agent/test-agent/src/error.rs
+++ b/agent/test-agent/src/error.rs
@@ -60,6 +60,9 @@ pub(crate) enum InnerError {
 
     #[snafu(display("An error occured while creating archive: {}", source))]
     Archive { source: std::io::Error },
+
+    #[snafu(display("Info Client: {}", source))]
+    InfoClient { source: InfoClientError },
 }
 
 impl<C, R> From<InnerError> for Error<C, R>
@@ -71,3 +74,25 @@ where
         Error::Agent(e.into())
     }
 }
+
+pub type InfoClientResult<T> = std::result::Result<T, InfoClientError>;
+
+#[derive(Debug)]
+pub enum InfoClientError {
+    /// The client could not be created.
+    InitializationFailed(Option<Box<dyn std::error::Error + Send + Sync + 'static>>),
+
+    /// A communication with Kubernetes failed.
+    RequestFailed(Option<Box<dyn std::error::Error + Send + Sync + 'static>>),
+}
+
+impl Display for InfoClientError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InitializationFailed(e) => write!(f, "initialization failed: {:?}", e),
+            Self::RequestFailed(e) => write!(f, "request failed: {:?}", e),
+        }
+    }
+}
+
+impl std::error::Error for InfoClientError {}

--- a/model/src/clients/test_client.rs
+++ b/model/src/clients/test_client.rs
@@ -78,9 +78,22 @@ impl TestClient {
             name,
             vec![
                 JsonPatch::new_timestamp(),
+                JsonPatch::new_remove_operation("/status/agent/currentTest"),
                 JsonPatch::new_add_operation("/status/agent/results/-", results),
             ],
             "send test results",
+        )
+        .await
+    }
+
+    pub async fn send_test_update(&self, name: &str, results: TestResults) -> Result<Test> {
+        self.patch_status(
+            name,
+            vec![
+                JsonPatch::new_timestamp(),
+                JsonPatch::new_add_operation("/status/agent/currentTest".to_string(), results),
+            ],
+            "update test results",
         )
         .await
     }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related #679 

**Description of changes:**

Adds a new client, `InfoClient` that allows a test to update `status.current_test`, a new field in the test's status. `current_test` represents the results for the current test that is being run and is given its own row in status reporting.

**Testing done:**

Tested with the `example-resource-agent` and saw the status change for each iteration of the loop and `LAST UPDATE` is updated every 3 seconds (the `hello_duration` in my yaml file).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
