### PR TITLE
TestManager: Show the state for current test

### DIFF
--- a/model/src/test_manager/status.rs
+++ b/model/src/test_manager/status.rs
@@ -303,8 +303,8 @@ impl From<&Crd> for Vec<ResultRow> {
                 let state = test.test_user_state().to_string();
                 let test_results = &test.agent_status().results;
                 let current_test = &test.agent_status().current_test;
-                let mut test_iter = test_results.iter().chain(current_test.iter()).peekable();
-                if test_iter.peek().is_none() {
+                let mut test_iter = test_results.iter().peekable();
+                if test_iter.peek().is_none() && current_test.is_none() {
                     results.push(ResultRow {
                         name,
                         object_type: "Test".to_string(),
@@ -324,6 +324,21 @@ impl From<&Crd> for Vec<ResultRow> {
                             name: retry_name,
                             object_type: "Test".to_string(),
                             state: result.outcome.to_string(),
+                            passed: Some(result.num_passed),
+                            skipped: Some(result.num_skipped),
+                            failed: Some(result.num_failed),
+                        });
+                    }
+                    if let Some(result) = current_test {
+                        let retry_name = if test_results.is_empty() {
+                            name
+                        } else {
+                            format!("{}-retry-{}", name, test_results.len())
+                        };
+                        results.push(ResultRow {
+                            name: retry_name,
+                            object_type: "Test".to_string(),
+                            state,
                             passed: Some(result.num_passed),
                             skipped: Some(result.num_skipped),
                             failed: Some(result.num_failed),


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

In a previous pr, the status was changed to show the outcome for each result row including the current test's row, but if the agent errored, the state stayed as `inProgress`.

**Testing done:**

Ran `cli status` and verified that an errored test showed that there was an error.
```shell
$ cli status                                                                                               Mon Dec 19 17:04:32 2022

 NAME                                       TYPE             STATE             PASSED        SKIPPED        FAILED
 x86-64-aws-k8s-124                         Resource         completed
 x86-64-aws-k8s-124-instances-quick         Resource         completed
 x86-64-aws-k8s-124-test                    Test             error             0             0              0
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
