### PR TITLE
Fix lint errors with 1.66 toolchain

### DIFF
--- a/bottlerocket/agents/src/bin/vsphere-k8s-cluster-resource-agent/vsphere_k8s_cluster_provider.rs
+++ b/bottlerocket/agents/src/bin/vsphere-k8s-cluster-resource-agent/vsphere_k8s_cluster_provider.rs
@@ -207,7 +207,7 @@ async fn write_validate_mgmt_kubeconfig(
             resources,
             "Failed to write out kubeconfig for the CAPI management cluster",
         )?;
-    let mgmt_kubeconfig = Kubeconfig::read_from(&mgmt_kubeconfig_path)
+    let mgmt_kubeconfig = Kubeconfig::read_from(mgmt_kubeconfig_path)
         .context(resources, "Unable to read kubeconfig")?;
     let mgmt_config =
         Config::from_custom_kubeconfig(mgmt_kubeconfig.to_owned(), &KubeConfigOptions::default())

--- a/bottlerocket/agents/src/bin/vsphere-vm-resource-agent/vsphere_vm_provider.rs
+++ b/bottlerocket/agents/src/bin/vsphere-vm-resource-agent/vsphere_vm_provider.rs
@@ -626,7 +626,7 @@ impl Destroy for VMDestroyer {
                 .arg(format!("-vm.ip={}", vm.ip_address))
                 .arg(&vm.name)
                 .output()
-                .context(&resources, "Failed to start govc")?;
+                .context(resources, "Failed to start govc")?;
             if !vm_destroy_output.status.success() {
                 return Err(ProviderError::new_with_context(
                     resources,

--- a/bottlerocket/agents/src/tuf.rs
+++ b/bottlerocket/agents/src/tuf.rs
@@ -39,7 +39,7 @@ pub fn download_target(
     // Need to download root.json. This is an unsafe operation but in the context of testing it's fine.
     let root_path = download_root(resources, metadata_url, outdir)?;
     let repository = RepositoryLoader::new(
-        File::open(&root_path).context(
+        File::open(root_path).context(
             resources,
             "Failed to open root.json file for loading TUF repository",
         )?,

--- a/bottlerocket/agents/src/workload.rs
+++ b/bottlerocket/agents/src/workload.rs
@@ -48,7 +48,7 @@ where
 
         // Write out the output to a file we can reference later
         let file_name = format!("{}-plugin.yaml", plugin.name);
-        let plugin_yaml = PathBuf::from(".").join(&file_name);
+        let plugin_yaml = PathBuf::from(".").join(file_name);
         let mut f = File::create(&plugin_yaml).context(error::FileWriteSnafu {
             path: plugin_yaml.display().to_string(),
         })?;

--- a/bottlerocket/testsys/src/status.rs
+++ b/bottlerocket/testsys/src/status.rs
@@ -81,7 +81,7 @@ impl Status {
             stream::iter(resource_names)
                 .then(|resource_name| async move {
                     resource_client
-                        .get(&resource_name)
+                        .get(resource_name)
                         .await
                         .context(error::GetSnafu {
                             what: resource_name.clone(),
@@ -160,7 +160,7 @@ impl Default for Results {
 impl Results {
     /// Adds a new `ResultRow` for each `TestResults` in test, or a single row if no `TestsResults` are available.
     fn add_test(&mut self, test: &Test) {
-        let name = test.metadata.name.clone().unwrap_or_else(|| "".to_string());
+        let name = test.metadata.name.clone().unwrap_or_default();
         let state = test.test_user_state().to_string();
         let results = &test.agent_status().results;
         if results.is_empty() {

--- a/model/src/test_manager/status.rs
+++ b/model/src/test_manager/status.rs
@@ -210,10 +210,7 @@ impl From<&StatusSnapshot> for Table {
             results.push(ResultRow {
                 name: "controller".to_string(),
                 object_type: "Controller".to_string(),
-                state: controller_status
-                    .phase
-                    .clone()
-                    .unwrap_or_else(|| "".to_string()),
+                state: controller_status.phase.clone().unwrap_or_default(),
                 passed: None,
                 skipped: None,
                 failed: None,
@@ -299,7 +296,7 @@ impl From<&Crd> for Vec<ResultRow> {
         let mut results = Vec::new();
         match crd {
             Crd::Test(test) => {
-                let name = test.metadata.name.clone().unwrap_or_else(|| "".to_string());
+                let name = test.metadata.name.clone().unwrap_or_default();
                 let state = test.test_user_state().to_string();
                 let test_results = &test.agent_status().results;
                 let current_test = &test.agent_status().current_test;


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

The latest rust toolchain errors on a few new things. This addresses the findings to clean those up.

**Testing done:**

Ran `make build` and verified no errors.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
