### PR TITLE
sonobuoy: Remove `--wait` from `sonobuoy run`

### DIFF
--- a/bottlerocket/agents/src/error.rs
+++ b/bottlerocket/agents/src/error.rs
@@ -154,6 +154,15 @@ pub enum Error {
     #[snafu(display("No task running tasks in cluster"))]
     NoTask,
 
+    #[snafu(display(
+        "Sonobuoy status could not be retrieved within the given time: {}",
+        source
+    ))]
+    SonobuoyTimeout { source: tokio::time::error::Elapsed },
+
+    #[snafu(display("Failed to retrieve sonobuoy status after '{}' retries", retries))]
+    SonobuoyStatus { retries: i32 },
+
     #[snafu(display("The task did not complete in time"))]
     TaskTimeout,
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to #679 

**Description of changes:**

Removes the `--wait` flag from sonobuoy run calls and introduces a new function to check the status of sonobuoy every 30 s. This will be used with #690 to provide live status updates for sonobuoy testing.

**Testing done:**

Used `cargo make test` with updated sonobuoy image.

<details>
<summary>Full logs:</summary>
[2022-12-12T14:28:30Z INFO  sonobuoy_test_agent] Initializing Sonobuoy test agent...

[2022-12-12T14:28:30Z INFO  sonobuoy_test_agent] Stored kubeconfig in /local/test-cluster.kubeconfig

[2022-12-12T14:28:30Z INFO  bottlerocket_agents::sonobuoy] Running sonobuoy

time="2022-12-12T14:28:30Z" level=info msg="create request issued" name=sonobuoy namespace= resource=namespaces

time="2022-12-12T14:28:30Z" level=info msg="create request issued" name=sonobuoy-serviceaccount namespace=sonobuoy resource=serviceaccounts

time="2022-12-12T14:28:30Z" level=info msg="create request issued" name=sonobuoy-serviceaccount-sonobuoy namespace= resource=clusterrolebindings

time="2022-12-12T14:28:30Z" level=info msg="create request issued" name=sonobuoy-serviceaccount-sonobuoy namespace= resource=clusterroles

time="2022-12-12T14:28:30Z" level=info msg="create request issued" name=sonobuoy-config-cm namespace=sonobuoy resource=configmaps

time="2022-12-12T14:28:30Z" level=info msg="create request issued" name=sonobuoy-plugins-cm namespace=sonobuoy resource=configmaps

time="2022-12-12T14:28:30Z" level=info msg="create request issued" name=sonobuoy namespace=sonobuoy resource=pods

time="2022-12-12T14:28:30Z" level=info msg="create request issued" name=sonobuoy-aggregator namespace=sonobuoy resource=services

[2022-12-12T14:28:30Z INFO  bottlerocket_agents::sonobuoy] Sonobuoy testing has started, waiting for status to be available

[2022-12-12T14:28:30Z INFO  bottlerocket_agents::sonobuoy] Parsing the following sonobuoy results output:

    The Sonobuoy aggregator is in the 'Pending' state. This is normal as the pod is created and begins to run, but if this state persists, use kubectl to debug further.

    

[2022-12-12T14:28:30Z INFO  bottlerocket_agents::sonobuoy] Sonobuoy status is not ready, retrying in 30s

[2022-12-12T14:29:00Z INFO  bottlerocket_agents::sonobuoy] Parsing the following sonobuoy results output:

    {"plugins":[{"plugin":"e2e","node":"global","status":"complete","result-status":"passed","result-counts":{"passed":1,"skipped":7051},"progress":{"name":"e2e","node":"global","timestamp":"2022-12-12T14:28:37.885340463Z","msg":"Test Suite completed","total":1,"completed":1}}],"status":"complete","tar-info":{"name":"202212121428_sonobuoy_ab368416-e97b-42cd-91bf-d9781bf22317.tar.gz","created":"2022-12-12T14:28:48.84972719Z","sha256":"c50447c9deca85e7821a024428140f8a61a7916c4116f88a1c4ad1448e9a8543","size":315757}}

    

[2022-12-12T14:29:00Z INFO  bottlerocket_agents::sonobuoy] Sonobuoy status is available, waiting for test to complete

[2022-12-12T14:29:00Z INFO  bottlerocket_agents::sonobuoy] Parsing the following sonobuoy results output:

    {"plugins":[{"plugin":"e2e","node":"global","status":"complete","result-status":"passed","result-counts":{"passed":1,"skipped":7051},"progress":{"name":"e2e","node":"global","timestamp":"2022-12-12T14:28:37.885340463Z","msg":"Test Suite completed","total":1,"completed":1}}],"status":"complete","tar-info":{"name":"202212121428_sonobuoy_ab368416-e97b-42cd-91bf-d9781bf22317.tar.gz","created":"2022-12-12T14:28:48.84972719Z","sha256":"c50447c9deca85e7821a024428140f8a61a7916c4116f88a1c4ad1448e9a8543","size":315757}}

    

[2022-12-12T14:29:00Z INFO  bottlerocket_agents::sonobuoy] Sonobuoy testing has completed, checking results

[2022-12-12T14:29:00Z INFO  bottlerocket_agents::sonobuoy] Running sonobuoy retrieve

tmp/.tmpbHVbpk/sonobuoy-results.tar.gz

[2022-12-12T14:29:00Z INFO  bottlerocket_agents::sonobuoy] Sonobuoy testing has completed, printing results

Plugin: e2e

Status: passed

Total: 7052

Passed: 1

Failed: 0

Skipped: 7051



Run Details:

API Server version: v1.23.13-eks-fb459a0

Node health: 2/2 (100%)

Pods health: 7/9 (77%)

Details for failed pods:

kube-system/aws-node-z89cz Ready:False: ContainersNotInitialized: containers with incomplete status: [aws-vpc-cni-init]

kube-system/kube-proxy-hhx77 Ready:False: ContainersNotReady: containers with unready status: [kube-proxy]

Errors detected in files:

Errors:

1 podlogs/sonobuoy/sonobuoy/logs/kube-sonobuoy.txt

Warnings:

2 podlogs/sonobuoy/sonobuoy/logs/kube-sonobuoy.txt

[2022-12-12T14:29:01Z INFO  bottlerocket_agents::sonobuoy] Getting Sonobuoy status

[2022-12-12T14:29:01Z INFO  bottlerocket_agents::sonobuoy] Parsing the following sonobuoy results output:

    {"plugins":[{"plugin":"e2e","node":"global","status":"complete","result-status":"passed","result-counts":{"passed":1,"skipped":7051},"progress":{"name":"e2e","node":"global","timestamp":"2022-12-12T14:28:37.885340463Z","msg":"Test Suite completed","total":1,"completed":1}}],"status":"complete","tar-info":{"name":"202212121428_sonobuoy_ab368416-e97b-42cd-91bf-d9781bf22317.tar.gz","created":"2022-12-12T14:28:48.84972719Z","sha256":"c50447c9deca85e7821a024428140f8a61a7916c4116f88a1c4ad1448e9a8543","size":315757}}

    

[2022-12-12T14:29:01Z INFO  bottlerocket_agents::sonobuoy] Deleting sonobuoy resources from cluster

time="2022-12-12T14:29:01Z" level=info msg="delete request issued" kind=namespace namespace=sonobuoy

time="2022-12-12T14:29:01Z" level=info msg="delete request issued" kind=clusterrolebindings

time="2022-12-12T14:29:01Z" level=info msg="delete request issued" kind=clusterroles



Namespace "sonobuoy" has status {Phase:Terminating Conditions:[]}



Namespace "sonobuoy" has status {Phase:Terminating Conditions:[{Type:NamespaceDeletionDiscoveryFailure Status:False LastTransitionTime:2022-12-12 14:29:06 +0000 UTC Reason:ResourcesDiscovered Message:All resources successfully discovered} {Type:NamespaceDeletionGroupVersionParsingFailure Status:False LastTransitionTime:2022-12-12 14:29:06 +0000 UTC Reason:ParsedGroupVersions Message:All legacy kube types successfully parsed} {Type:NamespaceDeletionContentFailure Status:False LastTransitionTime:2022-12-12 14:29:06 +0000 UTC Reason:ContentDeleted Message:All content successfully deleted, may be waiting on finalization} {Type:NamespaceContentRemaining Status:True LastTransitionTime:2022-12-12 14:29:06 +0000 UTC Reason:SomeResourcesRemain Message:Some resources are remaining: pods. has 1 resource instances} {Type:NamespaceFinalizersRemaining Status:False LastTransitionTime:2022-12-12 14:29:06 +0000 UTC Reason:ContentHasNoFinalizers Message:All content-preserving finalizers finished}]}



Namespace "sonobuoy" has been deleted



Deleted all ClusterRoles and ClusterRoleBindings.



All E2E namespaces deleted

[2022-12-12T14:29:16Z INFO  test_agent::agent] Test execution finished without returning an error.

[2022-12-12T14:29:16Z INFO  test_agent::agent] Test output tarball created.

[2022-12-12T14:29:16Z INFO  test_agent::agent] 'keep_running' is true.
</details>

<details>
<summary>Relevant logs:</summary>
[2022-12-12T14:28:30Z INFO  bottlerocket_agents::sonobuoy] Sonobuoy status is not ready, retrying in 30s

[2022-12-12T14:29:00Z INFO  bottlerocket_agents::sonobuoy] Parsing the following sonobuoy results output:

    {"plugins":[{"plugin":"e2e","node":"global","status":"complete","result-status":"passed","result-counts":{"passed":1,"skipped":7051},"progress":{"name":"e2e","node":"global","timestamp":"2022-12-12T14:28:37.885340463Z","msg":"Test Suite completed","total":1,"completed":1}}],"status":"complete","tar-info":{"name":"202212121428_sonobuoy_ab368416-e97b-42cd-91bf-d9781bf22317.tar.gz","created":"2022-12-12T14:28:48.84972719Z","sha256":"c50447c9deca85e7821a024428140f8a61a7916c4116f88a1c4ad1448e9a8543","size":315757}}

    

[2022-12-12T14:29:00Z INFO  bottlerocket_agents::sonobuoy] Sonobuoy status is available, waiting for test to complete

[2022-12-12T14:29:00Z INFO  bottlerocket_agents::sonobuoy] Parsing the following sonobuoy results output:

    {"plugins":[{"plugin":"e2e","node":"global","status":"complete","result-status":"passed","result-counts":{"passed":1,"skipped":7051},"progress":{"name":"e2e","node":"global","timestamp":"2022-12-12T14:28:37.885340463Z","msg":"Test Suite completed","total":1,"completed":1}}],"status":"complete","tar-info":{"name":"202212121428_sonobuoy_ab368416-e97b-42cd-91bf-d9781bf22317.tar.gz","created":"2022-12-12T14:28:48.84972719Z","sha256":"c50447c9deca85e7821a024428140f8a61a7916c4116f88a1c4ad1448e9a8543","size":315757}}

    

[2022-12-12T14:29:00Z INFO  bottlerocket_agents::sonobuoy] Sonobuoy testing has completed, checking results
</details>
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
