### PR TITLE
cli: Improve status filtering

### DIFF
--- a/model/src/test_manager/manager.rs
+++ b/model/src/test_manager/manager.rs
@@ -1,11 +1,11 @@
 use super::{
-    error, DeleteEvent, DockerConfigJson, ImageConfig, ResourceState, Result, SelectionParams,
-    StatusSnapshot,
+    error, CrdState, CrdType, DeleteEvent, DockerConfigJson, ImageConfig, ResourceState, Result,
+    SelectionParams, StatusSnapshot,
 };
 use crate::clients::{CrdClient, ResourceClient, TestClient};
 use crate::constants::{LABEL_COMPONENT, TESTSYS_RESULTS_FILE};
 use crate::system::AgentType;
-use crate::{Crd, CrdName, SecretName};
+use crate::{Crd, CrdName, Resource, SecretName, TaskState, Test, TestUserState};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use k8s_openapi::api::core::v1::{Pod, Secret};
@@ -186,68 +186,44 @@ impl TestManager {
 
     /// List all testsys objects following `SelectionParams`
     pub async fn list(&self, selection_params: &SelectionParams) -> Result<Vec<Crd>> {
-        Ok(match selection_params {
-            SelectionParams::All => {
-                let mut objects = Vec::new();
-                let list_params = Default::default();
-                let tests = self.test_client().api().list(&list_params).await.context(
-                    error::KubeSnafu {
-                        action: "list tests from label params",
-                    },
-                )?;
-                objects.extend(tests.into_iter().map(Crd::Test));
-                let resources = self
-                    .resource_client()
+        let mut list_params = ListParams::default();
+        if let Some(labels) = &selection_params.labels {
+            list_params = list_params.labels(labels)
+        }
+        if let Some(name) = &selection_params.name {
+            list_params = list_params.fields(&format!("metadata.name=={}", name));
+        }
+        let mut objects = Vec::new();
+        if matches!(selection_params.crd_type, Some(CrdType::Test) | None) {
+            objects.extend(
+                self.test_client()
                     .api()
                     .list(&list_params)
                     .await
                     .context(error::KubeSnafu {
-                        action: "list resources from label params",
-                    })?;
-                objects.extend(resources.into_iter().map(Crd::Resource));
-                objects
-            }
-            SelectionParams::Label(label) => {
-                let mut objects = Vec::new();
-                let list_params = ListParams {
-                    label_selector: Some(label.to_string()),
-                    ..Default::default()
-                };
-                let tests = self.test_client().api().list(&list_params).await.context(
-                    error::KubeSnafu {
                         action: "list tests from label params",
-                    },
-                )?;
-                objects.extend(tests.into_iter().map(Crd::Test));
-                let resources = self
-                    .resource_client()
+                    })?
+                    .into_iter()
+                    .filter(|test| filter_test_by_state(test, &selection_params.state))
+                    .map(Crd::Test),
+            );
+        }
+        if matches!(selection_params.crd_type, Some(CrdType::Resource) | None) {
+            objects.extend(
+                self.resource_client()
                     .api()
                     .list(&list_params)
                     .await
                     .context(error::KubeSnafu {
-                        action: "list resources from label params",
-                    })?;
-                objects.extend(resources.into_iter().map(Crd::Resource));
-                objects
-            }
-            SelectionParams::Name(CrdName::Test(test_name)) => {
-                vec![Crd::Test(
-                    self.test_client()
-                        .get(test_name)
-                        .await
-                        .context(error::ClientSnafu { action: "get test" })?,
-                )]
-            }
-            SelectionParams::Name(CrdName::Resource(resource_name)) => {
-                vec![Crd::Resource(
-                    self.resource_client().get(resource_name).await.context(
-                        error::ClientSnafu {
-                            action: "get resource",
-                        },
-                    )?,
-                )]
-            }
-        })
+                        action: "list tests from label params",
+                    })?
+                    .into_iter()
+                    .filter(|resource| filter_resource_by_state(resource, &selection_params.state))
+                    .map(Crd::Resource),
+            );
+        }
+
+        Ok(objects)
     }
 
     /// Delete all testsys `Test`s and `Resource`s from a cluster.
@@ -466,4 +442,66 @@ pub fn read_manifest(path: &Path) -> Result<Vec<Crd>> {
         crds.push(crd);
     }
     Ok(crds)
+}
+
+fn filter_test_by_state(test: &Test, state: &Option<CrdState>) -> bool {
+    if let Some(state) = state {
+        match state {
+            CrdState::Running => {
+                matches!(test.test_user_state(), TestUserState::Running)
+            }
+            CrdState::Completed => matches!(
+                test.test_user_state(),
+                TestUserState::NoTests
+                    | TestUserState::Passed
+                    | TestUserState::Failed
+                    | TestUserState::Error
+                    | TestUserState::ResourceError
+            ),
+            CrdState::Passed => {
+                matches!(test.test_user_state(), TestUserState::Passed)
+            }
+            CrdState::Failed => {
+                matches!(
+                    test.test_user_state(),
+                    TestUserState::Failed | TestUserState::Error | TestUserState::ResourceError
+                )
+            }
+            CrdState::NotFinished => matches!(
+                test.test_user_state(),
+                TestUserState::Running | TestUserState::Waiting | TestUserState::Unknown
+            ),
+        }
+    } else {
+        true
+    }
+}
+
+fn filter_resource_by_state(resource: &Resource, state: &Option<CrdState>) -> bool {
+    if let Some(state) = state {
+        match state {
+            CrdState::Running => {
+                matches!(resource.creation_task_state(), TaskState::Running)
+                    || matches!(resource.destruction_task_state(), TaskState::Running)
+            }
+            CrdState::Completed => {
+                matches!(
+                    resource.creation_task_state(),
+                    TaskState::Completed | TaskState::Error
+                ) && !matches!(resource.destruction_task_state(), TaskState::Running)
+            }
+            CrdState::NotFinished => {
+                matches!(
+                    resource.creation_task_state(),
+                    TaskState::Running | TaskState::Unknown
+                ) || matches!(
+                    resource.creation_task_state(),
+                    TaskState::Running | TaskState::Unknown
+                )
+            }
+            _ => false,
+        }
+    } else {
+        true
+    }
 }

--- a/model/src/test_manager/mod.rs
+++ b/model/src/test_manager/mod.rs
@@ -1,4 +1,3 @@
-use crate::CrdName;
 pub use delete::DeleteEvent;
 pub use error::{Error, Result};
 pub use manager::{read_manifest, TestManager};
@@ -14,19 +13,44 @@ mod manager;
 mod manager_impl;
 mod status;
 
-/// `SelectionParams` are used to select a group (or single) object from a testsys cluster.
-pub enum SelectionParams {
-    // TODO add field selectors (Think kube-rs `ListParams`)
-    Label(String),
-    Name(CrdName),
-    All,
+#[derive(Default, Debug, Clone)]
+/// `SelectionParams` are used to select a group (or single) object from a testsys cluster. For any
+/// of the filters, None is equivalent to all.
+pub struct SelectionParams {
+    /// Filter based on the type of the CRD
+    pub crd_type: Option<CrdType>,
+    /// Filter based on the crd labels
+    pub labels: Option<String>,
+    /// Filter based on the name of the CRD
+    pub name: Option<String>,
+    /// Filter based on the state of the CRD
+    pub state: Option<CrdState>,
 }
 
-impl Default for SelectionParams {
-    fn default() -> Self {
-        Self::All
-    }
+#[derive(Debug, Clone)]
+/// Filter based on the type of the CRD
+pub enum CrdType {
+    Test,
+    Resource,
 }
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+/// Filter based on the state of the CRD
+pub enum CrdState {
+    /// All `Test`s and `Resource`s that are not finished.
+    NotFinished,
+    /// All `Test`s and `Resource`s that are currently running.
+    Running,
+    /// All `Test`s and `Resource`s that are finished.
+    Completed,
+    /// All `Test`s that passed.
+    Passed,
+    /// All `Test`s that failed.
+    Failed,
+}
+
+derive_fromstr_from_deserialize!(CrdState);
 
 #[derive(Serialize)]
 pub(crate) struct DockerConfigJson {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

#656 

**Description of changes:**

Even though most of this change could be accomplished with `grep`, the improvement to `SelectionParams` will give users a much better control of deletion (in future pr).

    cli: Improve status filtering
    
    Convert `SelectionParams` from an enum to a struct.
    Add filtering based on the state of the objects.
    - Running
    - Completed
    - Passed
    - Failed
    - NotFinished
    
    Add filtering based on the crd type.
    - Tests
    - Resource
    
    Add new filtering to `cli status`
    - '-t' Only show tests
    - '-r' Only show resources
    - '--labels foo=bar' Filter based on labels in the CRD
    - '--name' Only show tests/resources with the specified name
    - '--state' Filter tests/resources by the given state

```bash
$ cli status -h
Get the status of testsys objects

Usage: cli status [OPTIONS]

Options:
      --json             Output the results in JSON format
  -c, --controller       Check the status of the testsys controller
  -p, --progress         Include the status of resources when reporting status
      --with-test        Include the `Test` status, too. Requires `--progress`
  -u, --with-time        Include the time the CRD was last updated
  -t, --tests            Include `Test`s (if passed with `--resources`, `Test`s and `Resource`s will be shown)
  -r, --resources        Include `Resource`s (if passed with `--tests`, `Test`s and `Resource`s will be shown)
      --labels <LABELS>  Only include objects with the specified labels ("foo=bar,biz=baz")
      --state <STATE>    Only include objects with the specified state ("completed", "running", "not-finished", "passed", "failed")
      --name <NAME>      Only include objects with the specified name
  -h, --help             Print help information
```

**Testing done:**

Tested various combinations of cli invocations and ensured that the status reported represented the cli query.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
