### PR TITLE
Add NVIDIA workload test definition

### DIFF
--- a/bottlerocket/tests/workload/README.md
+++ b/bottlerocket/tests/workload/README.md
@@ -1,0 +1,78 @@
+# TestSys Workload Tests
+
+This directory contains the source files and artifacts for running TestSys workloads.
+
+## Workload Tests
+
+New workload tests should be added under this subdirectory.
+The current list of tests are detailed below.
+
+**NVIDIA smoketests**
+
+This workload tests executes various CUDA samples to verify GPU functionality for Bottlerocket hosts running on NVIDIA instances.
+See [nvidia-smoke.yaml](nvidia-smoke.yaml) for an example configuration.
+
+---
+
+## Workload Test Requirements
+
+Workload tests are container images that execute one or more application workloads.
+
+The expectation of test authors is to provide a container image with the following:
+
+* Provide a script or binary that will run in a container as part of a Kubernetes pod or ECS task
+* Provide a `./run.sh` entry point for the test container, optional arguments may be defined through environment variables
+* The shell script may be used directly to perform the test, or be a wrapper to allow executing other binaries or scripts
+* Use the `$RESULTS_DIR` environment variable to determine where to place output
+* At end of execution, collect test output into a results file `results.tar.gz` placed in `$RESULTS_DIR` with all relevant output
+* Write the `${RESULTS_DIR}/results.tar.gz` full path name to a `${RESULTS_DIR}/done` file
+* Container exit code determines pass/fail - 0 is considered successful completion
+
+These requirements will make the container compliant as a Sonobuoy plugin when run on Kubernetes.
+
+### Examples
+
+To help illustrate, the following could be used as the `run.sh` entry point script:
+
+```bash
+#!/bin/env bash
+
+results_dir="${RESULTS_DIR:-/tmp/results}"
+mkdir -p "${results_dir}"
+
+# Example of optional argument passed as environment variable to the container
+name="${NAME:-spam}"
+
+saveResults() {
+     cd "${results_dir}"
+     tar czf results.tar.gz *
+     echo "${results_dir}/results.tar.gz" > "${results_dir}/done"
+}
+
+# Make sure to always capture results in expected place and format
+trap saveResults EXIT
+
+# Run whatever you intest to test using this container
+/bin/tests/benchmark --name "${name}" >> "${results_dir}/${test_name}-results" 2>&1
+```
+
+The container image would then be defined with this script as its `ENTRYPOINT` and could be run by TestSys using something like:
+
+```yaml
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: spam-workload
+  namespace: testsys
+spec:
+  agent:
+    configuration:
+      kubeconfigBase64: <Base64 encoded kubeconfig for the test cluster workload runs the tests in>
+      plugins:
+      - name: spam-workload
+        image: example/benchmark:v0.0.3
+    image: <your k8s-workload-agent image URI>
+    name: workload-test-agent
+    keepRunning: true
+  resources: {}
+```

--- a/bottlerocket/tests/workload/nvidia-smoke.yaml
+++ b/bottlerocket/tests/workload/nvidia-smoke.yaml
@@ -1,0 +1,16 @@
+kind: Test
+metadata:
+  name: workload-agent
+  namespace: testsys
+spec:
+  agent:
+    name: workload-agent
+    image: <WORKLOAD-AGENT-IMAGE>
+    keepRunning: false
+    configuration:
+      kubeconfigBase64: <BASE64-KUBECONFIG>
+      plugins:
+        - name: nvidia-workload
+          image: <NVIDIA-WORKLOAD-IMAGE>
+  resources: []
+  dependsOn: []

--- a/bottlerocket/tests/workload/nvidia-smoke/Dockerfile
+++ b/bottlerocket/tests/workload/nvidia-smoke/Dockerfile
@@ -1,0 +1,39 @@
+# Builder for the CUDA Sample binaries. The image we run to perform the tests
+# doesn't need everything that is included in the "devel" image. So we build with
+# the larger image, then copy them to the lightweight image we use to run.
+FROM nvidia/cuda:11.4.3-devel-ubi8 as builder
+
+# Make sure we have git to clone the sample repo
+RUN dnf makecache \
+  && dnf -y install git-core \
+  && dnf clean all \
+  && rm -fr /var/cache/dnf
+
+# Clone the samples, pinned to a version we know should work
+RUN git clone --branch v11.6 --depth 1 https://github.com/NVIDIA/cuda-samples.git
+RUN mkdir -p /samples
+
+# There is a Makefile in the 'cuda-samples' project, but it will
+# try to build all the samples, so we build the ones we want. There is
+# a 'FILTER_OUT' variable that can be set, but as the name suggests
+# it filters out what samples won't be build.
+# This only includes the samples that should run on both amd64 and arm64.
+RUN cd /cuda-samples/Samples/0_Introduction/vectorAdd/ && make && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/0_Introduction/simpleVoteIntrinsics/ && make && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/0_Introduction/simpleAtomicIntrinsics/ && make && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/0_Introduction/simpleAWBarrier/ && make && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/1_Utilities/deviceQuery/ && make && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/2_Concepts_and_Techniques/reductionMultiBlockCG/ && make && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/2_Concepts_and_Techniques/shfl_scan/ && make && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/3_CUDA_Features/immaTensorCoreGemm/ && make && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/3_CUDA_Features/warpAggregatedAtomicsCG/ && make && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/3_CUDA_Features/globalToShmemAsyncCopy/ && make && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/6_Performance/UnifiedMemoryPerf/ && make && cp $(basename $(pwd)) /samples/
+
+# We only need the base image to run the tests. It contains the necessary
+# drivers and runtime environment we need.
+FROM nvidia/cuda:11.4.3-base-ubi8
+COPY ./run.sh /
+COPY --from=builder /samples/* /samples/
+RUN chmod +x ./run.sh
+ENTRYPOINT ["sh", "-c", "/run.sh"]

--- a/bottlerocket/tests/workload/nvidia-smoke/Makefile
+++ b/bottlerocket/tests/workload/nvidia-smoke/Makefile
@@ -1,0 +1,28 @@
+.DEFAULT_GOAL:=publish
+
+#### Variables
+PUBLISH_IMAGES_REGISTRY ?=
+TAG ?= latest
+REPOSITORY ?= gpu-tests
+
+#### Format the registry portion of the image tag, if needed
+REGISTRY ?=
+ifdef PUBLISH_IMAGES_REGISTRY
+REGISTRY = "$(PUBLISH_IMAGES_REGISTRY)/"
+endif
+
+#### Actual build targets
+build:
+ifndef REGISTRY
+$(error "The PUBLISH_IMAGES_REGISTRY value must be provided (e.g. PUBLISH_IMAGES_REGISTRY=861807767978.dkr.ecr.us-east-2.amazonaws.com make)")
+endif
+	docker buildx build --platform linux/arm64,linux/amd64 --tag $(REGISTRY)$(REPOSITORY):$(TAG) .
+
+publish:
+	docker buildx build --push --platform linux/arm64,linux/amd64 --tag $(REGISTRY)$(REPOSITORY):$(TAG) .
+
+x86_64:
+	docker buildx build --platform linux/amd64 --tag $(REGISTRY)$(REPOSITORY):$(TAG)-x86_64 .
+
+aarch64:
+	docker buildx build --platform linux/arm64 --tag $(REGISTRY)$(REPOSITORY):$(TAG)-aarch64 .

--- a/bottlerocket/tests/workload/nvidia-smoke/README.md
+++ b/bottlerocket/tests/workload/nvidia-smoke/README.md
@@ -1,0 +1,68 @@
+# NVIDIA GPU Smoke tests
+
+The image created by the Dockerfile in this folder compiles a few [CUDA samples](https://github.com/NVIDIA/cuda-samples/) for both `x86_64` and `aarch64`.
+This container image can be used as a TestSys workload test to validate the Bottlerocket `*-nvidia` variants running on NVIDIA hosts.
+
+## Build requirements
+
+Due to missing packages needed for cross-compiling, and unexpected handling in the sample Makefile logic when compiling for one platform for another, the build for this image requires two Buildx hosts - one for each architecture.
+
+In order to build the image for both architectures, you need to set up the `buildx` docker plugin.
+[This guide describes](https://github.com/docker/buildx#installing) the installation process.
+
+By default, the install of `docker buildx` uses the `docker` driver type.
+This driver is not able to build for all platform targets we need.
+You will need to run the following to create a new builder using the `docker-container` driver:
+
+```bash
+docker buildx create --use --bootstrap
+docker buildx ls
+```
+
+You should see a `*` next to your newly created builder denoting it as the currently active builder to use.
+If it is not, you can switch builder contexts by running:
+
+```sh
+docker buildx use $BUILDER_NAME
+```
+
+You then need to add another "context" to the builder for a second host that can build the other platform architecture.
+If you are running these steps on an `amd64` host, you will need to add an `arm64` host to the builder, or vice versa.
+
+First, verify you are able to access the remote host via SSH:
+
+```sh
+docker -H ssh://user@hostname info
+```
+
+The output from that command should show information about the Docker instance running on the remote host.
+You can then add that host to your Buildx builder by running:
+
+```sh
+docker buildx create --name $BUILDER_NAME --append ssh://user@hostname
+```
+
+Supported platforms can be verified by running:
+
+```bash
+docker buildx inspect | grep Platforms
+```
+
+The output from this command should show both `linux/amd64` and `linux/arm64` platforms.
+
+By default, the image will be tagged `<PUBLISH_IMAGES_REGISTRY>/gpu-tests:<TAG>`, so make sure you already have a `gpu-tests` repository in your registry.
+You can change the name of the repo by overriding the `PUBLISH_IMAGES_REGISTRY` env variable while building the image.
+
+**NOTE:** This assumes that you have already configured your credentials to be able to perform a `docker push` to your registry.
+
+## Building the image
+
+To build the image for both `x86_64` and `aarch64`, run the following:
+
+```sh
+PUBLISH_IMAGES_REGISTRY=<YOUR_REGISTRY> make
+```
+
+The command will build, tag, and push the images to your `PUBLISH_IMAGES_REGISTRY` using the name `gpu-tests:<TAG>`.
+
+Since this is a multi-arch image, you can use it in both `x86_64` and `aarch64` clusters.

--- a/bottlerocket/tests/workload/nvidia-smoke/run.sh
+++ b/bottlerocket/tests/workload/nvidia-smoke/run.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# Collect the test output where sonobuoy expects plugins to place them
+results_dir="${RESULTS_DIR:-/tmp/results}"
+mkdir -p "${results_dir}"
+
+saveResults() {
+     cd "${results_dir}"
+     tar czf results.tar.gz ./*
+     echo "${results_dir}/results.tar.gz" > "${results_dir}/done"
+}
+
+# Make sure to always capture results in expected place and format
+trap saveResults EXIT
+
+# Run the CUDA sample binaries to exercise various GPU functions
+cd /samples
+for sample in *; do
+    echo
+    echo "========================================="
+    echo "  Running sample ${sample}"
+    echo "========================================="
+    echo
+    "./${sample}" 2>&1 | tee "${results_dir}/${sample}.log"
+done


### PR DESCRIPTION
**Issue number:**

Related: #419

**Description of changes:**

This adds a new `tests` directory tree to contain our workload tests and any other type of add-on test type we decide to add in the future. It adds our first workload test for running NVIDIA smoketests. Basic instructions are included to help guide future test authors of the requirements for tests and where they should be placed.

Some of this content will need to be updated once we fully finish publishing the container images and flesh out things like ECS testing and how the full execution of workload tests will be performed. This gets the majority of the pieces in place so those updates will be smaller and it will be easier to complete that work using published content.

**Testing done:**

Most testing was done when the initial `k8s-workload-agent` was added. The `nvidia-smoke` container creation has been tested by building the multiarch image and running it manually on both amd64 and arm64 ECS Bottlerocket nodes and viewing the output results.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
