### PR TITLE
sonobuoy: Fix results race condition

### DIFF
--- a/bottlerocket/agents/src/sonobuoy.rs
+++ b/bottlerocket/agents/src/sonobuoy.rs
@@ -193,7 +193,10 @@ pub async fn wait_for_sonobuoy_results(
         retries = 0;
         trace!("The sonobuoy results are valid json");
         let status = run_status.get("status");
-        if status.is_some() && status != Some(&Value::String("running".to_string())) {
+        if status.is_some()
+            && status != Some(&Value::String("running".to_string()))
+            && status != Some(&Value::String("post-processing".to_string()))
+        {
             return Ok(());
         }
         info!("Some tests are still running");


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

The sonobuoy agent was trying to pull results while the status was in the post-processing state. This pr makes sure the test is not running or in post-processing before trying to collect results.

**Testing done:**

Tested with `cargo make test` 10 times and all 10 quick tests passed without error.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
