### PR TITLE
samples: added workload agent files

### DIFF
--- a/bottlerocket/agents/src/bin/k8s-workload-agent/main.rs
+++ b/bottlerocket/agents/src/bin/k8s-workload-agent/main.rs
@@ -6,7 +6,7 @@ It expects to be run in a pod launched by the TestSys controller.
 You can configure the workload agent to run different types of plugins and tests.
 See `WorkloadConfig` for the different configuration values.
 
-To build the container for the workload test agent, run `make k8s-workload-agent-image` from the
+To build the container for the workload test agent, run `make k8s-workload-agent` from the
 root directory of this repository.
 
 Here is an example manifest for deploying the test definition for the workload test agent to a K8s cluster:
@@ -21,9 +21,10 @@ spec:
   agent:
     configuration:
       kubeconfigBase64: <Base64 encoded kubeconfig for the test cluster workload runs the tests in>
-      plugins:
+      tests:
       - name: nvidia-workload
         image: testsys-nvidia-workload-test:v0.0.3
+        gpu: false
     image: <your k8s-workload-agent image URI>
     name: workload-test-agent
     keepRunning: true

--- a/bottlerocket/samples/RUNBOOK.md
+++ b/bottlerocket/samples/RUNBOOK.md
@@ -69,6 +69,37 @@ EOF
 " 2> /dev/null
 ```
 
+### Workload Testing on `aws-ecs` Variants
+
+_Note_: An example of a workload test that can be used with the `ecs-workload-agent` is the `nvidia-smoke` test. See the `nvidia-smoke` [README.md](../tests/workload/nvidia-smoke/README.md) for instructions on how to build and use its image.
+
+```bash
+CLUSTER_NAME="x86-64-aws-ecs-1-nvidia"
+OUTPUT_FILE="${CLUSTER_NAME}.yaml"
+VARIANT="aws-ecs-1-nvidia"
+ARCHITECTURE="x86_64"
+AGENT_IMAGE_VERSION=$(cli --version | sed -e "s/^.* //g")
+ECS_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ecs-resource-agent:v${AGENT_IMAGE_VERSION}"
+EC2_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ec2-resource-agent:v${AGENT_IMAGE_VERSION}"
+ECS_WORKLOAD_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ecs-workload-agent:v${AGENT_IMAGE_VERSION}"
+ASSUME_ROLE="~"
+AWS_REGION="us-west-2"
+WORKLOAD_TEST_NAME=
+WORKLOAD_TEST_IMAGE_URI=
+GPU="true"
+INSTANCE_TYPES=$(if [ $GPU = "true" ]; then echo "[\"g4dn.xlarge\"]"; else echo "[\"m5.large\"]"; fi)
+
+BOTTLEROCKET_AMI_ID=$(aws ssm get-parameter \
+  --region ${AWS_REGION} \
+  --name "/aws/service/bottlerocket/${VARIANT}/${ARCHITECTURE}/latest/image_id" \
+  --query Parameter.Value --output text)
+
+eval "cat > ${OUTPUT_FILE} << EOF
+$(< eks/ecs-workload-test.yaml)
+EOF
+" 2> /dev/null
+```
+
 ### Migration Testing on `aws-k8s` Variants
 
 ```bash
@@ -121,6 +152,37 @@ BOTTLEROCKET_AMI_ID=$(aws ssm get-parameter \
 
 eval "cat > ${OUTPUT_FILE} << EOF
 $(< eks/sonobuoy-test.yaml)
+EOF
+" 2> /dev/null
+```
+
+### Workload Testing on `aws-k8s` Variants
+
+_Note_: An example of a workload test that can be used with the `k8s-workload-agent` is the `nvidia-smoke` test. See the `nvidia-smoke` [README.md](../tests/workload/nvidia-smoke/README.md) for instructions on how to build and use its image.
+
+```bash
+CLUSTER_NAME="x86-64-aws-k8s-124-nvidia"
+OUTPUT_FILE="${CLUSTER_NAME}.yaml"
+VARIANT="aws-k8s-1.24-nvidia"
+ARCHITECTURE="x86_64"
+AGENT_IMAGE_VERSION=$(cli --version | sed -e "s/^.* //g")
+K8S_WORKLOAD_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/k8s-workload-agent:v${AGENT_IMAGE_VERSION}"
+EKS_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/eks-resource-agent:v${AGENT_IMAGE_VERSION}"
+EC2_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ec2-resource-agent:v${AGENT_IMAGE_VERSION}"
+ASSUME_ROLE="~"
+AWS_REGION="us-west-2"
+WORKLOAD_TEST_NAME=
+WORKLOAD_TEST_IMAGE_URI=
+GPU="true"
+INSTANCE_TYPES=$(if [ $GPU = "true" ]; then echo "[\"g4dn.xlarge\"]"; else echo "[\"m5.large\"]"; fi)
+
+BOTTLEROCKET_AMI_ID=$(aws ssm get-parameter \
+  --region ${AWS_REGION} \
+  --name "/aws/service/bottlerocket/${VARIANT}/${ARCHITECTURE}/latest/image_id" \
+  --query Parameter.Value --output text)
+
+eval "cat > ${OUTPUT_FILE} << EOF
+$(< eks/k8s-workload-test.yaml)
 EOF
 " 2> /dev/null
 ```
@@ -234,6 +296,42 @@ EOF
 " 2> /dev/null
 ```
 
+### Workload Testing on `aws-ecs` Variants
+
+_Note_: An example of a workload test that can be used with the `ecs-workload-agent` is the `nvidia-smoke` test. See the `nvidia-smoke` [README.md](../tests/workload/nvidia-smoke/README.md) for instructions on how to build and use its image.
+
+```bash
+CLUSTER_NAME="x86-64-aws-ecs-1-nvidia"
+OUTPUT_FILE="${CLUSTER_NAME}.yaml"
+VARIANT="aws-ecs-1-nvidia"
+ARCHITECTURE="x86_64"
+AGENT_IMAGE_VERSION=$(cli --version | sed -e "s/^.* //g")
+ECS_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ecs-resource-agent:v${AGENT_IMAGE_VERSION}"
+EC2_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ec2-resource-agent:v${AGENT_IMAGE_VERSION}"
+ECS_WORKLOAD_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ecs-workload-agent:v${AGENT_IMAGE_VERSION}"
+ASSUME_ROLE="~"
+AWS_REGION="us-west-2"
+WORKLOAD_TEST_NAME=
+WORKLOAD_TEST_IMAGE_URI=
+GPU="true"
+INSTANCE_TYPES=$(if [ $GPU = "true" ]; then echo "[\"g4dn.xlarge\"]"; else echo "[\"m5.large\"]"; fi)
+
+BOTTLEROCKET_AMI_ID=$(aws ssm get-parameter \
+  --region ${AWS_REGION} \
+  --name "/aws/service/bottlerocket/${VARIANT}/${ARCHITECTURE}/latest/image_id" \
+  --query Parameter.Value --output text)
+
+cli add-secret map  \
+ --name "aws-creds" \
+ "ACCESS_KEY_ID=${ACCESS_KEY_ID}" \
+ "SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY}"
+
+eval "cat > ${OUTPUT_FILE} << EOF
+$(< kind/ecs-workload-test.yaml)
+EOF
+" 2> /dev/null
+```
+
 ### Conformance Testing on `aws-k8s` Variants
 
 ```bash
@@ -263,6 +361,42 @@ cli add-secret map  \
 
 eval "cat > ${OUTPUT_FILE} << EOF
 $(< kind/sonobuoy-test.yaml)
+EOF
+" 2> /dev/null
+```
+
+### Workload Testing on `aws-k8s` Variants
+
+_Note_: An example of a workload test that can be used with the `k8s-workload-agent` is the `nvidia-smoke` test. See the `nvidia-smoke` [README.md](../tests/workload/nvidia-smoke/README.md) for instructions on how to build and use its image.
+
+```bash
+CLUSTER_NAME="x86-64-aws-k8s-124-nvidia"
+OUTPUT_FILE="${CLUSTER_NAME}.yaml"
+VARIANT="aws-k8s-1.24-nvidia"
+ARCHITECTURE="x86_64"
+AGENT_IMAGE_VERSION=$(cli --version | sed -e "s/^.* //g")
+K8S_WORKLOAD_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/k8s-workload-agent:v${AGENT_IMAGE_VERSION}"
+EKS_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/eks-resource-agent:v${AGENT_IMAGE_VERSION}"
+EC2_RESOURCE_AGENT_IMAGE_URI="public.ecr.aws/bottlerocket-test-system/ec2-resource-agent:v${AGENT_IMAGE_VERSION}"
+ASSUME_ROLE="~"
+AWS_REGION="us-west-2"
+WORKLOAD_TEST_NAME=
+WORKLOAD_TEST_IMAGE_URI=
+GPU="true"
+INSTANCE_TYPES=$(if [ $GPU = "true" ]; then echo "[\"g4dn.xlarge\"]"; else echo "[\"m5.large\"]"; fi)
+
+BOTTLEROCKET_AMI_ID=$(aws ssm get-parameter \
+  --region ${AWS_REGION} \
+  --name "/aws/service/bottlerocket/${VARIANT}/${ARCHITECTURE}/latest/image_id" \
+  --query Parameter.Value --output text)
+
+cli add-secret map  \
+ --name "aws-creds" \
+ "ACCESS_KEY_ID=${ACCESS_KEY_ID}" \
+ "SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY}"
+
+eval "cat > ${OUTPUT_FILE} << EOF
+$(< kind/k8s-workload-test.yaml)
 EOF
 " 2> /dev/null
 ```

--- a/bottlerocket/samples/eks/ecs-workload-test.yaml
+++ b/bottlerocket/samples/eks/ecs-workload-test.yaml
@@ -1,0 +1,60 @@
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test
+  namespace: testsys 
+spec:
+  agent:
+    name: ecs-workload-agent
+    image: ${ECS_WORKLOAD_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      region: \${${CLUSTER_NAME}.region}
+      assumeRole: ${ASSUME_ROLE}
+      tests:
+      - name: ${WORKLOAD_TEST_NAME}
+        image: ${WORKLOAD_TEST_IMAGE_URI}
+        gpu: ${GPU}
+  dependsOn: []
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: testsys
+spec:
+  agent:
+    name: ecs-provider
+    image: ${ECS_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: ${CLUSTER_NAME}
+      region: ${AWS_REGION}
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: []
+  destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}-instances
+  namespace: testsys
+spec:
+  agent:
+    name: ec2-provider
+    image: ${EC2_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      clusterType: ecs
+      instanceCount: 2
+      nodeAmi: ${BOTTLEROCKET_AMI_ID}
+      region: ${AWS_REGION}
+      instanceProfileArn: \${${CLUSTER_NAME}.iamInstanceProfileArn}
+      subnetIds: \${${CLUSTER_NAME}.publicSubnetIds}
+      instanceTypes: ${INSTANCE_TYPES}
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: [${CLUSTER_NAME}]
+  destructionPolicy: onDeletion

--- a/bottlerocket/samples/eks/k8s-workload-test.yaml
+++ b/bottlerocket/samples/eks/k8s-workload-test.yaml
@@ -1,0 +1,63 @@
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test
+  namespace: testsys
+spec:
+  agent:
+    name: k8s-workload-agent
+    image: ${K8S_WORKLOAD_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      kubeconfigBase64: \${${CLUSTER_NAME}.encodedKubeconfig}
+      tests:
+      - name: ${WORKLOAD_TEST_NAME}
+        image: ${WORKLOAD_TEST_IMAGE_URI}
+        gpu: ${GPU}
+  dependsOn: []
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: testsys
+spec:
+  agent:
+    name: eks-provider
+    image: ${EKS_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      creationPolicy: ifNotExists
+      cluster_name: ${CLUSTER_NAME}
+      region: ${AWS_REGION}
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: []
+  destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}-instances
+  namespace: testsys
+spec:
+  agent:
+    name: ec2-provider
+    image: ${EC2_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      clusterType: eks
+      instanceCount: 2
+      instanceProfileArn: \${${CLUSTER_NAME}.iamInstanceProfileArn}
+      nodeAmi: ${BOTTLEROCKET_AMI_ID}
+      region: ${AWS_REGION}
+      subnetIds: \${${CLUSTER_NAME}.publicSubnetIds}
+      instanceTypes: ${INSTANCE_TYPES}
+      assumeRole: ${ASSUME_ROLE}
+      endpoint: \${${CLUSTER_NAME}.endpoint}
+      certificate: \${${CLUSTER_NAME}.certificate}
+      clusterDnsIp: \${${CLUSTER_NAME}.clusterDnsIp}
+      securityGroups: \${${CLUSTER_NAME}.securityGroups}
+  dependsOn: [${CLUSTER_NAME}]
+  destructionPolicy: onDeletion

--- a/bottlerocket/samples/kind/ecs-workload-test.yaml
+++ b/bottlerocket/samples/kind/ecs-workload-test.yaml
@@ -1,0 +1,66 @@
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test
+  namespace: testsys 
+spec:
+  agent:
+    name: ecs-workload-agent
+    image: ${ECS_WORKLOAD_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      region: \${${CLUSTER_NAME}.region}
+      assumeRole: ${ASSUME_ROLE}
+      tests:
+      - name: ${WORKLOAD_TEST_NAME}
+        image: ${WORKLOAD_TEST_IMAGE_URI}
+        gpu: ${GPU}
+    secrets:
+      awsCredentials: aws-creds
+  dependsOn: []
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: testsys
+spec:
+  agent:
+    name: ecs-provider
+    image: ${ECS_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: ${CLUSTER_NAME}
+      region: ${AWS_REGION}
+      assumeRole: ${ASSUME_ROLE}
+    secrets:
+      awsCredentials: aws-creds
+  dependsOn: []
+  destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}-instances
+  namespace: testsys
+spec:
+  agent:
+    name: ec2-provider
+    image: ${EC2_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      clusterType: ecs
+      instanceCount: 2
+      nodeAmi: ${BOTTLEROCKET_AMI_ID}
+      region: ${AWS_REGION}
+      instanceProfileArn: \${${CLUSTER_NAME}.iamInstanceProfileArn}
+      subnetIds: \${${CLUSTER_NAME}.publicSubnetIds}
+      instanceTypes: ${INSTANCE_TYPES}
+      assumeRole: ${ASSUME_ROLE}
+    secrets:
+      awsCredentials: aws-creds
+  dependsOn: [${CLUSTER_NAME}]
+  destructionPolicy: onDeletion

--- a/bottlerocket/samples/kind/k8s-workload-test.yaml
+++ b/bottlerocket/samples/kind/k8s-workload-test.yaml
@@ -1,0 +1,69 @@
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test
+  namespace: testsys
+spec:
+  agent:
+    name: k8s-workload-agent
+    image: ${K8S_WORKLOAD_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      kubeconfigBase64: \${${CLUSTER_NAME}.encodedKubeconfig}
+      tests:
+      - name: ${WORKLOAD_TEST_NAME}
+        image: ${WORKLOAD_TEST_IMAGE_URI}
+        gpu: ${GPU}
+    secrets:
+      awsCredentials: aws-creds
+  dependsOn: []
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: testsys
+spec:
+  agent:
+    name: eks-provider
+    image: ${EKS_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      creationPolicy: ifNotExists
+      cluster_name: ${CLUSTER_NAME}
+      region: ${AWS_REGION}
+      assumeRole: ${ASSUME_ROLE}
+    secrets:
+      awsCredentials: aws-creds
+  dependsOn: []
+  destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}-instances
+  namespace: testsys
+spec:
+  agent:
+    name: ec2-provider
+    image: ${EC2_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      clusterType: eks
+      instanceCount: 2
+      instanceProfileArn: \${${CLUSTER_NAME}.iamInstanceProfileArn}
+      nodeAmi: ${BOTTLEROCKET_AMI_ID}
+      region: ${AWS_REGION}
+      subnetIds: \${${CLUSTER_NAME}.publicSubnetIds}
+      instanceTypes: ${INSTANCE_TYPES}
+      assumeRole: ${ASSUME_ROLE}
+      endpoint: \${${CLUSTER_NAME}.endpoint}
+      certificate: \${${CLUSTER_NAME}.certificate}
+      clusterDnsIp: \${${CLUSTER_NAME}.clusterDnsIp}
+      securityGroups: \${${CLUSTER_NAME}.securityGroups}
+    secrets:
+      awsCredentials: aws-creds
+  dependsOn: [${CLUSTER_NAME}]
+  destructionPolicy: onDeletion

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -526,7 +526,10 @@ mod test {
     use std::fs::read_to_string;
     use std::path::PathBuf;
 
-    use super::{EksClusterConfig, SonobuoyConfig, VSphereK8sClusterConfig, VSphereVmConfig};
+    use super::{
+        EcsWorkloadTestConfig, EksClusterConfig, SonobuoyConfig, VSphereK8sClusterConfig,
+        VSphereVmConfig, WorkloadConfig,
+    };
 
     fn samples_dir() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -639,6 +642,39 @@ mod test {
     }
 
     #[test]
+    fn ecs_workload_test() {
+        let s = read_eks_file("ecs-workload-test.yaml");
+        let s = s
+            .replace("\\${${CLUSTER_NAME}.publicSubnetIds}", r#"["a", "b", "c"]"#)
+            .replace("${GPU}", "true")
+            .replace("${INSTANCE_TYPES}", r#"["a", "b", "c"]"#)
+            .replace("${", "<")
+            .replace("}", ">");
+
+        let docs: Vec<&str> = s.split("---").collect();
+        let &yaml = docs.get(0).unwrap();
+        let test_1_initial: Test = serde_yaml::from_str(yaml).unwrap();
+        let _: EcsWorkloadTestConfig = serde_json::from_value(JsonValue::Object(
+            test_1_initial.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+
+        let &yaml = docs.get(1).unwrap();
+        let cluster_resource: Resource = serde_yaml::from_str(yaml).unwrap();
+        let _: EcsClusterConfig = serde_json::from_value(JsonValue::Object(
+            cluster_resource.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+
+        let &yaml = docs.get(2).unwrap();
+        let ec2_resource: Resource = serde_yaml::from_str(yaml).unwrap();
+        let _: Ec2Config = serde_json::from_value(JsonValue::Object(
+            ec2_resource.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+    }
+
+    #[test]
     fn sonobuoy_migration_test() {
         let s = read_eks_file("sonobuoy-migration-test.yaml");
         let s = s
@@ -703,7 +739,6 @@ mod test {
     fn sonobuoy_test() {
         let s = read_eks_file("sonobuoy-test.yaml");
         let s = s
-            .replace("\\${${CLUSTER_NAME}-instances.ids}", r#"["a", "b", "c"]"#)
             .replace("\\${${CLUSTER_NAME}.publicSubnetIds}", r#"["a", "b", "c"]"#)
             .replace("\\${${CLUSTER_NAME}.securityGroups}", r#"["a", "b", "c"]"#)
             .replace("${SONOBUOY_MODE}", "quick")
@@ -714,6 +749,40 @@ mod test {
         let &yaml = docs.get(0).unwrap();
         let test_1_initial: Test = serde_yaml::from_str(yaml).unwrap();
         let _: SonobuoyConfig = serde_json::from_value(JsonValue::Object(
+            test_1_initial.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+
+        let &yaml = docs.get(1).unwrap();
+        let cluster_resource: Resource = serde_yaml::from_str(yaml).unwrap();
+        let _: EksClusterConfig = serde_json::from_value(JsonValue::Object(
+            cluster_resource.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+
+        let &yaml = docs.get(2).unwrap();
+        let ec2_resource: Resource = serde_yaml::from_str(yaml).unwrap();
+        let _: Ec2Config = serde_json::from_value(JsonValue::Object(
+            ec2_resource.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+    }
+
+    #[test]
+    fn k8s_workload_test() {
+        let s = read_eks_file("k8s-workload-test.yaml");
+        let s = s
+            .replace("\\${${CLUSTER_NAME}.publicSubnetIds}", r#"["a", "b", "c"]"#)
+            .replace("\\${${CLUSTER_NAME}.securityGroups}", r#"["a", "b", "c"]"#)
+            .replace("${GPU}", "true")
+            .replace("${INSTANCE_TYPES}", r#"["a", "b", "c"]"#)
+            .replace("${", "<")
+            .replace("}", ">");
+
+        let docs: Vec<&str> = s.split("---").collect();
+        let &yaml = docs.get(0).unwrap();
+        let test_1_initial: Test = serde_yaml::from_str(yaml).unwrap();
+        let _: WorkloadConfig = serde_json::from_value(JsonValue::Object(
             test_1_initial.spec.agent.configuration.unwrap(),
         ))
         .unwrap();
@@ -864,10 +933,42 @@ mod test {
     }
 
     #[test]
+    fn ecs_workload_test_kind() {
+        let s = read_kind_file("ecs-workload-test.yaml");
+        let s = s
+            .replace("\\${${CLUSTER_NAME}.publicSubnetIds}", r#"["a", "b", "c"]"#)
+            .replace("${GPU}", "true")
+            .replace("${INSTANCE_TYPES}", r#"["a", "b", "c"]"#)
+            .replace("${", "<")
+            .replace("}", ">");
+
+        let docs: Vec<&str> = s.split("---").collect();
+        let &yaml = docs.get(0).unwrap();
+        let test_1_initial: Test = serde_yaml::from_str(yaml).unwrap();
+        let _: EcsWorkloadTestConfig = serde_json::from_value(JsonValue::Object(
+            test_1_initial.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+
+        let &yaml = docs.get(1).unwrap();
+        let cluster_resource: Resource = serde_yaml::from_str(yaml).unwrap();
+        let _: EcsClusterConfig = serde_json::from_value(JsonValue::Object(
+            cluster_resource.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+
+        let &yaml = docs.get(2).unwrap();
+        let ec2_resource: Resource = serde_yaml::from_str(yaml).unwrap();
+        let _: Ec2Config = serde_json::from_value(JsonValue::Object(
+            ec2_resource.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+    }
+
+    #[test]
     fn sonobuoy_test_kind() {
         let s = read_kind_file("sonobuoy-test.yaml");
         let s = s
-            .replace("\\${${CLUSTER_NAME}-instances.ids}", r#"["a", "b", "c"]"#)
             .replace("\\${${CLUSTER_NAME}.publicSubnetIds}", r#"["a", "b", "c"]"#)
             .replace("\\${${CLUSTER_NAME}.securityGroups}", r#"["a", "b", "c"]"#)
             .replace("${SONOBUOY_MODE}", "quick")


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Added sample files for ecs and k8s workload test agents. Updated `bottlerocket/samples/RUNBOOK.md` and `bottlerocket/types/agent_config.rs` with new guides and unit tests.

**Testing done:**

- New unit tests pass.

- ecs-workload-tests: nvidia-smoke-test passes
```
NAME                                      TYPE             STATE             PASSED         SKIPPED        FAILED
x86-64-aws-ecs-1-nvidia                   Resource         completed
x86-64-aws-ecs-1-nvidia-instances         Resource         completed
x86-64-aws-ecs-1-nvidia-test              Test             pass              1              0              0
```
- k8s-workload-tests: nvidia-smoke-test passes
```
NAME                                        TYPE             STATE            PASSED        SKIPPED        FAILED
x86-64-aws-k8s-124-nvidia                   Resource         completed
x86-64-aws-k8s-124-nvidia-instances         Resource         completed
x86-64-aws-k8s-124-nvidia-test              Test             pass             11            0              0
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
