### PR TITLE
actions-workflow: use 16-core GitHub hosted runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,10 +15,12 @@ on:
     branches: [develop]
 jobs:
   build:
-    runs-on: [self-hosted, linux, x64]
+    runs-on:
+      group: bottlerocket
+      labels: bottlerocket_ubuntu-latest_16-core
     steps:
       - uses: actions/checkout@v3
-      - run: rustup default 1.61.0
+      - run: rustup default 1.61.0 && rustup component add rustfmt && rustup component add clippy
       - run: make build
         # If we forget to add yamlgen changes to our commits, this will fail.
       - name: ensure that git is clean
@@ -33,7 +35,9 @@ jobs:
           TESTSYS_SELFTEST_SKIP_IMAGE_BUILDS: true
           TESTSYS_SELFTEST_THREADS: 1
   images:
-    runs-on: [ self-hosted, linux, x64 ]
+    runs-on:
+      group: bottlerocket
+      labels: bottlerocket_ubuntu-latest_16-core
     steps:
       - uses: actions/checkout@v3
       - run: make images

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -9,7 +9,9 @@ on:
     branches: [develop]
 jobs:
   build:
-    runs-on: [self-hosted, linux, x64]
+    runs-on:
+      group: bottlerocket
+      labels: bottlerocket_ubuntu-latest_16-core
     steps:
       - uses: actions/checkout@v3
       - run: make tools


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
This changes the build workflow and tools workflow so that instead of using self-hosted runners, we use Github-hosted 16-core runners.


**Testing done:**
See this PR's actions workflow.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
