### PR TITLE
TestManager: Block on uninstall for namespace

### DIFF
--- a/model/src/test_manager/manager.rs
+++ b/model/src/test_manager/manager.rs
@@ -152,7 +152,8 @@ impl TestManager {
 
     /// Uninstall testsys from a cluster.
     pub async fn uninstall(&self) -> Result<()> {
-        self.uninstall_testsys().await
+        self.uninstall_testsys().await?;
+        self.wait_for_namespace_deletion().await
     }
 
     /// Restart a crd object by deleting the crd from the cluster and adding a copy of it with its


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #703 

**Description of changes:**

Uninstall blocks until the `testsys` namespace is cleaned up.

**Testing done:**

Verify that `cli uninstall` immediately followed by `cli install` works.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
