### PR TITLE
k8s workload: Add support for assumed roles

### DIFF
--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -505,6 +505,7 @@ pub struct WorkloadTest {
 pub struct WorkloadConfig {
     pub kubeconfig_base64: String,
     pub tests: Vec<WorkloadTest>,
+    pub assume_role: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Configuration, Builder)]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #730 

**Description of changes:**

When trying to access a cluster that was created with an assumed role, we get the error:
```
time="2023-01-30T23:24:03Z" level=error msg="could not create sonobuoy client: couldn't get sonobuoy api helper: could not get api group resources: Unauthorized"
```
Now the assume role is used and the test passes:
```
 NAME                        TYPE         STATE         PASSED     SKIPPED     FAILED
 x86-64-aws-k8s-124          Resource     completed
 x86-64-aws-k8s-124-test     Test         pass          1          0           0
```

**Testing done:**

See above

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
