### PR TITLE
workload: Remove `canonicalize` from plugin file path

### DIFF
--- a/bottlerocket/agents/src/error.rs
+++ b/bottlerocket/agents/src/error.rs
@@ -106,12 +106,6 @@ pub enum Error {
         path: String,
     },
 
-    #[snafu(display("Invalid path: {path}"))]
-    BadPath {
-        source: std::io::Error,
-        path: String,
-    },
-
     #[snafu(display("Results location is invalid"))]
     ResultsLocation,
 

--- a/bottlerocket/agents/src/workload.rs
+++ b/bottlerocket/agents/src/workload.rs
@@ -48,10 +48,7 @@ where
 
         // Write out the output to a file we can reference later
         let file_name = format!("{}-plugin.yaml", plugin.name);
-        let plugin_yaml = PathBuf::from(".")
-            .join(&file_name)
-            .canonicalize()
-            .context(error::BadPathSnafu { path: &file_name })?;
+        let plugin_yaml = PathBuf::from(".").join(&file_name);
         let mut f = File::create(&plugin_yaml).context(error::FileWriteSnafu {
             path: plugin_yaml.display().to_string(),
         })?;


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

There was a bug in the workload agent where the plugin's file path couldn't be canonicalized.

**Testing done:**

Tested with `cargo make test`.
```bash
 NAME                         TYPE      STATE      PASSED      SKIPPED      FAILED     STATUS    LAST UPDATE                BUILD ID
 x86-64-aws-k8s-124-test      Test      pass       1           0            0                     2023-01-04T14:58:58Z      3ebb33a9
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
