### PR TITLE
agents: use camelCase for EksctlConfig

### DIFF
--- a/bottlerocket/samples/eks/k8s-workload-test.yaml
+++ b/bottlerocket/samples/eks/k8s-workload-test.yaml
@@ -29,7 +29,7 @@ spec:
     keepRunning: true
     configuration:
       creationPolicy: ifNotExists
-      cluster_name: ${CLUSTER_NAME}
+      clusterName: ${CLUSTER_NAME}
       region: ${AWS_REGION}
       assumeRole: ${ASSUME_ROLE}
   dependsOn: []

--- a/bottlerocket/samples/eks/sonobuoy-migration-test.yaml
+++ b/bottlerocket/samples/eks/sonobuoy-migration-test.yaml
@@ -109,7 +109,7 @@ spec:
     keepRunning: true
     configuration:
       creationPolicy: ifNotExists
-      cluster_name: ${CLUSTER_NAME}
+      clusterName: ${CLUSTER_NAME}
       region: ${AWS_REGION}
       assumeRole: ${ASSUME_ROLE}
   dependsOn: []

--- a/bottlerocket/samples/eks/sonobuoy-test.yaml
+++ b/bottlerocket/samples/eks/sonobuoy-test.yaml
@@ -29,7 +29,7 @@ spec:
     keepRunning: true
     configuration:
       creationPolicy: ifNotExists
-      cluster_name: ${CLUSTER_NAME}
+      clusterName: ${CLUSTER_NAME}
       region: ${AWS_REGION}
       assumeRole: ${ASSUME_ROLE}
   dependsOn: []

--- a/bottlerocket/samples/kind/k8s-workload-test.yaml
+++ b/bottlerocket/samples/kind/k8s-workload-test.yaml
@@ -31,7 +31,7 @@ spec:
     keepRunning: true
     configuration:
       creationPolicy: ifNotExists
-      cluster_name: ${CLUSTER_NAME}
+      clusterName: ${CLUSTER_NAME}
       region: ${AWS_REGION}
       assumeRole: ${ASSUME_ROLE}
     secrets:

--- a/bottlerocket/samples/kind/sonobuoy-test.yaml
+++ b/bottlerocket/samples/kind/sonobuoy-test.yaml
@@ -32,7 +32,7 @@ spec:
     keepRunning: true
     configuration:
       creationPolicy: ifNotExists
-      cluster_name: ${CLUSTER_NAME}
+      clusterName: ${CLUSTER_NAME}
       region: ${AWS_REGION}
       assumeRole: ${ASSUME_ROLE}
     secrets:

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -109,11 +109,11 @@ pub struct EksClusterConfig {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(untagged, rename_all = "camelCase")]
+#[serde(untagged)]
 pub enum EksctlConfig {
-    File {
-        encoded_config: String,
-    },
+    #[serde(rename_all = "camelCase")]
+    File { encoded_config: String },
+    #[serde(rename_all = "camelCase")]
     Args {
         cluster_name: String,
         region: Option<String>,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Fixes a bug where eksctl configs were snake_case instead of camelCase

**Testing done:**

```
#[test]
fn t() {
    let e = EksctlConfig::File {
        encoded_config: "foo".to_string(),
    };
    println!("{}", serde_yaml::to_string(&e).unwrap());
}
```

```
encodedConfig: foo
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
