### PR TITLE
controller: Resource creation waits for test

### DIFF
--- a/controller/src/resource_controller/mod.rs
+++ b/controller/src/resource_controller/mod.rs
@@ -103,6 +103,9 @@ async fn do_creation_action(r: ResourceInterface, action: CreationAction) -> Res
                 conflict
             );
         }
+        CreationAction::WaitForDependent => {
+            debug!("'{}' is waiting for test that requires it", r.name());
+        }
         CreationAction::AddResourceFinalizer => {
             let _ = r
                 .resource_client()


### PR DESCRIPTION
Resources now wait for a test that requires them before they are created. This along with an addition to `is_delete_required()` that checks to make sure the resource exists before deleting it solve a race condition where a resource that was applied to a cluster slightly before its corresponding test would automatically be cleaned up before it was created.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Resources now wait for a test that requires them before they are created. This along with an addition to `is_delete_required()` that checks to make sure the resource exists before deleting it solve a race condition where a resource that was applied to a cluster slightly before its corresponding test would automatically be cleaned up before it was created.

Adds a new wait action, WaitForDependent that signifies that no tests or resources require that resource.

**Testing done:**

Applied a cluster and instances yaml without the proposed changes and the instances resource was instantly cleaned up. After this pr, applying the same yaml, instance resource is not automatically deleted.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
