### PR TITLE
Bump testsys crate versions to v0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "agent-common"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "model",
  "snafu",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "agent-utils"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "agent-common",
  "aws-config",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-agents"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "agent-common",
  "agent-utils",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-types"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "builder-derive",
  "configuration-derive",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "builder-derive"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "configuration-derive",
  "model",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "cli"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "configuration-derive"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "quote",
  "syn",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "model"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -2226,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "resource-agent"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "agent-common",
  "async-trait",
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "selftest"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "envy",
@@ -2777,7 +2777,7 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "test-agent"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "agent-common",
  "async-trait",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "test-agent-cli"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "agent-common",
  "argh",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "testsys"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "assert_cmd",
  "base64 0.20.0",

--- a/agent/agent-common/Cargo.toml
+++ b/agent/agent-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "agent-common"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-model = { version = "0.0.4", path = "../../model" }
+model = { version = "0.0.5", path = "../../model" }
 snafu = "0.7"
 
 [dev-dependencies]

--- a/agent/builder-derive/Cargo.toml
+++ b/agent/builder-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "builder-derive"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2018"
 publish = false
 license = "MIT OR Apache-2.0"
@@ -17,5 +17,5 @@ proc-macro = true
 [dev-dependencies]
 serde = "1"
 serde_json= "1"
-model = { version = "0.0.4", path = "../../model" }
-configuration-derive = { version = "0.0.4", path = "../configuration-derive" }
+model = { version = "0.0.5", path = "../../model" }
+configuration-derive = { version = "0.0.5", path = "../configuration-derive" }

--- a/agent/configuration-derive/Cargo.toml
+++ b/agent/configuration-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "configuration-derive"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2018"
 publish = false
 license = "MIT OR Apache-2.0"

--- a/agent/resource-agent/Cargo.toml
+++ b/agent/resource-agent/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "resource-agent"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-agent-common = { version = "0.0.4", path = "../agent-common" }
+agent-common = { version = "0.0.5", path = "../agent-common" }
 async-trait = "0.1"
 log = "0.4"
-model = { version = "0.0.4", path = "../../model" }
+model = { version = "0.0.5", path = "../../model" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu = "0.7"

--- a/agent/test-agent-cli/Cargo.toml
+++ b/agent/test-agent-cli/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "test-agent-cli"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 argh = "0.1"
-agent-common = { version = "0.0.4", path = "../agent-common" }
+agent-common = { version = "0.0.5", path = "../agent-common" }
 copy_dir = "0.1"
-test-agent = { version = "0.0.4", path = "../test-agent" }
+test-agent = { version = "0.0.5", path = "../test-agent" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
 tokio-util = "0.7"
 log = "0.4"
-model = { version = "0.0.4", path = "../../model" }
+model = { version = "0.0.5", path = "../../model" }
 snafu = "0.7"
 async-trait = "0.1"
 tempfile = "3"
@@ -26,4 +26,4 @@ tar = "0.4"
 
 [dev-dependencies]
 assert_cmd = "2"
-selftest = { version = "0.0.4", path = "../../selftest" }
+selftest = { version = "0.0.5", path = "../../selftest" }

--- a/agent/test-agent/Cargo.toml
+++ b/agent/test-agent/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "test-agent"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-agent-common = { version = "0.0.4", path = "../agent-common" }
+agent-common = { version = "0.0.5", path = "../agent-common" }
 async-trait = "0.1"
 log = "0.4"
-model = { version = "0.0.4", path = "../../model" }
+model = { version = "0.0.5", path = "../../model" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu = "0.7"

--- a/agent/utils/Cargo.toml
+++ b/agent/utils/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "agent-utils"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2018"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-agent-common = { version = "0.0.4", path = "../../agent/agent-common" }
+agent-common = { version = "0.0.5", path = "../../agent/agent-common" }
 aws-config = "0.49"
 aws-types = "0.49"
 aws-sdk-sts = "0.19"
@@ -14,9 +14,9 @@ aws-smithy-types = "0.49"
 base64 = "0.20"
 env_logger = "0.10"
 log = "0.4"
-model = { version = "0.0.4", path = "../../model" }
-resource-agent = { version = "0.0.4", path = "../../agent/resource-agent" }
+model = { version = "0.0.5", path = "../../model" }
+resource-agent = { version = "0.0.5", path = "../../agent/resource-agent" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu = "0.7"
-test-agent = { version = "0.0.4", path = "../../agent/test-agent" }
+test-agent = { version = "0.0.5", path = "../../agent/test-agent" }

--- a/bottlerocket/agents/Cargo.toml
+++ b/bottlerocket/agents/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "bottlerocket-agents"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2018"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-agent-common = { version = "0.0.4", path = "../../agent/agent-common" }
-agent-utils = { version = "0.0.4", path = "../../agent/utils" }
-bottlerocket-types = { version = "0.0.4", path = "../types" }
+agent-common = { version = "0.0.5", path = "../../agent/agent-common" }
+agent-utils = { version = "0.0.5", path = "../../agent/utils" }
+bottlerocket-types = { version = "0.0.5", path = "../types" }
 async-trait = "0.1"
 aws-config = "0.49"
 aws-types = "0.49"
@@ -26,16 +26,16 @@ k8s-openapi = { version = "0.16", default-features = false, features = ["v1_20"]
 kube = { version = "0.75", default-features = false, features = ["config", "derive", "client"] }
 log = "0.4"
 maplit = "1"
-model = { version = "0.0.4", path = "../../model" }
+model = { version = "0.0.5", path = "../../model" }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "blocking"] }
-resource-agent = { version = "0.0.4", path = "../../agent/resource-agent" }
+resource-agent = { version = "0.0.5", path = "../../agent/resource-agent" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1"
 serde_yaml = "0.8"
 sha2 = "0.10"
 snafu = "0.7"
-test-agent = { version = "0.0.4", path = "../../agent/test-agent" }
+test-agent = { version = "0.0.5", path = "../../agent/test-agent" }
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
 toml = "0.5"
 tough = { version = "0.12", features = ["http"] }

--- a/bottlerocket/testsys/Cargo.toml
+++ b/bottlerocket/testsys/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "testsys"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 base64 = "0.20.0"
-bottlerocket-types = { version = "0.0.4", path = "../types" }
+bottlerocket-types = { version = "0.0.5", path = "../types" }
 env_logger = "0.10"
 futures = "0.3"
 http = "0"
@@ -15,7 +15,7 @@ k8s-openapi = { version = "0.16", features = ["v1_20", "api"], default-features 
 kube = { version = "0.75", default-features = true, features = ["config", "derive", "ws"] }
 log = "0.4"
 maplit = "1"
-model = { version = "0.0.4", path = "../../model" }
+model = { version = "0.0.5", path = "../../model" }
 serde = "1"
 serde_plain = "1"
 serde_json = "1"
@@ -30,7 +30,7 @@ topological-sort = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2"
-selftest = { version = "0.0.4", path = "../../selftest" }
+selftest = { version = "0.0.5", path = "../../selftest" }
 
 [features]
 # The `integ` feature enables integration tests. These tests require docker and kind.

--- a/bottlerocket/types/Cargo.toml
+++ b/bottlerocket/types/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "bottlerocket-types"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2018"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-configuration-derive = { version = "0.0.4", path = "../../agent/configuration-derive" }
-builder-derive = { version = "0.0.4", path = "../../agent/builder-derive" }
-model = { version = "0.0.4", path = "../../model" }
+configuration-derive = { version = "0.0.5", path = "../../agent/configuration-derive" }
+builder-derive = { version = "0.0.5", path = "../../agent/builder-derive" }
+model = { version = "0.0.5", path = "../../model" }
 serde = "1"
 serde_plain = "1"
 serde_yaml = "0.8"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "controller"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ kube = { version = "0.75", default-features = true, features = ["derive"] }
 kube-runtime = "0.75"
 lazy_static = "1"
 log = "0.4"
-model = { version = "0.0.4", path = "../model" }
+model = { version = "0.0.5", path = "../model" }
 schemars = "=0.8.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "model"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
@@ -32,7 +32,7 @@ tokio-util = "0.7"
 topological-sort = "0.2"
 
 [dev-dependencies]
-selftest = { version = "0.0.4", path = "../selftest" }
+selftest = { version = "0.0.5", path = "../selftest" }
 tokio = { version = "1", features = ["macros"] }
 
 [features]

--- a/selftest/Cargo.toml
+++ b/selftest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "selftest"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
@@ -13,7 +13,7 @@ futures = "0.3"
 k8s-openapi = { version = "0.16", default-features = false, features = ["v1_20"] }
 kube = { version = "0.75", default-features = true }
 lazy_static = "1"
-model = { version = "0.0.4", path = "../model"}
+model = { version = "0.0.5", path = "../model"}
 serde = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["time"] }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

Needs to merge after https://github.com/bottlerocket-os/bottlerocket-test-system/pull/721
**Issue number:**
N/A


**Description of changes:**
Bumps testsys crate versions to 0.0.5 to prepare for v0.0.5 release

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
