### PR TITLE
Add category field to allow getting all testsys objects

### DIFF
--- a/model/src/resource.rs
+++ b/model/src/resource.rs
@@ -25,6 +25,7 @@ use std::fmt::{Display, Formatter};
     plural = "resources",
     singular = "resource",
     status = "ResourceStatus",
+    category = "testsys",
     version = "v1",
     printcolumn = r#"{"name":"DestructionPolicy", "type":"string", "jsonPath":".spec.destructionPolicy"}"#,
     printcolumn = r#"{"name":"CreationState", "type":"string", "jsonPath":".status.creation.taskState"}"#,

--- a/model/src/test.rs
+++ b/model/src/test.rs
@@ -22,6 +22,7 @@ use std::borrow::Cow;
     plural = "tests",
     singular = "test",
     status = "TestStatus",
+    category = "testsys",
     version = "v1",
     printcolumn = r#"{"name":"State", "type":"string", "jsonPath":".status.agent.taskState"}"#,
     printcolumn = r#"{"name":"Result", "type":"string", "jsonPath":".status.agent.results.outcome"}"#


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

This adds a `category` setting of `"testsys"` to our CRD definitions. This allows getting all objects in a cluster by running `kubectl get testsys`, similar to how `kubectl get all` works.

**Testing done:**

Built and deployed to local kind testsys cluster. Ran test and verified able to get all objects (expected to fail in local quick test, so ignore failure states):

```bash
$ k get testsys

NAME                               STATE     RESULT
test.testsys.system/testsys-demo   unknown   

NAME                                             DESTRUCTIONPOLICY   CREATIONSTATE   DESTRUCTIONSTATE
resource.testsys.system/bottlerocket             onDeletion          error           unknown
resource.testsys.system/bottlerocket-instances   onDeletion          unknown         unknown
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
