### PR TITLE
ec2 Agent: Update `run-instances` to use IMDSv2

### DIFF
--- a/bottlerocket/agents/src/bin/ec2-resource-agent/ec2_provider.rs
+++ b/bottlerocket/agents/src/bin/ec2-resource-agent/ec2_provider.rs
@@ -3,7 +3,8 @@ use agent_utils::json_display;
 use aws_sdk_ec2::client::fluent_builders::RunInstances;
 use aws_sdk_ec2::error::RunInstancesError;
 use aws_sdk_ec2::model::{
-    ArchitectureValues, Filter, IamInstanceProfileSpecification, InstanceType, ResourceType, Tag,
+    ArchitectureValues, Filter, HttpTokensState, IamInstanceProfileSpecification,
+    InstanceMetadataEndpointState, InstanceMetadataOptionsRequest, InstanceType, ResourceType, Tag,
     TagSpecification,
 };
 use aws_sdk_ec2::output::RunInstancesOutput;
@@ -264,6 +265,13 @@ where
                 .iam_instance_profile(
                     IamInstanceProfileSpecification::builder()
                         .arn(&spec.configuration.instance_profile_arn)
+                        .build(),
+                )
+                .metadata_options(
+                    InstanceMetadataOptionsRequest::builder()
+                        .http_tokens(HttpTokensState::Required)
+                        .http_endpoint(InstanceMetadataEndpointState::Enabled)
+                        .http_put_response_hop_limit(1)
                         .build(),
                 );
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes: #748 

**Description of changes:**

Adds `metadata options` for launching IMDSv2 compliant instances.

**Testing done:**

Ran `cargo make test` with the updated ec2 agent and the test passed.

```
 NAME                        TYPE         STATE         PASSED     SKIPPED     FAILED
 x86-64-aws-k8s-124          Resource     completed
 x86-64-aws-k8s-124-test     Test         pass          1          6972        0
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
