### PR TITLE
sonobuoy: Fix regression while retrieving progress

### DIFF
--- a/bottlerocket/agents/src/sonobuoy.rs
+++ b/bottlerocket/agents/src/sonobuoy.rs
@@ -186,9 +186,8 @@ pub(crate) fn process_sonobuoy_test_results(
         let progress_status = result
             .get("progress")
             .unwrap_or(&default_progress)
-            .as_str()
-            // Unwrap is safe here because we know from above it will at least have an empty string
-            .unwrap();
+            .to_string();
+
         if !progress_status.is_empty() {
             progress.push(format!("{}: {}", plugin, progress_status));
         }


### PR DESCRIPTION
A bug occured that would cause the sonobuoy test agent to fail when using e2e due to the progress field being an object instead of a string.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

```
Author: ecpullen <ecpullen@aol.com>
Date:   Thu Dec 8 15:54:18 2022 +0000

    sonobuoy: Fix regression while retrieving progress
    
    A bug occured that would cause the sonobuoy test agent to fail when
    using e2e due to the progress field being an object instead of a string.
```

**Testing done:**

The sonobuoy test agent now works successfully.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
