### PR TITLE
TestManager: fix `cli add-secret map ...`

### DIFF
--- a/model/src/test_manager/manager.rs
+++ b/model/src/test_manager/manager.rs
@@ -103,7 +103,7 @@ impl TestManager {
             type_: Some("kubernetes.io/dockerconfigjson".to_string()),
         };
 
-        self.create_or_update(self.api(), &secret, "controller pull secret")
+        self.create_or_update(self.namespaced_api(), &secret, "controller pull secret")
             .await?;
         Ok(secret)
     }
@@ -125,7 +125,8 @@ impl TestManager {
             string_data: Some(data.into_iter().collect()),
             type_: None,
         };
-        self.create_or_update(self.api(), &secret, "secret").await?;
+        self.create_or_update(self.namespaced_api(), &secret, "secret")
+            .await?;
         Ok(secret)
     }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

When `kube-rs` was updated, secrets required a namespaced api.

**Testing done:**

Before:
```
$ cli add-secret map --name test foo=bar
Unable to create secret
```
After:
```
$ cli add-secret map --name test foo=bar
Successfully added 'test' to secrets.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
