### PR TITLE
TestManager: Simplify code for `cargo make test`

### DIFF
--- a/model/src/test_manager/manager.rs
+++ b/model/src/test_manager/manager.rs
@@ -444,9 +444,15 @@ impl TestManager {
 /// Takes a path to a yaml manifest of testsys crds (`Test` and `Resource`) and creates a set of
 /// `Crd`s through deserialization. These can be added using `TestManager::create_object`
 pub fn read_manifest(path: &Path) -> Result<Vec<Crd>> {
-    let mut crds = Vec::new();
     // Create the resource objects from its path.
     let manifest_string = std::fs::read_to_string(path).context(error::FileSnafu { path })?;
+    convert_manifest(manifest_string)
+}
+
+/// Takes a `String` containing a yaml manifest of testsys crds (`Test` and `Resource`) and creates
+/// a set of `Crd`s through deserialization. These can be added using `TestManager::create_object`
+pub fn convert_manifest(manifest_string: String) -> Result<Vec<Crd>> {
+    let mut crds = Vec::new();
     for crd_doc in serde_yaml::Deserializer::from_str(&manifest_string) {
         let value = serde_yaml::Value::deserialize(crd_doc).context(error::SerdeYamlSnafu {
             action: "deserialize manifest",

--- a/model/src/test_manager/manager.rs
+++ b/model/src/test_manager/manager.rs
@@ -317,7 +317,7 @@ impl TestManager {
         &self,
         test_name: S,
         follow: bool,
-    ) -> Result<impl Stream<Item = core::result::Result<Bytes, Error>>>
+    ) -> Result<impl Stream<Item = Result<Bytes>>>
     where
         S: Into<String>,
     {
@@ -334,6 +334,13 @@ impl TestManager {
             .context(error::KubeSnafu {
                 action: "stream logs",
             })
+            .map(|stream| {
+                stream.map(|res| {
+                    res.context(error::KubeSnafu {
+                        action: "stream logs",
+                    })
+                })
+            })
     }
 
     /// Retrieve the logs of a resource.
@@ -342,7 +349,7 @@ impl TestManager {
         resource_name: S,
         state: ResourceState,
         follow: bool,
-    ) -> Result<impl Stream<Item = core::result::Result<Bytes, Error>>>
+    ) -> Result<impl Stream<Item = Result<Bytes>>>
     where
         S: Into<String>,
     {
@@ -358,6 +365,13 @@ impl TestManager {
             .await
             .context(error::KubeSnafu {
                 action: "stream logs",
+            })
+            .map(|stream| {
+                stream.map(|res| {
+                    res.context(error::KubeSnafu {
+                        action: "stream logs",
+                    })
+                })
             })
     }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

TestManager: convert String manifest to CRDs

Allows users to convert a string to a manifest instead of requiring a file path. This will clean up the custom tests in [Bottlerocket](https://github.com/bottlerocket-os/bottlerocket/blob/38c4137607dfe08e7000b295338295fe85631d3f/tools/testsys/src/crds.rs#L385-L405)

TestManager: Convert the log error to model

The log stream originally returned `kube::error`. This required `kube-client` to be a dependency of [testsys](https://github.com/bottlerocket-os/bottlerocket/blob/38c4137607dfe08e7000b295338295fe85631d3f/tools/testsys/Cargo.toml#L21) in the monorepo. After this change, we can remove that dependency.

**Testing done:**

Actions pass.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
