### PR TITLE
added sample test config files

### DIFF
--- a/bottlerocket/samples/RUNBOOK.md
+++ b/bottlerocket/samples/RUNBOOK.md
@@ -1,0 +1,304 @@
+# Bottlerocket Test System Sample Files
+
+These files contain templates that can be populated using environment variables and the `eval` command and run with the `cli` tool.
+
+Examples of how to populate each one of these files can be found below.
+
+Each codeblock starts with a small number of variables that need to be populated before running the block, followed by a number of variables that contain default values (but can be modified by the user).
+
+_Note_: `ASSUME_ROLE` has a default value of `~` (null), but you can replace this with the ARN of an AWS IAM role that should be used for all AWS calls.
+
+The final `cat` command will print the populated file to the path indicated by `OUTPUT_FILE`.
+
+## EKS
+
+The files in [eks](./eks) are meant to be run on an EKS test cluster. You can create a new cluster using the [eksctl](https://eksctl.io/introduction/) tool.
+
+### Migration Testing on `aws-ecs` Variants
+
+```bash
+CLUSTER_NAME="x86-64-aws-ecs-1"
+OUTPUT_FILE="${CLUSTER_NAME}-migration.yaml"
+VARIANT="aws-ecs-1"
+ARCHITECTURE="x86_64"
+AGENT_IMAGE_VERSION=$(cli --version | sed -e "s/^.* //g")
+ECS_TEST_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ecs-test-agent:v${AGENT_IMAGE_VERSION}"
+MIGRATION_TEST_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/migration-test-agent:v${AGENT_IMAGE_VERSION}"
+ECS_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ecs-resource-agent:v${AGENT_IMAGE_VERSION}"
+EC2_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ec2-resource-agent:v${AGENT_IMAGE_VERSION}"
+ASSUME_ROLE="~"
+AWS_REGION="us-west-2"
+UPGRADE_VERSION="v1.11.1"
+STARTING_VERSION="v1.11.0"
+METADATA_URL="https://updates.bottlerocket.aws/2020-07-07/${VARIANT}/${ARCHITECTURE}"
+TARGETS_URL="https://updates.bottlerocket.aws/targets"
+
+BOTTLEROCKET_AMI_ID=$(aws ssm get-parameter \
+  --region ${AWS_REGION} \
+  --name "/aws/service/bottlerocket/${VARIANT}/${ARCHITECTURE}/$(echo ${STARTING_VERSION} | tr -d "v")/image_id" \
+  --query Parameter.Value --output text)
+
+eval "cat > ${OUTPUT_FILE} << EOF
+$(< eks/ecs-migration-test.yaml)
+EOF
+" 2> /dev/null
+```
+
+### Conformance Testing on `aws-ecs` Variants
+
+```bash
+CLUSTER_NAME="x86-64-aws-ecs-1"
+OUTPUT_FILE="${CLUSTER_NAME}.yaml"
+VARIANT="aws-ecs-1"
+ARCHITECTURE="x86_64"
+AGENT_IMAGE_VERSION=$(cli --version | sed -e "s/^.* //g")
+ECS_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ecs-resource-agent:v${AGENT_IMAGE_VERSION}"
+EC2_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ec2-resource-agent:v${AGENT_IMAGE_VERSION}"
+ECS_TEST_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ecs-test-agent:v${AGENT_IMAGE_VERSION}"
+ASSUME_ROLE="~"
+AWS_REGION="us-west-2"
+
+BOTTLEROCKET_AMI_ID=$(aws ssm get-parameter \
+  --region ${AWS_REGION} \
+  --name "/aws/service/bottlerocket/${VARIANT}/${ARCHITECTURE}/latest/image_id" \
+  --query Parameter.Value --output text)
+
+eval "cat > ${OUTPUT_FILE} << EOF
+$(< eks/ecs-test.yaml)
+EOF
+" 2> /dev/null
+```
+
+### Migration Testing on `aws-k8s` Variants
+
+```bash
+CLUSTER_NAME="x86-64-aws-k8s-124"
+OUTPUT_FILE="${CLUSTER_NAME}-migration.yaml"
+VARIANT="aws-k8s-1.24"
+ARCHITECTURE="x86_64"
+AGENT_IMAGE_VERSION=$(cli --version | sed -e "s/^.* //g")
+SONOBUOY_TEST_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/sonobuoy-test-agent:v${AGENT_IMAGE_VERSION}"
+MIGRATION_TEST_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/migration-test-agent:v${AGENT_IMAGE_VERSION}"
+EKS_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/eks-resource-agent:v${AGENT_IMAGE_VERSION}"
+EC2_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ec2-resource-agent:v${AGENT_IMAGE_VERSION}"
+ASSUME_ROLE="~"
+AWS_REGION="us-west-2"
+UPGRADE_VERSION="v1.11.1"
+STARTING_VERSION="v1.11.0"
+METADATA_URL="https://updates.bottlerocket.aws/2020-07-07/${VARIANT}/${ARCHITECTURE}"
+TARGETS_URL="https://updates.bottlerocket.aws/targets"
+
+BOTTLEROCKET_AMI_ID=$(aws ssm get-parameter \
+  --region ${AWS_REGION} \
+  --name "/aws/service/bottlerocket/${VARIANT}/${ARCHITECTURE}/$(echo ${STARTING_VERSION} | tr -d "v")/image_id" \
+  --query Parameter.Value --output text)
+
+eval "cat > ${OUTPUT_FILE} << EOF
+$(< eks/sonobuoy-migration-test.yaml)
+EOF
+" 2> /dev/null
+```
+
+### Conformance Testing on `aws-k8s` Variants
+
+```bash
+CLUSTER_NAME="x86-64-aws-k8s-124"
+OUTPUT_FILE="${CLUSTER_NAME}.yaml"
+VARIANT="aws-k8s-1.24"
+ARCHITECTURE="x86_64"
+AGENT_IMAGE_VERSION=$(cli --version | sed -e "s/^.* //g")
+SONOBUOY_TEST_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/sonobuoy-test-agent:v${AGENT_IMAGE_VERSION}"
+EKS_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/eks-resource-agent:v${AGENT_IMAGE_VERSION}"
+EC2_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ec2-resource-agent:v${AGENT_IMAGE_VERSION}"
+ASSUME_ROLE="~"
+AWS_REGION="us-west-2"
+SONOBUOY_MODE="quick"
+
+BOTTLEROCKET_AMI_ID=$(aws ssm get-parameter \
+  --region ${AWS_REGION} \
+  --name "/aws/service/bottlerocket/${VARIANT}/${ARCHITECTURE}/latest/image_id" \
+  --query Parameter.Value --output text)
+
+eval "cat > ${OUTPUT_FILE} << EOF
+$(< eks/sonobuoy-test.yaml)
+EOF
+" 2> /dev/null
+```
+
+### Migration Testing on `vmware-k8s` Variants
+
+This codeblock assumes that your vSphere config file has been sourced. Specifically, the variables `GOVC_USERNAME`, `GOVC_PASSWORD`, `GOVC_DATACENTER`, `GOVC_DATASTORE`, `GOVC_URL`, `GOVC_NETWORK`, `GOVC_RESOURCE_POOL`, and `GOVC_FOLDER` need to be populated.
+
+```bash
+CONTROL_PLANE_ENDPOINT_IP=
+MGMT_CLUSTER_KUBECONFIG_PATH=
+
+CLUSTER_NAME="vmware-k8s-124"
+OUTPUT_FILE="${CLUSTER_NAME}-migration.yaml"
+VARIANT="vmware-k8s-1.24"
+K8S_VERSION="1.24"
+AGENT_IMAGE_VERSION=$(cli --version | sed -e "s/^.* //g")
+SONOBUOY_TEST_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/sonobuoy-test-agent:v${AGENT_IMAGE_VERSION}"
+MIGRATION_TEST_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/migration-test-agent:v${AGENT_IMAGE_VERSION}"
+VSPHERE_K8S_CLUSTER_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/vsphere-k8s-cluster-resource-agent:v${AGENT_IMAGE_VERSION}"
+VSPHERE_VM_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/vsphere-vm-resource-agent:v${AGENT_IMAGE_VERSION}"
+ASSUME_ROLE="~"
+REGION="us-west-2"
+UPGRADE_VERSION="v1.11.1"
+STARTING_VERSION="v1.11.0"
+METADATA_URL="https://updates.bottlerocket.aws/2020-07-07/${VARIANT}/x86_64"
+TARGETS_URL="https://updates.bottlerocket.aws/targets"
+OVA_NAME="bottlerocket-${VARIANT}-x86_64-${STARTING_VERSION}.ova"
+MGMT_CLUSTER_KUBECONFIG_BASE64=$(cat ${MGMT_CLUSTER_KUBECONFIG_PATH} | base64)
+
+cli add-secret map  \
+ --name "vsphere-creds" \
+ "username=${GOVC_USERNAME}" \
+ "password=${GOVC_PASSWORD}"
+
+eval "cat > ${OUTPUT_FILE} << EOF
+$(< eks/vmware-migration-test.yaml)
+EOF
+" 2> /dev/null
+```
+
+### Conformance Testing on `vmware-k8s` Variants
+
+This codeblock assumes that your vSphere config file has been sourced. Specifically, the variables `GOVC_USERNAME`, `GOVC_PASSWORD`, `GOVC_DATACENTER`, `GOVC_DATASTORE`, `GOVC_URL`, `GOVC_NETWORK`, `GOVC_RESOURCE_POOL`, and `GOVC_FOLDER` need to be populated.
+
+```bash
+CONTROL_PLANE_ENDPOINT_IP=
+MGMT_CLUSTER_KUBECONFIG_PATH=
+
+CLUSTER_NAME="vmware-k8s-124"
+OUTPUT_FILE="${CLUSTER_NAME}.yaml"
+VARIANT="vmware-k8s-1.24"
+K8S_VERSION="1.24"
+AGENT_IMAGE_VERSION=$(cli --version | sed -e "s/^.* //g")
+SONOBUOY_TEST_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/sonobuoy-test-agent:v${AGENT_IMAGE_VERSION}"
+VSPHERE_K8S_CLUSTER_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/vsphere-k8s-cluster-resource-agent:v${AGENT_IMAGE_VERSION}"
+VSPHERE_VM_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/vsphere-vm-resource-agent:v${AGENT_IMAGE_VERSION}"
+ASSUME_ROLE="~"
+REGION="us-west-2"
+SONOBUOY_MODE="quick"
+VERSION="v1.11.1"
+METADATA_URL="https://updates.bottlerocket.aws/2020-07-07/${VARIANT}/x86_64"
+TARGETS_URL="https://updates.bottlerocket.aws/targets"
+OVA_NAME="bottlerocket-${VARIANT}-x86_64-${VERSION}.ova"
+MGMT_CLUSTER_KUBECONFIG_BASE64=$(cat $MGMT-CLUSTER-KUBECONFIG-PATH | base64)
+
+cli add-secret map  \
+ --name "vsphere-creds" \
+ "username=${GOVC_USERNAME}" \
+ "password=${GOVC_PASSWORD}"
+
+eval "cat > ${OUTPUT_FILE} << EOF
+$(< eks/vmware-sonobuoy-test.yaml)
+EOF
+" 2> /dev/null
+```
+
+## kind
+
+The files in [kind](./kind) are meant to be run on a `kind` cluster. Directions on how to use a `kind` cluster with TestSys can be found in our [QUICKSTART](../../docs/QUICKSTART.md).
+
+### Conformance Testing on `aws-ecs` Variants
+
+```bash
+CLUSTER_NAME="x86-64-aws-ecs-1"
+OUTPUT_FILE="${CLUSTER_NAME}.yaml"
+VARIANT="aws-ecs-1"
+ARCHITECTURE="x86_64"
+AGENT_IMAGE_VERSION=$(cli --version | sed -e "s/^.* //g")
+ACCESS_KEY_ID=$(aws configure get aws_access_key_id)
+SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key)
+ECS_TEST_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ecs-test-agent:v${AGENT_IMAGE_VERSION}"
+ECS_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ecs-resource-agent:v${AGENT_IMAGE_VERSION}"
+EC2_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ec2-resource-agent:v${AGENT_IMAGE_VERSION}"
+ASSUME_ROLE="~"
+AWS_REGION="us-west-2"
+
+BOTTLEROCKET_AMI_ID=$(aws ssm get-parameter \
+  --region ${AWS_REGION} \
+  --name "/aws/service/bottlerocket/${VARIANT}/${ARCHITECTURE}/latest/image_id" \
+  --query Parameter.Value --output text)
+
+cli add-secret map  \
+ --name "aws-creds" \
+ "ACCESS_KEY_ID=${ACCESS_KEY_ID}" \
+ "SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY}"
+
+eval "cat > ${OUTPUT_FILE} << EOF
+$(< kind/ecs-test.yaml)
+EOF
+" 2> /dev/null
+```
+
+### Conformance Testing on `aws-k8s` Variants
+
+```bash
+CLUSTER_NAME="x86-64-aws-k8s-124"
+OUTPUT_FILE="${CLUSTER_NAME}.yaml"
+VARIANT="aws-k8s-1.24"
+ARCHITECTURE="x86_64"
+AGENT_IMAGE_VERSION=$(cli --version | sed -e "s/^.* //g")
+ACCESS_KEY_ID=$(aws configure get aws_access_key_id)
+SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key)
+SONOBUOY_TEST_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/sonobuoy-test-agent:v${AGENT_IMAGE_VERSION}"
+EKS_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/eks-resource-agent:v${AGENT_IMAGE_VERSION}"
+EC2_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ec2-resource-agent:v${AGENT_IMAGE_VERSION}"
+ASSUME_ROLE="~"
+AWS_REGION="us-west-2"
+SONOBUOY_MODE="quick"
+
+BOTTLEROCKET_AMI_ID=$(aws ssm get-parameter \
+  --region ${AWS_REGION} \
+  --name "/aws/service/bottlerocket/${VARIANT}/${ARCHITECTURE}/latest/image_id" \
+  --query Parameter.Value --output text)
+
+cli add-secret map  \
+ --name "aws-creds" \
+ "ACCESS_KEY_ID=${ACCESS_KEY_ID}" \
+ "SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY}"
+
+eval "cat > ${OUTPUT_FILE} << EOF
+$(< kind/sonobuoy-test.yaml)
+EOF
+" 2> /dev/null
+```
+
+### Conformance Testing on `vmware-k8s` Variants
+
+This codeblock assumes that your vSphere config file has been sourced. Specifically, the variables `GOVC_USERNAME`, `GOVC_PASSWORD`, `GOVC_DATACENTER`, `GOVC_DATASTORE`, `GOVC_URL`, `GOVC_NETWORK`, `GOVC_RESOURCE_POOL`, and `GOVC_FOLDER` need to be populated.
+
+```bash
+CONTROL_PLANE_ENDPOINT_IP=
+MGMT_CLUSTER_KUBECONFIG_PATH=
+
+CLUSTER_NAME="vmware-k8s-124"
+OUTPUT_FILE="${CLUSTER_NAME}.yaml"
+VARIANT="vmware-k8s-1.24"
+K8S_VERSION="1.24"
+AGENT_IMAGE_VERSION=$(cli --version | sed -e "s/^.* //g")
+SONOBUOY_TEST_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/sonobuoy-test-agent:v${AGENT_IMAGE_VERSION}"
+VSPHERE_K8S_CLUSTER_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/vsphere-k8s-cluster-resource-agent:v${AGENT_IMAGE_VERSION}"
+VSPHERE_VM_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/vsphere-vm-resource-agent:v${AGENT_IMAGE_VERSION}"
+ASSUME_ROLE="~"
+REGION="us-west-2"
+SONOBUOY_MODE="quick"
+VERSION="v1.11.1"
+METADATA_URL="https://updates.bottlerocket.aws/2020-07-07/${VARIANT}/x86_64"
+TARGETS_URL="https://updates.bottlerocket.aws/targets"
+OVA_NAME="bottlerocket-${VARIANT}-x86_64-${VERSION}.ova"
+MGMT_CLUSTER_KUBECONFIG_BASE64=$(cat ${MGMT_CLUSTER_KUBECONFIG_PATH} | base64)
+
+cli add-secret map  \
+ --name "vsphere-creds" \
+ "username=$GOVC_USERNAME" \
+ "password=$GOVC_PASSWORD"
+
+eval "cat > ${OUTPUT_FILE} << EOF
+$(< kind/vmware-sonobuoy-test.yaml)
+EOF
+" 2> /dev/null
+```

--- a/bottlerocket/samples/eks/ecs-migration-test.yaml
+++ b/bottlerocket/samples/eks/ecs-migration-test.yaml
@@ -1,0 +1,132 @@
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test-1-initial
+  namespace: testsys
+spec:
+  agent:
+    name: ecs-test-agent
+    image: ${ECS_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      region: \${${CLUSTER_NAME}.region}
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: []
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+---  
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test-2-migrate
+  namespace: testsys
+spec:
+  agent:
+    configuration:
+      awsRegion: ${AWS_REGION}
+      instanceIds: \${${CLUSTER_NAME}-instances.ids}
+      migrateToVersion: ${UPGRADE_VERSION}
+      tufRepo:
+        metadataUrl: ${METADATA_URL}
+        targetsUrl: ${TARGETS_URL}
+      assumeRole: ${ASSUME_ROLE}
+    image: ${MIGRATION_TEST_AGENT_IMAGE_URI}
+    name: migration-test-agent
+    keepRunning: true
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+  dependsOn: [${CLUSTER_NAME}-test-1-initial]
+---
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test-3-migrated
+  namespace: testsys
+spec:
+  agent:
+    name: ecs-test-agent
+    image: ${ECS_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      region: \${${CLUSTER_NAME}.region}
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: [${CLUSTER_NAME}-test-2-migrate]
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test-4-migrate
+  namespace: testsys
+spec:
+  agent:
+    configuration:
+      awsRegion: ${AWS_REGION}
+      instanceIds: \${${CLUSTER_NAME}-instances.ids}
+      migrateToVersion: ${STARTING_VERSION}
+      tufRepo:
+        metadataUrl: ${METADATA_URL}
+        targetsUrl: ${TARGETS_URL}
+      assumeRole: ${ASSUME_ROLE}
+    image: ${MIGRATION_TEST_AGENT_IMAGE_URI}
+    name: migration-test-agent
+    keepRunning: true
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+  dependsOn: [${CLUSTER_NAME}-test-3-migrated]
+---
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test-5-final
+  namespace: testsys
+spec:
+  agent:
+    name: ecs-test-agent
+    image: ${ECS_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      region: \${${CLUSTER_NAME}.region}
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: [${CLUSTER_NAME}-test-4-migrate]
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: testsys
+spec:
+  agent:
+    name: ecs-provider
+    image: ${ECS_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: ${CLUSTER_NAME}
+      region: ${AWS_REGION}
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: []
+  destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}-instances
+  namespace: testsys
+spec:
+  agent:
+    name: ec2-provider
+    image: ${EC2_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      clusterType: ecs
+      instanceCount: 2
+      nodeAmi: ${BOTTLEROCKET_AMI_ID}
+      region: ${AWS_REGION}
+      instanceProfileArn: \${${CLUSTER_NAME}.iamInstanceProfileArn}
+      subnetIds: \${${CLUSTER_NAME}.publicSubnetIds}
+      instanceTypes: ["m5.large"]
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: [${CLUSTER_NAME}]
+  destructionPolicy: onDeletion

--- a/bottlerocket/samples/eks/ecs-test.yaml
+++ b/bottlerocket/samples/eks/ecs-test.yaml
@@ -1,0 +1,56 @@
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test
+  namespace: testsys
+spec:
+  agent:
+    name: ecs-test-agent
+    image: ${ECS_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      region: \${${CLUSTER_NAME}.region}
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: []
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: testsys
+spec:
+  agent:
+    name: ecs-provider
+    image: ${ECS_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: ${CLUSTER_NAME}
+      region: ${AWS_REGION}
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: []
+  destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}-instances
+  namespace: testsys
+spec:
+  agent:
+    name: ec2-provider
+    image: ${EC2_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      clusterType: ecs
+      instanceCount: 2
+      nodeAmi: ${BOTTLEROCKET_AMI_ID}
+      region: ${AWS_REGION}
+      instanceProfileArn: \${${CLUSTER_NAME}.iamInstanceProfileArn}
+      subnetIds: \${${CLUSTER_NAME}.publicSubnetIds}
+      instanceTypes: ["m5.large"]
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: [${CLUSTER_NAME}]
+  destructionPolicy: onDeletion

--- a/bottlerocket/samples/eks/sonobuoy-migration-test.yaml
+++ b/bottlerocket/samples/eks/sonobuoy-migration-test.yaml
@@ -1,0 +1,143 @@
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test-1-initial
+  namespace: testsys
+spec:
+  agent:
+    name: sonobuoy-test-agent
+    image: ${SONOBUOY_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      region: \${${CLUSTER_NAME}.region}
+      assumeRole: ${ASSUME_ROLE}
+      kubeconfigBase64: \${${CLUSTER_NAME}.encodedKubeconfig}
+      plugin: "e2e"
+      mode: "quick"
+  dependsOn: []
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+---  
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test-2-migrate
+  namespace: testsys
+spec:
+  agent:
+    configuration:
+      awsRegion: ${AWS_REGION}
+      instanceIds: \${${CLUSTER_NAME}-instances.ids}
+      migrateToVersion: ${UPGRADE_VERSION}
+      tufRepo:
+        metadataUrl: ${METADATA_URL}
+        targetsUrl: ${TARGETS_URL}
+      assumeRole: ${ASSUME_ROLE}
+    image: ${MIGRATION_TEST_AGENT_IMAGE_URI}
+    name: migration-test-agent
+    keepRunning: true
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+  dependsOn: [${CLUSTER_NAME}-test-1-initial]
+---
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test-3-migrated
+  namespace: testsys
+spec:
+  agent:
+    name: sonobuoy-test-agent
+    image: ${SONOBUOY_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      region: \${${CLUSTER_NAME}.region}
+      assumeRole: ${ASSUME_ROLE}
+      kubeconfigBase64: \${${CLUSTER_NAME}.encodedKubeconfig}
+      plugin: "e2e"
+      mode: "quick"
+  dependsOn: [${CLUSTER_NAME}-test-2-migrate]
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test-4-migrate
+  namespace: testsys
+spec:
+  agent:
+    configuration:
+      awsRegion: ${AWS_REGION}
+      instanceIds: \${${CLUSTER_NAME}-instances.ids}
+      migrateToVersion: ${STARTING_VERSION}
+      tufRepo:
+        metadataUrl: ${METADATA_URL}
+        targetsUrl: ${TARGETS_URL}
+      assumeRole: ${ASSUME_ROLE}
+    image: ${MIGRATION_TEST_AGENT_IMAGE_URI}
+    name: migration-test-agent
+    keepRunning: true
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+  dependsOn: [${CLUSTER_NAME}-test-3-migrated]
+---
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test-5-final
+  namespace: testsys
+spec:
+  agent:
+    name: sonobuoy-test-agent
+    image: ${SONOBUOY_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      region: \${${CLUSTER_NAME}.region}
+      assumeRole: ${ASSUME_ROLE}
+      kubeconfigBase64: \${${CLUSTER_NAME}.encodedKubeconfig}
+      plugin: "e2e"
+      mode: "quick"
+  dependsOn: [${CLUSTER_NAME}-test-4-migrate]
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: testsys
+spec:
+  agent:
+    name: eks-provider
+    image: ${EKS_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      creationPolicy: ifNotExists
+      cluster_name: ${CLUSTER_NAME}
+      region: ${AWS_REGION}
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: []
+  destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}-instances
+  namespace: testsys
+spec:
+  agent:
+    name: ec2-provider
+    image: ${EC2_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      clusterType: eks
+      instanceCount: 2
+      instanceProfileArn: \${${CLUSTER_NAME}.iamInstanceProfileArn}
+      nodeAmi: ${BOTTLEROCKET_AMI_ID}
+      region: ${AWS_REGION}
+      subnetIds: \${${CLUSTER_NAME}.publicSubnetIds}
+      instanceTypes: ["m5.large"]
+      assumeRole: ${ASSUME_ROLE}
+      endpoint: \${${CLUSTER_NAME}.endpoint}
+      certificate: \${${CLUSTER_NAME}.certificate}
+      clusterDnsIp: \${${CLUSTER_NAME}.clusterDnsIp}
+      securityGroups: \${${CLUSTER_NAME}.securityGroups}
+  dependsOn: [${CLUSTER_NAME}]
+  destructionPolicy: onDeletion

--- a/bottlerocket/samples/eks/sonobuoy-test.yaml
+++ b/bottlerocket/samples/eks/sonobuoy-test.yaml
@@ -1,0 +1,63 @@
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test
+  namespace: testsys
+spec:
+  agent:
+    name: sonobuoy-test-agent
+    image: ${SONOBUOY_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      region: \${${CLUSTER_NAME}.region}
+      assumeRole: ${ASSUME_ROLE}
+      kubeconfigBase64: \${${CLUSTER_NAME}.encodedKubeconfig}
+      plugin: "e2e"
+      mode: ${SONOBUOY_MODE}
+  dependsOn: []
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: testsys
+spec:
+  agent:
+    name: eks-provider
+    image: ${EKS_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      creationPolicy: ifNotExists
+      cluster_name: ${CLUSTER_NAME}
+      region: ${AWS_REGION}
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: []
+  destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}-instances
+  namespace: testsys
+spec:
+  agent:
+    name: ec2-provider
+    image: ${EC2_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      clusterType: eks
+      instanceCount: 2
+      instanceProfileArn: \${${CLUSTER_NAME}.iamInstanceProfileArn}
+      nodeAmi: ${BOTTLEROCKET_AMI_ID}
+      region: ${AWS_REGION}
+      subnetIds: \${${CLUSTER_NAME}.publicSubnetIds}
+      instanceTypes: ["m5.large"]
+      assumeRole: ${ASSUME_ROLE}
+      endpoint: \${${CLUSTER_NAME}.endpoint}
+      certificate: \${${CLUSTER_NAME}.certificate}
+      clusterDnsIp: \${${CLUSTER_NAME}.clusterDnsIp}
+      securityGroups: \${${CLUSTER_NAME}.securityGroups}
+  dependsOn: [${CLUSTER_NAME}]
+  destructionPolicy: onDeletion

--- a/bottlerocket/samples/eks/vmware-migration-test.yaml
+++ b/bottlerocket/samples/eks/vmware-migration-test.yaml
@@ -1,0 +1,168 @@
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test-1-initial
+  namespace: testsys
+spec:
+  agent:
+    name: sonobuoy-test-agent
+    image: ${SONOBUOY_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      assumeRole: ${ASSUME_ROLE}
+      kubeconfigBase64: \${${CLUSTER_NAME}.encodedKubeconfig}
+      plugin: "e2e"
+      mode: "quick"
+    secrets:
+      vsphereCredentials: vsphere-creds
+  dependsOn: []
+  resources: [${CLUSTER_NAME}-vms, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test-2-migrate
+  namespace: testsys
+spec:
+  agent:
+    configuration:
+      awsRegion: ${REGION}
+      instanceIds: \${${CLUSTER_NAME}-vms.ids}
+      migrateToVersion: ${UPGRADE_VERSION}
+      tufRepo:
+        metadataUrl: ${METADATA_URL}
+        targetsUrl: ${TARGETS_URL}
+      assumeRole: ${ASSUME_ROLE}
+    secrets:
+      vsphereCredentials: vsphere-creds
+    image: ${MIGRATION_TEST_AGENT_IMAGE_URI}
+    name: migration-test-agent
+    keepRunning: true
+  resources: [${CLUSTER_NAME}-vms, ${CLUSTER_NAME}]
+  dependsOn: [${CLUSTER_NAME}-test-1-initial]
+---
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test-3-migrated
+  namespace: testsys
+spec:
+  agent:
+    name: sonobuoy-test-agent
+    image: ${SONOBUOY_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      assumeRole: ${ASSUME_ROLE}
+      kubeconfigBase64: \${${CLUSTER_NAME}.encodedKubeconfig}
+      plugin: "e2e"
+      mode: "quick"
+    secrets:
+      vsphereCredentials: vsphere-creds
+  dependsOn: [${CLUSTER_NAME}-test-2-migrate]
+  resources: [${CLUSTER_NAME}-vms, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test-4-migrate
+  namespace: testsys
+spec:
+  agent:
+    configuration:
+      awsRegion: ${REGION}
+      instanceIds: \${${CLUSTER_NAME}-vms.ids}
+      migrateToVersion: ${STARTING_VERSION}
+      tufRepo:
+        metadataUrl: ${METADATA_URL}
+        targetsUrl: ${TARGETS_URL}
+      assumeRole: ${ASSUME_ROLE}
+    secrets:
+      vsphereCredentials: vsphere-creds
+    image: ${MIGRATION_TEST_AGENT_IMAGE_URI}
+    name: migration-test-agent
+    keepRunning: true
+  resources: [${CLUSTER_NAME}-vms, ${CLUSTER_NAME}]
+  dependsOn: [${CLUSTER_NAME}-test-3-migrated]
+---
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test-5-final
+  namespace: testsys
+spec:
+  agent:
+    name: sonobuoy-test-agent
+    image: ${SONOBUOY_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      assumeRole: ${ASSUME_ROLE}
+      kubeconfigBase64: \${${CLUSTER_NAME}.encodedKubeconfig}
+      plugin: "e2e"
+      mode: "quick"
+    secrets:
+      vsphereCredentials: vsphere-creds
+  dependsOn: [${CLUSTER_NAME}-test-4-migrate]
+  resources: [${CLUSTER_NAME}-vms, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: testsys
+spec:
+  agent:
+    name: agent
+    image: ${VSPHERE_K8S_CLUSTER_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      controlPlaneEndpointIp: ${CONTROL_PLANE_ENDPOINT_IP}
+      creationPolicy: ifNotExists
+      mgmtClusterKubeconfigBase64: ${MGMT_CLUSTER_KUBECONFIG_BASE64}
+      name: ${CLUSTER_NAME}
+      ovaName: ${OVA_NAME}
+      tufRepo:
+        metadataUrl: ${METADATA_URL}
+        targetsUrl: ${TARGETS_URL}
+      version: ${K8S_VERSION}
+      vcenterDatacenter: ${VCENTER_DATACENTER}
+      vcenterDatastore: ${VCENTER_DATASTORE}
+      vcenterHostUrl: ${VCENTER_HOST_URL}
+      vcenterNetwork: ${VCENTER_NETWORK}
+      vcenterResourcePool: ${VCENTER_RESOURCE_POOL}
+      vcenterWorkloadFolder: ${VCENTER_WORKLOAD_FOLDER}
+    secrets:
+      vsphereCredentials: vsphere-creds
+  dependsOn: []
+  destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}-vms
+  namespace: testsys
+spec:
+  agent:
+    name: agent
+    image: ${VSPHERE_VM_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      assumeRole: ${ASSUME_ROLE}
+      cluster:
+        controlPlaneEndpointIp: "\${${CLUSTER_NAME}.endpoint}"
+        kubeconfigBase64: "\${${CLUSTER_NAME}.encodedKubeconfig}"
+        name: "\${${CLUSTER_NAME}.clusterName}"
+      ovaName: ${OVA_NAME}
+      tufRepo:
+        metadataUrl: ${METADATA_URL}
+        targetsUrl: ${TARGETS_URL}
+      vcenterDatacenter: ${VCENTER_DATACENTER}
+      vcenterDatastore: ${VCENTER_DATASTORE}
+      vcenterHostUrl: ${VCENTER_HOST_URL}
+      vcenterNetwork: ${VCENTER_NETWORK}
+      vcenterResourcePool: ${VCENTER_RESOURCE_POOL}
+      vcenterWorkloadFolder: ${VCENTER_WORKLOAD_FOLDER}
+      vmCount: 2
+    secrets:
+      vsphereCredentials: vsphere-creds
+  dependsOn: [${CLUSTER_NAME}]
+  destructionPolicy: onDeletion

--- a/bottlerocket/samples/eks/vmware-sonobuoy-test.yaml
+++ b/bottlerocket/samples/eks/vmware-sonobuoy-test.yaml
@@ -1,0 +1,82 @@
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test
+  namespace: testsys
+spec:
+  agent:
+    name: sonobuoy-test-agent
+    image: ${SONOBUOY_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      assumeRole: ${ASSUME_ROLE}
+      kubeconfigBase64: \${${CLUSTER_NAME}.encodedKubeconfig}
+      plugin: "e2e"
+      mode: ${SONOBUOY_MODE}
+    secrets:
+      vsphereCredentials: vsphere-creds
+  dependsOn: []
+  resources: [${CLUSTER_NAME}-vms, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: testsys
+spec:
+  agent:
+    name: agent
+    image: ${VSPHERE_K8S_CLUSTER_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      controlPlaneEndpointIp: ${CONTROL_PLANE_ENDPOINT_IP}
+      creationPolicy: ifNotExists
+      mgmtClusterKubeconfigBase64: ${MGMT_CLUSTER_KUBECONFIG_BASE64}
+      name: ${CLUSTER_NAME}
+      ovaName: ${OVA_NAME}
+      tufRepo:
+        metadataUrl: ${METADATA_URL}
+        targetsUrl: ${TARGETS_URL}
+      version: ${K8S_VERSION}
+      vcenterDatacenter: ${VCENTER_DATACENTER}
+      vcenterDatastore: ${VCENTER_DATASTORE}
+      vcenterHostUrl: ${VCENTER_HOST_URL}
+      vcenterNetwork: ${VCENTER_NETWORK}
+      vcenterResourcePool: ${VCENTER_RESOURCE_POOL}
+      vcenterWorkloadFolder: ${VCENTER_WORKLOAD_FOLDER}
+    secrets:
+      vsphereCredentials: vsphere-creds
+  dependsOn: []
+  destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}-vms
+  namespace: testsys
+spec:
+  agent:
+    name: agent
+    image: ${VSPHERE_VM_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      assumeRole: ${ASSUME_ROLE}
+      cluster:
+        controlPlaneEndpointIp: "\${${CLUSTER_NAME}.endpoint}"
+        kubeconfigBase64: "\${${CLUSTER_NAME}.encodedKubeconfig}"
+        name: "\${${CLUSTER_NAME}.clusterName}"
+      ovaName: ${OVA_NAME}
+      tufRepo:
+        metadataUrl: ${METADATA_URL}
+        targetsUrl: ${TARGETS_URL}
+      vcenterDatacenter: ${VCENTER_DATACENTER}
+      vcenterDatastore: ${VCENTER_DATASTORE}
+      vcenterHostUrl: ${VCENTER_HOST_URL}
+      vcenterNetwork: ${VCENTER_NETWORK}
+      vcenterResourcePool: ${VCENTER_RESOURCE_POOL}
+      vcenterWorkloadFolder: ${VCENTER_WORKLOAD_FOLDER}
+      vmCount: 2
+    secrets:
+      vsphereCredentials: vsphere-creds
+  dependsOn: [${CLUSTER_NAME}]
+  destructionPolicy: onDeletion

--- a/bottlerocket/samples/kind/ecs-test.yaml
+++ b/bottlerocket/samples/kind/ecs-test.yaml
@@ -1,0 +1,63 @@
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test
+  namespace: testsys
+spec:
+  agent:
+    name: ecs-test-agent
+    image: ${ECS_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      region: \${${CLUSTER_NAME}.region}
+      subnets: \${${CLUSTER_NAME}.publicSubnetIds}
+      assumeRole: ${ASSUME_ROLE}
+    secrets:
+      awsCredentials: aws-creds
+  dependsOn: []
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: testsys
+spec:
+  agent:
+    name: ecs-provider
+    image: ${ECS_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: ${CLUSTER_NAME}
+      region: ${AWS_REGION}
+      assumeRole: ${ASSUME_ROLE}
+    secrets:
+      awsCredentials: aws-creds
+  dependsOn: []
+  destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}-instances
+  namespace: testsys
+spec:
+  agent:
+    name: ec2-provider
+    image: ${EC2_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      clusterType: ecs
+      instanceCount: 2
+      nodeAmi: ${BOTTLEROCKET_AMI_ID}
+      region: ${AWS_REGION}
+      instanceProfileArn: \${${CLUSTER_NAME}.iamInstanceProfileArn}
+      subnetIds: \${${CLUSTER_NAME}.publicSubnetIds}
+      instanceTypes: ["m5.large"]
+      assumeRole: ${ASSUME_ROLE}
+    secrets:
+      awsCredentials: aws-creds
+  dependsOn: [${CLUSTER_NAME}]
+  destructionPolicy: onDeletion

--- a/bottlerocket/samples/kind/sonobuoy-test.yaml
+++ b/bottlerocket/samples/kind/sonobuoy-test.yaml
@@ -1,0 +1,70 @@
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test
+  namespace: testsys
+spec:
+  agent:
+    name: sonobuoy-test-agent
+    image: ${SONOBUOY_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      region: \${${CLUSTER_NAME}.region}
+      subnets: \${${CLUSTER_NAME}.publicSubnetIds}
+      assumeRole: ${ASSUME_ROLE}
+      kubeconfigBase64: \${${CLUSTER_NAME}.encodedKubeconfig}
+      plugin: "e2e"
+      mode: ${SONOBUOY_MODE}
+    secrets:
+      awsCredentials: aws-creds
+  dependsOn: []
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: testsys
+spec:
+  agent:
+    name: eks-provider
+    image: ${EKS_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      creationPolicy: ifNotExists
+      cluster_name: ${CLUSTER_NAME}
+      region: ${AWS_REGION}
+      assumeRole: ${ASSUME_ROLE}
+    secrets:
+      awsCredentials: aws-creds
+  dependsOn: []
+  destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}-instances
+  namespace: testsys
+spec:
+  agent:
+    name: ec2-provider
+    image: ${EC2_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      clusterType: eks
+      instanceCount: 2
+      instanceProfileArn: \${${CLUSTER_NAME}.iamInstanceProfileArn}
+      nodeAmi: ${BOTTLEROCKET_AMI_ID}
+      region: ${AWS_REGION}
+      subnetIds: \${${CLUSTER_NAME}.publicSubnetIds}
+      instanceTypes: ["m5.large"]
+      assumeRole: ${ASSUME_ROLE}
+      endpoint: \${${CLUSTER_NAME}.endpoint}
+      certificate: \${${CLUSTER_NAME}.certificate}
+      clusterDnsIp: \${${CLUSTER_NAME}.clusterDnsIp}
+      securityGroups: \${${CLUSTER_NAME}.securityGroups}
+    secrets:
+      awsCredentials: aws-creds
+  dependsOn: [${CLUSTER_NAME}]
+  destructionPolicy: onDeletion

--- a/bottlerocket/samples/kind/vmware-sonobuoy-test.yaml
+++ b/bottlerocket/samples/kind/vmware-sonobuoy-test.yaml
@@ -1,0 +1,82 @@
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test
+  namespace: testsys
+spec:
+  agent:
+    name: sonobuoy-test-agent
+    image: ${SONOBUOY_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      assumeRole: ${ASSUME_ROLE}
+      kubeconfigBase64: \${${CLUSTER_NAME}.encodedKubeconfig}
+      plugin: "e2e"
+      mode: ${SONOBUOY_MODE}
+    secrets:
+      vsphereCredentials: vsphere-creds
+  dependsOn: []
+  resources: [${CLUSTER_NAME}-vms, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: testsys
+spec:
+  agent:
+    name: agent
+    image: ${VSPHERE_K8S_CLUSTER_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      controlPlaneEndpointIp: ${CONTROL_PLANE_ENDPOINT_IP}
+      creationPolicy: ifNotExists
+      mgmtClusterKubeconfigBase64: ${MGMT_CLUSTER_KUBECONFIG_BASE64}
+      name: ${CLUSTER_NAME}
+      ovaName: ${OVA_NAME}
+      tufRepo:
+        metadataUrl: ${METADATA_URL}
+        targetsUrl: ${TARGETS_URL}
+      version: ${K8S_VERSION}
+      vcenterDatacenter: ${VCENTER_DATACENTER}
+      vcenterDatastore: ${VCENTER_DATASTORE}
+      vcenterHostUrl: ${VCENTER_HOST_URL}
+      vcenterNetwork: ${VCENTER_NETWORK}
+      vcenterResourcePool: ${VCENTER_RESOURCE_POOL}
+      vcenterWorkloadFolder: ${VCENTER_WORKLOAD_FOLDER}
+    secrets:
+      vsphereCredentials: vsphere-creds
+  dependsOn: []
+  destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}-vms
+  namespace: testsys
+spec:
+  agent:
+    name: agent
+    image: ${VSPHERE_VM_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      assumeRole: ${ASSUME_ROLE}
+      cluster:
+        controlPlaneEndpointIp: "\${${CLUSTER_NAME}.endpoint}"
+        kubeconfigBase64: "\${${CLUSTER_NAME}.encodedKubeconfig}"
+        name: "\${${CLUSTER_NAME}.clusterName}"
+      ovaName: ${OVA_NAME}
+      tufRepo:
+        metadataUrl: ${METADATA_URL}
+        targetsUrl: ${TARGETS_URL}
+      vcenterDatacenter: ${VCENTER_DATACENTER}
+      vcenterDatastore: ${VCENTER_DATASTORE}
+      vcenterHostUrl: ${VCENTER_HOST_URL}
+      vcenterNetwork: ${VCENTER_NETWORK}
+      vcenterResourcePool: ${VCENTER_RESOURCE_POOL}
+      vcenterWorkloadFolder: ${VCENTER_WORKLOAD_FOLDER}
+      vmCount: 2
+    secrets:
+      vsphereCredentials: vsphere-creds
+  dependsOn: [${CLUSTER_NAME}]
+  destructionPolicy: onDeletion


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Added sample YAML files to be used with `cli`, as well as a runbook that shows how to populate and use the files.

**Testing done:**

- Populating and running `ecs-migration-test.yaml`:
```
 NAME                                TYPE              STATE              PASSED          SKIPPED          FAILED
 aws-ecs-1-initial                   Test              pass               1               0                0
 aws-ecs-2-migrate                   Test              pass               2               0                0
 aws-ecs-3-migrated                  Test              pass               1               0                0
 aws-ecs-4-migrate                   Test              pass               2               0                0
 aws-ecs-5-final                     Test              pass               1               0                0
 external-cluster                    Resource          completed
 external-cluster-instances          Resource          completed
```
- Populating and running `ecs-test.yaml`:
```
 NAME                            TYPE               STATE               PASSED           SKIPPED          FAILED
 aws-ecs                         Test               pass                1                0                0
 external-cluster                Resource           completed
 external-cluster-instances      Resource           completed
```
- Populating and running `sonobuoy-migration-test.yaml`:
```
 NAME                            TYPE               STATE               PASSED           SKIPPED          FAILED
 aws-k8s-1-initial               Test               pass                1                5772             0
 aws-k8s-2-migrate               Test               pass                2                0                0
 aws-k8s-3-migrated              Test               pass                1                5772             0
 aws-k8s-4-migrate               Test               pass                2                0                0
 aws-k8s-5-final                 Test               pass                1                5772             0
 external-cluster                Resource           completed
 external-cluster-instances      Resource           completed
```
- Populating and running `sonobuoy-test.yaml` with SONOBUOY-MODE "quick":
```
 NAME                            TYPE               STATE               PASSED           SKIPPED          FAILED
 aws-k8s                         Test               pass                1                5772             0
 external-cluster                Resource           completed
 external-cluster-instances      Resource           completed
```
- Populating and running `vmware-migration-test.yaml`:
```
 NAME                                TYPE              STATE              PASSED          SKIPPED          FAILED
 vmware-k8s-1-initial                Test              pass               1               5772             0
 vmware-k8s-2-migrate                Test              pass               2               0                0
 vmware-k8s-3-migrated               Test              pass               1               5772             0
 vmware-k8s-4-migrate                Test              pass               2               0                0
 vmware-k8s-5-final                  Test              pass               1               5772             0
 vmware-cluster                      Resource          completed
 vmware-cluster-vms                  Resource          completed
```
- Populating and running `vmware-sonobuoy-test.yaml`:
```
 NAME                            TYPE               STATE               PASSED           SKIPPED          FAILED
 vmware-k8s                      Test               pass                1                5772             0
 vmware-cluster                  Resource           completed
 vmware-cluster-vms              Resource           completed
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
