### PR TITLE
Renamed 'model' crate to 'testsys-model'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,9 +6,9 @@ version = 3
 name = "agent-common"
 version = "0.0.5"
 dependencies = [
- "model",
  "snafu",
  "tempfile",
+ "testsys-model",
 ]
 
 [[package]]
@@ -23,12 +23,12 @@ dependencies = [
  "base64 0.20.0",
  "env_logger",
  "log",
- "model",
  "resource-agent",
  "serde",
  "serde_json",
  "snafu",
  "test-agent",
+ "testsys-model",
 ]
 
 [[package]]
@@ -597,7 +597,6 @@ dependencies = [
  "kube",
  "log",
  "maplit",
- "model",
  "reqwest",
  "resource-agent",
  "serde",
@@ -607,6 +606,7 @@ dependencies = [
  "sha2",
  "snafu",
  "test-agent",
+ "testsys-model",
  "tokio",
  "toml",
  "tough",
@@ -620,11 +620,11 @@ version = "0.0.5"
 dependencies = [
  "builder-derive",
  "configuration-derive",
- "model",
  "serde",
  "serde_json",
  "serde_plain",
  "serde_yaml",
+ "testsys-model",
 ]
 
 [[package]]
@@ -643,12 +643,12 @@ name = "builder-derive"
 version = "0.0.5"
 dependencies = [
  "configuration-derive",
- "model",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
  "syn",
+ "testsys-model",
 ]
 
 [[package]]
@@ -775,12 +775,12 @@ dependencies = [
  "env_logger",
  "futures",
  "log",
- "model",
  "selftest",
  "serde",
  "serde_json",
  "serde_plain",
  "terminal_size",
+ "testsys-model",
  "tokio",
 ]
 
@@ -805,11 +805,11 @@ dependencies = [
  "kube-runtime",
  "lazy_static",
  "log",
- "model",
  "schemars",
  "serde",
  "serde_json",
  "snafu",
+ "testsys-model",
  "tokio",
 ]
 
@@ -1738,37 +1738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "model"
-version = "0.0.5"
-dependencies = [
- "async-recursion",
- "async-trait",
- "base64 0.20.0",
- "bytes",
- "chrono",
- "futures",
- "http",
- "json-patch",
- "k8s-openapi",
- "kube",
- "lazy_static",
- "log",
- "maplit",
- "regex",
- "schemars",
- "selftest",
- "serde",
- "serde_json",
- "serde_plain",
- "serde_yaml",
- "snafu",
- "tabled 0.10.0",
- "tokio",
- "tokio-util",
- "topological-sort",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,11 +2209,11 @@ dependencies = [
  "async-trait",
  "env_logger",
  "log",
- "model",
  "nonzero_ext",
  "serde",
  "serde_json",
  "snafu",
+ "testsys-model",
  "tokio",
 ]
 
@@ -2450,9 +2419,9 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "lazy_static",
- "model",
  "serde",
  "tempfile",
+ "testsys-model",
  "tokio",
 ]
 
@@ -2793,12 +2762,12 @@ dependencies = [
  "agent-common",
  "async-trait",
  "log",
- "model",
  "serde",
  "serde_json",
  "snafu",
  "tar",
  "tempfile",
+ "testsys-model",
  "tokio",
 ]
 
@@ -2813,7 +2782,6 @@ dependencies = [
  "copy_dir",
  "env_logger",
  "log",
- "model",
  "selftest",
  "serde",
  "serde_derive",
@@ -2823,6 +2791,7 @@ dependencies = [
  "tar",
  "tempfile",
  "test-agent",
+ "testsys-model",
  "tokio",
  "tokio-util",
 ]
@@ -2841,7 +2810,6 @@ dependencies = [
  "kube",
  "log",
  "maplit",
- "model",
  "selftest",
  "serde",
  "serde_json",
@@ -2851,6 +2819,38 @@ dependencies = [
  "structopt",
  "tabled 0.4.2",
  "termion",
+ "testsys-model",
+ "tokio",
+ "tokio-util",
+ "topological-sort",
+]
+
+[[package]]
+name = "testsys-model"
+version = "0.0.5"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "base64 0.20.0",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "json-patch",
+ "k8s-openapi",
+ "kube",
+ "lazy_static",
+ "log",
+ "maplit",
+ "regex",
+ "schemars",
+ "selftest",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "serde_yaml",
+ "snafu",
+ "tabled 0.10.0",
  "tokio",
  "tokio-util",
  "topological-sort",

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ See the [Developer Guide for TestSys](docs/DEVELOPER.md) for an introduction to 
 
 ### Project Structure
 
-- `model` is the root dependency. It includes the CRDs and clients for interacting with them.
+- `testsys-model` is the root dependency. It includes the CRDs and clients for interacting with them.
 - `controller` contains the Kubernetes controller responsible for running resource and test pods.
 - `agent` contains libraries with the traits and harnesses for creating test and resource agents.
 - `bottlerocket/agents` contains the implementations of the test and resource traits that we use for Bottlerocket testing.
 - `bottlerocket/testsys` contains the command line interface for installing the system and running tests.
 
-The `model`, `agents` and `controller` crates are general-purpose, and define the TestSys system.
+The `testsys-model`, `agents` and `controller` crates are general-purpose, and define the TestSys system.
 It is possible to use these libraries and controller for testing purposes other than Bottlerocket.
 
 The `bottlerocket/testsys` CLI and `bottlerocket/agents` crates are more specialized to Bottlerocket's testing use cases.

--- a/agent/agent-common/Cargo.toml
+++ b/agent/agent-common/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-model = { version = "0.0.5", path = "../../model" }
+testsys-model = { version = "0.0.5", path = "../../model" }
 snafu = "0.7"
 
 [dev-dependencies]

--- a/agent/agent-common/src/secrets.rs
+++ b/agent/agent-common/src/secrets.rs
@@ -1,10 +1,10 @@
-use model::constants::SECRETS_PATH;
-use model::SecretName;
 use snafu::{OptionExt, ResultExt};
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 use std::fs;
 use std::path::PathBuf;
+use testsys_model::constants::SECRETS_PATH;
+use testsys_model::SecretName;
 
 /// Reads the keys (which become files) and values of a Kubernetes generic/[opaque] secret.
 /// [opaque]: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
@@ -111,9 +111,9 @@ impl Default for SecretsReader {
 }
 
 mod error {
-    use model::SecretName;
     use snafu::Snafu;
     use std::path::PathBuf;
+    use testsys_model::SecretName;
 
     #[derive(Debug, Snafu)]
     #[snafu(visibility(pub(super)))]

--- a/agent/builder-derive/Cargo.toml
+++ b/agent/builder-derive/Cargo.toml
@@ -17,5 +17,5 @@ proc-macro = true
 [dev-dependencies]
 serde = "1"
 serde_json= "1"
-model = { version = "0.0.5", path = "../../model" }
+testsys-model = { version = "0.0.5", path = "../../model" }
 configuration-derive = { version = "0.0.5", path = "../configuration-derive" }

--- a/agent/builder-derive/src/derive.rs
+++ b/agent/builder-derive/src/derive.rs
@@ -55,7 +55,7 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
         let ty = field.ty.clone();
         Some(quote! {
             #(#attrs)*
-            #field_ident: model::ConfigValue<#ty>,
+            #field_ident: testsys_model::ConfigValue<#ty>,
         })
     });
     // Create the setters for each field, one for typed values and one for templated strings
@@ -79,7 +79,7 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
             pub fn #field_ident<T>(&mut self, #field_ident: T) -> &mut Self
             where
             T: Into<#ty>{
-                self.#field_ident = model::ConfigValue::Value(#field_ident.into());
+                self.#field_ident = testsys_model::ConfigValue::Value(#field_ident.into());
                 self
             }
 
@@ -89,7 +89,7 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
             S1: Into<String>,
             S2: Into<String>,
             {
-                self.#field_ident = model::ConfigValue::TemplatedString(format!("${{{}.{}}}", resource.into(), field.into()));
+                self.#field_ident = testsys_model::ConfigValue::TemplatedString(format!("${{{}.{}}}", resource.into(), field.into()));
                 self
             }
         })
@@ -117,7 +117,7 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
                     #[serde(skip)]
                     image_pull_secret: Option<String>,
                     #[serde(skip)]
-                    secrets: std::collections::BTreeMap<String, model::SecretName>,
+                    secrets: std::collections::BTreeMap<String, testsys_model::SecretName>,
                     #[serde(skip)]
                     retries: Option<u32>,
                     #[serde(skip)]
@@ -196,14 +196,14 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
                         self
                     }
 
-                    pub fn secrets<S1, S2>(&mut self, key: S1, value: model::SecretName) -> &mut Self
+                    pub fn secrets<S1, S2>(&mut self, key: S1, value: testsys_model::SecretName) -> &mut Self
                     where
                     S1: Into<String>{
                         self.secrets.insert(key.into(), value.into());
                         self
                     }
 
-                    pub fn set_secrets(&mut self, secrets: Option<std::collections::BTreeMap<String,model::SecretName>>) -> &mut Self {
+                    pub fn set_secrets(&mut self, secrets: Option<std::collections::BTreeMap<String,testsys_model::SecretName>>) -> &mut Self {
                         self.secrets = secrets.unwrap_or_default();
                         self
                     }
@@ -250,7 +250,7 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
                         self
                     }
 
-                    pub fn build<S1>(&self, name: S1) -> Result<model::Test, Box<dyn std::error::Error + Sync + Send>>
+                    pub fn build<S1>(&self, name: S1) -> Result<testsys_model::Test, Box<dyn std::error::Error + Sync + Send>>
                     where
                     S1: Into<String>,
                     {
@@ -260,11 +260,11 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
                             _ => return Err("Configuration must be a map".into()),
                         };
 
-                        Ok(model::create_test_crd(name, Some(&self.labels), model::TestSpec {
+                        Ok(testsys_model::create_test_crd(name, Some(&self.labels), testsys_model::TestSpec {
                                 resources: self.resources.clone(),
                                 depends_on: Some(self.depends_on.clone()),
                                 retries: Some(self.retries.as_ref().cloned().unwrap_or(5)),
-                                agent: model::Agent {
+                                agent: testsys_model::Agent {
                                     name: "agent".to_string(),
                                     image: self.image.as_ref().cloned().ok_or_else(|| "Image is required to build a test".to_string())?,
                                     pull_secret: self.image_pull_secret.as_ref().cloned(),
@@ -299,13 +299,13 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
                     #[serde(skip)]
                     image_pull_secret: Option<String>,
                     #[serde(skip)]
-                    secrets: std::collections::BTreeMap<String, model::SecretName>,
+                    secrets: std::collections::BTreeMap<String, testsys_model::SecretName>,
                     #[serde(skip)]
                     keep_running: Option<bool>,
                     #[serde(skip)]
                     capabilities: Vec<String>,
                     #[serde(skip)]
-                    destruction_policy: Option<model::DestructionPolicy>,
+                    destruction_policy: Option<testsys_model::DestructionPolicy>,
                     #[serde(skip)]
                     privileged: Option<bool>,
                 }
@@ -378,14 +378,14 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
                         self
                     }
 
-                    pub fn secrets<S1, S2>(&mut self, key: S1, value: model::SecretName) -> &mut Self
+                    pub fn secrets<S1, S2>(&mut self, key: S1, value: testsys_model::SecretName) -> &mut Self
                     where
                     S1: Into<String>{
                         self.secrets.insert(key.into(), value.into());
                         self
                     }
 
-                    pub fn set_secrets(&mut self, secrets: Option<std::collections::BTreeMap<String,model::SecretName>>) -> &mut Self {
+                    pub fn set_secrets(&mut self, secrets: Option<std::collections::BTreeMap<String,testsys_model::SecretName>>) -> &mut Self {
                         self.secrets = secrets.unwrap_or_default();
                         self
                     }
@@ -412,12 +412,12 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
                         self
                     }
 
-                    pub fn destruction_policy(&mut self, destruction_policy: model::DestructionPolicy) -> &mut Self {
+                    pub fn destruction_policy(&mut self, destruction_policy: testsys_model::DestructionPolicy) -> &mut Self {
                         self.destruction_policy = Some(destruction_policy);
                         self
                     }
 
-                    pub fn set_destruction_policy(&mut self, destruction_policy: Option<model::DestructionPolicy>) -> &mut Self {
+                    pub fn set_destruction_policy(&mut self, destruction_policy: Option<testsys_model::DestructionPolicy>) -> &mut Self {
                         self.destruction_policy = destruction_policy;
                         self
                     }
@@ -432,7 +432,7 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
                         self
                     }
 
-                    pub fn build<S1>(&self, name: S1) -> Result<model::Resource, Box<dyn std::error::Error + Sync + Send>>
+                    pub fn build<S1>(&self, name: S1) -> Result<testsys_model::Resource, Box<dyn std::error::Error + Sync + Send>>
                     where
                     S1: Into<String>,
                     {
@@ -442,10 +442,10 @@ pub(crate) fn build_struct(ast: &syn::DeriveInput) -> TokenStream {
                             _ => return Err("Configuration must be a map".to_string().into()),
                         };
 
-                        Ok(model::create_resource_crd(name, Some(&self.labels), model::ResourceSpec {
+                        Ok(testsys_model::create_resource_crd(name, Some(&self.labels), testsys_model::ResourceSpec {
                             conflicts_with: Some(self.conflicts_with.clone()),
                             depends_on: Some(self.depends_on.clone()),
-                            agent: model::Agent {
+                            agent: testsys_model::Agent {
                                 name: "agent".to_string(),
                                 image: self.image.as_ref().cloned().ok_or_else(|| "Image is required to build a test".to_string())?,
                                 pull_secret: self.image_pull_secret.as_ref().cloned(),

--- a/agent/configuration-derive/src/lib.rs
+++ b/agent/configuration-derive/src/lib.rs
@@ -11,7 +11,7 @@ pub fn derive_configuration(input: TokenStream) -> TokenStream {
     let ident = ast.ident;
 
     quote! {
-       impl model::Configuration for #ident{}
+       impl testsys_model::Configuration for #ident{}
     }
     .into()
 }

--- a/agent/resource-agent/Cargo.toml
+++ b/agent/resource-agent/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 agent-common = { version = "0.0.5", path = "../agent-common" }
 async-trait = "0.1"
 log = "0.4"
-model = { version = "0.0.5", path = "../../model" }
+testsys-model = { version = "0.0.5", path = "../../model" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu = "0.7"

--- a/agent/resource-agent/examples/duplicator_resource_agent/main.rs
+++ b/agent/resource-agent/examples/duplicator_resource_agent/main.rs
@@ -60,7 +60,7 @@ fn init_logger() {
             Builder::new()
                 .filter(Some(env!("CARGO_CRATE_NAME")), LevelFilter::Trace)
                 .filter(Some("resource_agent"), LevelFilter::Trace)
-                .filter(Some("model"), LevelFilter::Trace)
+                .filter(Some("testsys_model"), LevelFilter::Trace)
                 .init();
         }
     }

--- a/agent/resource-agent/examples/duplicator_resource_agent/provider.rs
+++ b/agent/resource-agent/examples/duplicator_resource_agent/provider.rs
@@ -6,13 +6,13 @@ and tests that depend on resources for their inputs.
 
 !*/
 
-use model::Configuration;
 use resource_agent::clients::InfoClient;
 use resource_agent::provider::{
     Create, Destroy, IntoProviderError, ProviderResult, Resources, Spec,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use testsys_model::Configuration;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/agent/resource-agent/examples/example_resource_agent/main.rs
+++ b/agent/resource-agent/examples/example_resource_agent/main.rs
@@ -60,7 +60,7 @@ fn init_logger() {
             Builder::new()
                 .filter(Some(env!("CARGO_CRATE_NAME")), LevelFilter::Trace)
                 .filter(Some("resource_agent"), LevelFilter::Trace)
-                .filter(Some("model"), LevelFilter::Trace)
+                .filter(Some("testsys_model"), LevelFilter::Trace)
                 .init();
         }
     }

--- a/agent/resource-agent/examples/example_resource_agent/provider.rs
+++ b/agent/resource-agent/examples/example_resource_agent/provider.rs
@@ -7,13 +7,13 @@ color.
 !*/
 
 use log::{debug, info};
-use model::Configuration;
 use nonzero_ext::nonzero;
 use resource_agent::clients::InfoClient;
 use resource_agent::provider::{Create, Destroy, ProviderError, ProviderResult, Resources, Spec};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::num::NonZeroU16;
+use testsys_model::Configuration;
 use tokio::time::{sleep, Duration};
 
 /// The color of a robot.

--- a/agent/resource-agent/src/bootstrap.rs
+++ b/agent/resource-agent/src/bootstrap.rs
@@ -5,9 +5,9 @@ container environment to construct the [`Agent`] and all of its parts.
 
 !*/
 use crate::ResourceAction;
-use model::constants::{ENV_RESOURCE_ACTION, ENV_RESOURCE_NAME};
 use snafu::{ResultExt, Snafu};
 use std::str::FromStr;
+use testsys_model::constants::{ENV_RESOURCE_ACTION, ENV_RESOURCE_NAME};
 
 /// The public error type for the default [`Bootstrap`].
 #[derive(Debug, Snafu)]
@@ -26,7 +26,10 @@ pub(crate) enum InnerError {
     },
 
     #[snafu(display("Incorrect resource action '{}': {}", value, source))]
-    ResourceActionParse { value: String, source: model::Error },
+    ResourceActionParse {
+        value: String,
+        source: testsys_model::Error,
+    },
 }
 
 /// Data that is read from the TestPod's container environment and filesystem.

--- a/agent/resource-agent/src/clients/agent_client.rs
+++ b/agent/resource-agent/src/clients/agent_client.rs
@@ -1,8 +1,8 @@
 use super::error::ClientResult;
 use crate::provider::{ProviderError, Spec};
 use crate::{BootstrapData, ResourceAction};
-use model::clients::ResourceClient;
-use model::Configuration;
+use testsys_model::clients::ResourceClient;
+use testsys_model::Configuration;
 
 /// `AgentClient` allows the [`Agent`] to communicate with Kubernetes.
 ///

--- a/agent/resource-agent/src/clients/implementation.rs
+++ b/agent/resource-agent/src/clients/implementation.rs
@@ -3,13 +3,13 @@ use crate::clients::{AgentClient, ClientError, DefaultAgentClient, DefaultInfoCl
 use crate::provider::{ProviderError, Resources, Spec};
 use crate::{BootstrapData, ResourceAction};
 use agent_common::secrets::{SecretData, SecretsReader};
-use model::clients::{CrdClient, ResourceClient};
-use model::{
+use testsys_model::clients::{CrdClient, ResourceClient};
+use testsys_model::{
     Configuration, Error as ModelError, ErrorResources, ResourceError, SecretName, TaskState,
 };
 
-impl From<model::clients::Error> for ClientError {
-    fn from(e: model::clients::Error) -> Self {
+impl From<testsys_model::clients::Error> for ClientError {
+    fn from(e: testsys_model::clients::Error) -> Self {
         ClientError::RequestFailed(Some(Box::new(e)))
     }
 }

--- a/agent/resource-agent/src/clients/info_client.rs
+++ b/agent/resource-agent/src/clients/info_client.rs
@@ -1,8 +1,8 @@
 use super::error::ClientResult;
 use crate::BootstrapData;
 use agent_common::secrets::SecretData;
-use model::clients::ResourceClient;
-use model::{Configuration, SecretName};
+use testsys_model::clients::ResourceClient;
+use testsys_model::{Configuration, SecretName};
 
 /// `InfoClient` allows [`Create`] and [`Destroy`] objects to store arbitrary information in the
 /// Kubernetes status fields associated with the `Resource` CRD. For example, you might want to

--- a/agent/resource-agent/src/lib.rs
+++ b/agent/resource-agent/src/lib.rs
@@ -14,4 +14,4 @@ pub mod provider;
 
 pub use agent::{Agent, Types};
 pub use bootstrap::BootstrapData;
-pub use model::{Configuration, ResourceAction};
+pub use testsys_model::{Configuration, ResourceAction};

--- a/agent/resource-agent/src/provider/mod.rs
+++ b/agent/resource-agent/src/provider/mod.rs
@@ -2,9 +2,9 @@ mod error;
 
 pub use self::error::{AsResources, IntoProviderError, ProviderError, ProviderResult, Resources};
 use crate::clients::InfoClient;
-use model::{Configuration, SecretName, SecretType};
 use serde::Serialize;
 use std::collections::BTreeMap;
+use testsys_model::{Configuration, SecretName, SecretType};
 
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct Spec<C>

--- a/agent/resource-agent/tests/mock/agent_client.rs
+++ b/agent/resource-agent/tests/mock/agent_client.rs
@@ -1,7 +1,7 @@
-use model::Configuration;
 use resource_agent::clients::{AgentClient, ClientResult};
 use resource_agent::provider::{ProviderError, Spec};
 use resource_agent::{BootstrapData, ResourceAction};
+use testsys_model::Configuration;
 
 /// Create an [`AgentClient`] that does nothing so that we can test without Kubernetes.
 pub(crate) struct MockAgentClient;

--- a/agent/resource-agent/tests/mock/info_client.rs
+++ b/agent/resource-agent/tests/mock/info_client.rs
@@ -1,7 +1,7 @@
 use agent_common::secrets::SecretData;
-use model::{Configuration, SecretName};
 use resource_agent::clients::{ClientResult, InfoClient};
 use resource_agent::BootstrapData;
+use testsys_model::{Configuration, SecretName};
 
 /// Create an [`InfoClient`] that does nothing so that we can test without Kubernetes.
 pub(crate) struct MockInfoClient {}

--- a/agent/resource-agent/tests/mock/mod.rs
+++ b/agent/resource-agent/tests/mock/mod.rs
@@ -10,10 +10,10 @@ Also provided here are a very simple mock implementations of the [`Create`] and 
 pub(crate) mod agent_client;
 pub(crate) mod info_client;
 
-use model::Configuration;
 use resource_agent::clients::InfoClient;
 use resource_agent::provider::{Create, Destroy, ProviderError, ProviderResult, Resources, Spec};
 use serde::{Deserialize, Serialize};
+use testsys_model::Configuration;
 
 /// InstanceCreator pretends to create instances for the sake demonstrating a mock resource provider.
 pub(crate) struct InstanceCreator {}

--- a/agent/test-agent-cli/Cargo.toml
+++ b/agent/test-agent-cli/Cargo.toml
@@ -13,7 +13,7 @@ test-agent = { version = "0.0.5", path = "../test-agent" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
 tokio-util = "0.7"
 log = "0.4"
-model = { version = "0.0.5", path = "../../model" }
+testsys-model = { version = "0.0.5", path = "../../model" }
 snafu = "0.7"
 async-trait = "0.1"
 tempfile = "3"

--- a/agent/test-agent-cli/src/init.rs
+++ b/agent/test-agent-cli/src/init.rs
@@ -1,12 +1,12 @@
 use crate::error::{ArchiveSnafu, ClientSnafu, JsonSerializeSnafu, Result};
 use argh::FromArgs;
-use model::constants::TESTSYS_RESULTS_DIRECTORY;
-use model::Configuration;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use snafu::ResultExt;
 use std::fs;
 use test_agent::{Client, DefaultClient, Spec};
+use testsys_model::constants::TESTSYS_RESULTS_DIRECTORY;
+use testsys_model::Configuration;
 
 #[derive(Debug, FromArgs, PartialEq)]
 #[argh(

--- a/agent/test-agent-cli/src/save_results.rs
+++ b/agent/test-agent-cli/src/save_results.rs
@@ -2,10 +2,10 @@ use crate::error::{ArchiveSnafu, Result};
 use argh::FromArgs;
 use copy_dir::copy_dir;
 use log::error;
-use model::constants::TESTSYS_RESULTS_DIRECTORY;
 use snafu::ResultExt;
 use std::path::Path;
 use test_agent::DefaultClient;
+use testsys_model::constants::TESTSYS_RESULTS_DIRECTORY;
 
 #[derive(Debug, FromArgs, PartialEq)]
 #[argh(

--- a/agent/test-agent-cli/src/send_results.rs
+++ b/agent/test-agent-cli/src/send_results.rs
@@ -1,8 +1,8 @@
 use crate::error::{ClientSnafu, Result};
 use argh::FromArgs;
-use model::{Outcome, TestResults};
 use snafu::ResultExt;
 use test_agent::{Client, DefaultClient};
+use testsys_model::{Outcome, TestResults};
 
 #[derive(Debug, FromArgs, PartialEq)]
 #[argh(

--- a/agent/test-agent-cli/src/terminate.rs
+++ b/agent/test-agent-cli/src/terminate.rs
@@ -1,13 +1,13 @@
 use crate::error::{self, ArchiveSnafu, ClientSnafu, Result};
 use argh::FromArgs;
 use log::{error, info};
-use model::constants::TESTSYS_RESULTS_DIRECTORY;
 use snafu::ResultExt;
 use std::fs::File;
 use std::path::PathBuf;
 use std::time::Duration;
 use tar::Builder;
 use test_agent::{Client, DefaultClient};
+use testsys_model::constants::TESTSYS_RESULTS_DIRECTORY;
 use tokio::time::sleep;
 
 #[derive(Debug, FromArgs, PartialEq)]

--- a/agent/test-agent-cli/tests/cli_test.rs
+++ b/agent/test-agent-cli/tests/cli_test.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "integ")]
 mod data;
 use assert_cmd::Command;
-use model::{constants::NAMESPACE, Test};
 use selftest::Cluster;
+use testsys_model::{constants::NAMESPACE, Test};
 use tokio::time::Duration;
 
 const POD_TIMEOUT: Duration = Duration::from_secs(300);

--- a/agent/test-agent/Cargo.toml
+++ b/agent/test-agent/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 agent-common = { version = "0.0.5", path = "../agent-common" }
 async-trait = "0.1"
 log = "0.4"
-model = { version = "0.0.5", path = "../../model" }
+testsys-model = { version = "0.0.5", path = "../../model" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu = "0.7"

--- a/agent/test-agent/examples/example_test_agent/main.rs
+++ b/agent/test-agent/examples/example_test_agent/main.rs
@@ -28,10 +28,10 @@ spec:
 
 !*/
 
-use model::{Outcome, TestResults};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use test_agent::{BootstrapData, Configuration, InfoClient, Spec};
+use testsys_model::{Outcome, TestResults};
 use tokio::time::{sleep, Duration};
 
 struct ExampleTestRunner {

--- a/agent/test-agent/src/agent.rs
+++ b/agent/test-agent/src/agent.rs
@@ -1,12 +1,12 @@
 use crate::error::{self, AgentError, Error, Result};
 use crate::{BootstrapData, Client, InfoClient, Runner};
 use log::{debug, error, info, trace};
-use model::{Outcome, TestResults};
 use snafu::ResultExt;
 use std::fs::File;
 use std::path::PathBuf;
 use std::time::Duration;
 use tar::Builder;
+use testsys_model::{Outcome, TestResults};
 use tokio::time::sleep;
 
 /// The `TestAgent` is the main entrypoint for the program running in a TestPod. It starts a test

--- a/agent/test-agent/src/bootstrap.rs
+++ b/agent/test-agent/src/bootstrap.rs
@@ -5,8 +5,8 @@ container environment to construct the [`Agent`] and all of its parts.
 
 !*/
 
-use model::constants::ENV_TEST_NAME;
 use snafu::{ResultExt, Snafu};
+use testsys_model::constants::ENV_TEST_NAME;
 
 #[derive(Clone)]
 /// Data that is read from the TestPod's container environment and filesystem.

--- a/agent/test-agent/src/k8s_client.rs
+++ b/agent/test-agent/src/k8s_client.rs
@@ -3,14 +3,14 @@ use crate::{
     BootstrapData, Client, DefaultClient, DefaultInfoClient, InfoClient, Spec, TestResults,
 };
 use async_trait::async_trait;
-use model::clients::{CrdClient, ResourceClient, TestClient};
-use model::constants::TESTSYS_RESULTS_FILE;
-use model::{Configuration, TaskState};
 use serde_json::Value;
 use snafu::{ResultExt, Snafu};
 use std::fmt::{Debug, Display};
 use std::path::PathBuf;
 use tempfile::TempDir;
+use testsys_model::clients::{CrdClient, ResourceClient, TestClient};
+use testsys_model::constants::TESTSYS_RESULTS_FILE;
+use testsys_model::{Configuration, TaskState};
 
 /// The public error type for the default [`Client`].
 #[derive(Debug, Snafu)]
@@ -23,16 +23,22 @@ pub(crate) enum InnerError {
     /// `DefaultClient` is in a better position to provide context than we are, so we forward the
     /// error message.
     #[snafu(display("{}", source))]
-    K8s { source: model::clients::Error },
+    K8s {
+        source: testsys_model::clients::Error,
+    },
 
     #[snafu(display("Unable to deserialize test configuration: {}", source))]
     Deserialization { source: serde_json::Error },
 
     #[snafu(display("Unable to create resource client: {}", source))]
-    ResourceClientCreate { source: model::clients::Error },
+    ResourceClientCreate {
+        source: testsys_model::clients::Error,
+    },
 
     #[snafu(display("Unable to resolve config templates: {}", source))]
-    ResolveConfig { source: model::clients::Error },
+    ResolveConfig {
+        source: testsys_model::clients::Error,
+    },
 
     #[snafu(display("An error occured while creating a `TempDir`: {}", source))]
     TempDirCreate { source: std::io::Error },

--- a/agent/test-agent/src/lib.rs
+++ b/agent/test-agent/src/lib.rs
@@ -18,13 +18,13 @@ pub use bootstrap::{BootstrapData, BootstrapError};
 use error::InfoClientResult;
 pub use k8s_client::ClientError;
 use log::info;
-use model::clients::TestClient;
-pub use model::{Configuration, TestResults};
-use model::{Outcome, SecretName, SecretType};
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Display};
 use std::path::PathBuf;
 use tempfile::TempDir;
+use testsys_model::clients::TestClient;
+pub use testsys_model::{Configuration, TestResults};
+use testsys_model::{Outcome, SecretName, SecretType};
 
 /// Information that a test [`Runner`] needs before it can begin a test.
 #[derive(Debug, Clone)]

--- a/agent/test-agent/tests/mock.rs
+++ b/agent/test-agent/tests/mock.rs
@@ -6,7 +6,6 @@ to test a [`Runner`] with the [`TestAgent`].
 !*/
 
 use async_trait::async_trait;
-use model::{Configuration, Outcome};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
 use std::path::PathBuf;
@@ -14,6 +13,7 @@ use tempfile::{tempdir, TempDir};
 use test_agent::error::InfoClientResult;
 use test_agent::{BootstrapData, Client, InfoClient, Runner};
 use test_agent::{Spec, TestResults};
+use testsys_model::{Configuration, Outcome};
 use tokio::time::{sleep, Duration};
 
 /// When creating a test, this is the object that you create which will implement the [`Runner`]

--- a/agent/utils/Cargo.toml
+++ b/agent/utils/Cargo.toml
@@ -14,7 +14,7 @@ aws-smithy-types = "0.49"
 base64 = "0.20"
 env_logger = "0.10"
 log = "0.4"
-model = { version = "0.0.5", path = "../../model" }
+testsys-model = { version = "0.0.5", path = "../../model" }
 resource-agent = { version = "0.0.5", path = "../../agent/resource-agent" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/agent/utils/src/aws.rs
+++ b/agent/utils/src/aws.rs
@@ -9,10 +9,10 @@ use aws_smithy_types::retry::RetryMode;
 use aws_types::credentials::{Credentials, SharedCredentialsProvider};
 use aws_types::SdkConfig;
 use log::info;
-use model::SecretName;
 use snafu::{OptionExt, ResultExt};
 use std::env;
 use std::time::Duration;
+use testsys_model::SecretName;
 
 /// Set up the config for aws calls using `aws_secret_name` if provided and `sts::assume_role`
 /// if a role arn is provided. Set credentials as environment variables if `setup_env` is true

--- a/agent/utils/src/lib.rs
+++ b/agent/utils/src/lib.rs
@@ -52,9 +52,9 @@ pub fn init_agent_logger(bin_crate: &str, log_level: Option<LevelFilter>) {
                 .filter(Some(bin_crate), log_level)
                 .filter(Some("agent_common"), log_level)
                 .filter(Some("bottlerocket_agents"), log_level)
-                .filter(Some("model"), log_level)
                 .filter(Some("resource_agent"), log_level)
                 .filter(Some("test_agent"), log_level)
+                .filter(Some("testsys_model"), log_level)
                 .init();
         }
     }

--- a/bottlerocket/agents/Cargo.toml
+++ b/bottlerocket/agents/Cargo.toml
@@ -26,7 +26,7 @@ k8s-openapi = { version = "0.16", default-features = false, features = ["v1_20"]
 kube = { version = "0.75", default-features = false, features = ["config", "derive", "client"] }
 log = "0.4"
 maplit = "1"
-model = { version = "0.0.5", path = "../../model" }
+testsys-model = { version = "0.0.5", path = "../../model" }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "blocking"] }
 resource-agent = { version = "0.0.5", path = "../../agent/resource-agent" }
 serde = { version = "1", features = ["derive"] }

--- a/bottlerocket/agents/src/bin/ec2-resource-agent/ec2_provider.rs
+++ b/bottlerocket/agents/src/bin/ec2-resource-agent/ec2_provider.rs
@@ -14,7 +14,6 @@ use bottlerocket_types::agent_config::{
     ClusterType, CustomUserData, Ec2Config, AWS_CREDENTIALS_SECRET_NAME,
 };
 use log::{debug, info, trace, warn};
-use model::{Configuration, SecretName};
 use resource_agent::clients::InfoClient;
 use resource_agent::provider::{
     AsResources, Create, Destroy, IntoProviderError, ProviderError, ProviderResult, Resources, Spec,
@@ -24,6 +23,7 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 use std::iter::FromIterator;
 use std::time::Duration;
+use testsys_model::{Configuration, SecretName};
 use toml::Value;
 use uuid::Uuid;
 

--- a/bottlerocket/agents/src/bin/ecs-resource-agent/ecs_provider.rs
+++ b/bottlerocket/agents/src/bin/ecs-resource-agent/ecs_provider.rs
@@ -6,13 +6,13 @@ use aws_sdk_iam::output::GetInstanceProfileOutput;
 use aws_types::sdk_config::SdkConfig;
 use bottlerocket_types::agent_config::{EcsClusterConfig, AWS_CREDENTIALS_SECRET_NAME};
 use log::{error, info};
-use model::{Configuration, SecretName};
 use resource_agent::clients::InfoClient;
 use resource_agent::provider::{
     Create, Destroy, IntoProviderError, ProviderResult, Resources, Spec,
 };
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
+use testsys_model::{Configuration, SecretName};
 
 /// The default region for the cluster.
 const DEFAULT_REGION: &str = "us-west-2";

--- a/bottlerocket/agents/src/bin/ecs-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/ecs-test-agent/main.rs
@@ -15,13 +15,13 @@ use bottlerocket_agents::constants::DEFAULT_TASK_DEFINITION;
 use bottlerocket_agents::error::{self, Error};
 use bottlerocket_types::agent_config::{EcsTestConfig, AWS_CREDENTIALS_SECRET_NAME};
 use log::info;
-use model::{Outcome, SecretName, TestResults};
 use snafu::{OptionExt, ResultExt};
 use std::time::Duration;
 use test_agent::{
     BootstrapData, ClientError, DefaultClient, DefaultInfoClient, InfoClient, Runner, Spec,
     TestAgent,
 };
+use testsys_model::{Outcome, SecretName, TestResults};
 
 struct EcsTestRunner {
     config: EcsTestConfig,

--- a/bottlerocket/agents/src/bin/ecs-workload-agent/main.rs
+++ b/bottlerocket/agents/src/bin/ecs-workload-agent/main.rs
@@ -49,13 +49,13 @@ use bottlerocket_types::agent_config::{
     EcsWorkloadTestConfig, WorkloadTest, AWS_CREDENTIALS_SECRET_NAME,
 };
 use log::info;
-use model::{Outcome, SecretName, TestResults};
 use snafu::{OptionExt, ResultExt};
 use std::time::Duration;
 use test_agent::{
     BootstrapData, ClientError, DefaultClient, DefaultInfoClient, InfoClient, Runner, Spec,
     TestAgent,
 };
+use testsys_model::{Outcome, SecretName, TestResults};
 
 pub const DEFAULT_TASK_DEFINITION_PREFIX: &str = "testsys-bottlerocket-";
 

--- a/bottlerocket/agents/src/bin/eks-resource-agent/eks_provider.rs
+++ b/bottlerocket/agents/src/bin/eks-resource-agent/eks_provider.rs
@@ -11,7 +11,6 @@ use bottlerocket_types::agent_config::{
     CreationPolicy, EksClusterConfig, EksctlConfig, K8sVersion, AWS_CREDENTIALS_SECRET_NAME,
 };
 use log::{debug, info, trace};
-use model::{Configuration, SecretName};
 use resource_agent::clients::InfoClient;
 use resource_agent::provider::{
     Create, Destroy, IntoProviderError, ProviderError, ProviderResult, Resources, Spec,
@@ -22,6 +21,7 @@ use std::env::temp_dir;
 use std::fs::write;
 use std::path::Path;
 use std::process::Command;
+use testsys_model::{Configuration, SecretName};
 
 /// The default region for the cluster.
 const DEFAULT_REGION: &str = "us-west-2";

--- a/bottlerocket/agents/src/bin/k8s-workload-agent/main.rs
+++ b/bottlerocket/agents/src/bin/k8s-workload-agent/main.rs
@@ -41,11 +41,11 @@ use bottlerocket_agents::error::Error;
 use bottlerocket_agents::workload::{delete_workload, rerun_failed_workload, run_workload};
 use bottlerocket_types::agent_config::{WorkloadConfig, AWS_CREDENTIALS_SECRET_NAME};
 use log::info;
-use model::{SecretName, TestResults};
 use std::path::PathBuf;
 use test_agent::{
     BootstrapData, ClientError, DefaultClient, DefaultInfoClient, InfoClient, Spec, TestAgent,
 };
+use testsys_model::{SecretName, TestResults};
 
 struct WorkloadTestRunner {
     config: WorkloadConfig,

--- a/bottlerocket/agents/src/bin/migration-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/migration-test-agent/main.rs
@@ -48,13 +48,13 @@ use bottlerocket_agents::error::{self, Error};
 use bottlerocket_types::agent_config::{MigrationConfig, AWS_CREDENTIALS_SECRET_NAME};
 use log::{error, info};
 use maplit::hashmap;
-use model::{Outcome, SecretName, TestResults};
 use snafu::ResultExt;
 use std::path::Path;
 use std::time::Duration;
 use test_agent::{
     BootstrapData, ClientError, DefaultClient, DefaultInfoClient, InfoClient, Spec, TestAgent,
 };
+use testsys_model::{Outcome, SecretName, TestResults};
 
 const BR_CHANGE_UPDATE_REPO_DOCUMENT_NAME: &str = "BR-ChangeUpdateRepo";
 const BR_CHANGE_UPDATE_REPO_DOCUMENT_PATH: &str = "/local/ssm-documents/ssm-change-update-repo.yml";

--- a/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
@@ -40,11 +40,11 @@ use bottlerocket_agents::error::Error;
 use bottlerocket_agents::sonobuoy::{delete_sonobuoy, rerun_failed_sonobuoy, run_sonobuoy};
 use bottlerocket_types::agent_config::{SonobuoyConfig, AWS_CREDENTIALS_SECRET_NAME};
 use log::{debug, info};
-use model::{SecretName, TestResults};
 use std::path::PathBuf;
 use test_agent::{
     BootstrapData, ClientError, DefaultClient, DefaultInfoClient, InfoClient, Spec, TestAgent,
 };
+use testsys_model::{SecretName, TestResults};
 
 struct SonobuoyTestRunner {
     config: SonobuoyConfig,

--- a/bottlerocket/agents/src/bin/vsphere-k8s-cluster-resource-agent/vsphere_k8s_cluster_provider.rs
+++ b/bottlerocket/agents/src/bin/vsphere-k8s-cluster-resource-agent/vsphere_k8s_cluster_provider.rs
@@ -11,7 +11,6 @@ use kube::api::ListParams;
 use kube::config::{KubeConfigOptions, Kubeconfig};
 use kube::{Api, Config};
 use log::{debug, info};
-use model::{Configuration, SecretName};
 use resource_agent::clients::InfoClient;
 use resource_agent::provider::{
     Create, Destroy, IntoProviderError, ProviderError, ProviderResult, Resources, Spec,
@@ -24,6 +23,7 @@ use std::fs::File;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::{env, fs};
+use testsys_model::{Configuration, SecretName};
 
 const WORKING_DIR: &str = "/local/eksa-work";
 

--- a/bottlerocket/agents/src/bin/vsphere-vm-resource-agent/vsphere_vm_provider.rs
+++ b/bottlerocket/agents/src/bin/vsphere-vm-resource-agent/vsphere_vm_provider.rs
@@ -13,7 +13,6 @@ use kube::api::ListParams;
 use kube::config::{KubeConfigOptions, Kubeconfig};
 use kube::{Api, Config};
 use log::{debug, info};
-use model::{Configuration, SecretName};
 use resource_agent::clients::InfoClient;
 use resource_agent::provider::{
     Create, Destroy, IntoProviderError, ProviderError, ProviderResult, Resources, Spec,
@@ -28,6 +27,7 @@ use std::fs::File;
 use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
+use testsys_model::{Configuration, SecretName};
 use toml::Value;
 
 /// The default number of VMs to spin up.

--- a/bottlerocket/agents/src/sonobuoy.rs
+++ b/bottlerocket/agents/src/sonobuoy.rs
@@ -1,7 +1,6 @@
 use crate::error;
 use bottlerocket_types::agent_config::{SonobuoyConfig, SONOBUOY_RESULTS_FILENAME};
 use log::{error, info, trace};
-use model::{Outcome, TestResults};
 use serde_json::Value;
 use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::HashMap;
@@ -10,6 +9,7 @@ use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
 use test_agent::InfoClient;
+use testsys_model::{Outcome, TestResults};
 
 /// Runs the sonobuoy conformance tests according to the provided configuration and returns a test
 /// result at the end.

--- a/bottlerocket/agents/src/vsphere.rs
+++ b/bottlerocket/agents/src/vsphere.rs
@@ -1,7 +1,7 @@
-use model::SecretName;
 use resource_agent::clients::InfoClient;
 use resource_agent::provider::{IntoProviderError, ProviderResult, Resources};
 use std::env;
+use testsys_model::SecretName;
 
 // Helper for getting the vsphere credentials and setting up GOVC_USERNAME and GOVC_PASSWORD env vars
 pub async fn vsphere_credentials<I>(

--- a/bottlerocket/agents/src/workload.rs
+++ b/bottlerocket/agents/src/workload.rs
@@ -4,7 +4,6 @@ use crate::sonobuoy::{
 };
 use bottlerocket_types::agent_config::{WorkloadConfig, SONOBUOY_RESULTS_FILENAME};
 use log::{info, trace};
-use model::TestResults;
 use snafu::{ensure, ResultExt};
 use std::fs::File;
 use std::io::Write;
@@ -12,6 +11,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 use test_agent::InfoClient;
+use testsys_model::TestResults;
 
 const SONOBUOY_BIN_PATH: &str = "/usr/bin/sonobuoy";
 

--- a/bottlerocket/testsys/Cargo.toml
+++ b/bottlerocket/testsys/Cargo.toml
@@ -15,7 +15,7 @@ k8s-openapi = { version = "0.16", features = ["v1_20", "api"], default-features 
 kube = { version = "0.75", default-features = true, features = ["config", "derive", "ws"] }
 log = "0.4"
 maplit = "1"
-model = { version = "0.0.5", path = "../../model" }
+testsys-model = { version = "0.0.5", path = "../../model" }
 serde = "1"
 serde_plain = "1"
 serde_json = "1"

--- a/bottlerocket/testsys/src/add_aws_secret.rs
+++ b/bottlerocket/testsys/src/add_aws_secret.rs
@@ -2,10 +2,10 @@ use crate::error::Result;
 use crate::k8s::create_or_update;
 use k8s_openapi::api::core::v1::Secret;
 use kube::{Api, Client};
-use model::constants::NAMESPACE;
-use model::SecretName;
 use std::collections::BTreeMap;
 use structopt::StructOpt;
+use testsys_model::constants::NAMESPACE;
+use testsys_model::SecretName;
 
 /// Add a `Secret` with key value pairs.
 #[derive(Debug, StructOpt)]

--- a/bottlerocket/testsys/src/add_secret_map.rs
+++ b/bottlerocket/testsys/src/add_secret_map.rs
@@ -2,11 +2,11 @@ use crate::error::{self, Result};
 use crate::k8s::create_or_update;
 use k8s_openapi::api::core::v1::Secret;
 use kube::{Api, Client};
-use model::constants::NAMESPACE;
-use model::SecretName;
 use snafu::OptionExt;
 use std::collections::BTreeMap;
 use structopt::StructOpt;
+use testsys_model::constants::NAMESPACE;
+use testsys_model::SecretName;
 
 /// Add a `Secret` with key value pairs.
 #[derive(Debug, StructOpt)]

--- a/bottlerocket/testsys/src/delete.rs
+++ b/bottlerocket/testsys/src/delete.rs
@@ -1,15 +1,15 @@
 use crate::error::{self, Result};
 use http::StatusCode;
 use kube::{core::object::HasStatus, Client, ResourceExt};
-use model::{
-    clients::{AllowNotFound, CrdClient, HttpStatusCode, ResourceClient, TestClient},
-    TaskState,
-};
 use serde::Deserialize;
 use serde_plain::derive_fromstr_from_deserialize;
 use snafu::ResultExt;
 use std::{collections::HashSet, time::Duration};
 use structopt::StructOpt;
+use testsys_model::{
+    clients::{AllowNotFound, CrdClient, HttpStatusCode, ResourceClient, TestClient},
+    TaskState,
+};
 use topological_sort::TopologicalSort;
 
 /// Delete an object from a testsys cluster.

--- a/bottlerocket/testsys/src/error.rs
+++ b/bottlerocket/testsys/src/error.rs
@@ -37,15 +37,19 @@ pub(crate) enum Error {
     Creation { what: String, source: kube::Error },
 
     #[snafu(display("Error creating test: {}", source))]
-    CreateTest { source: model::clients::Error },
+    CreateTest {
+        source: testsys_model::clients::Error,
+    },
 
     #[snafu(display("Error creating resource: {}", source))]
-    CreateResource { source: model::clients::Error },
+    CreateResource {
+        source: testsys_model::clients::Error,
+    },
 
     #[snafu(display("Unable to delete '{}': {}", what, source))]
     Delete {
         what: String,
-        source: model::clients::Error,
+        source: testsys_model::clients::Error,
     },
 
     #[snafu(display("{} objects failed to be deleted.", count))]
@@ -82,7 +86,7 @@ pub(crate) enum Error {
     #[snafu(display("Unable to get '{}': {}", what, source))]
     Get {
         what: String,
-        source: model::clients::Error,
+        source: testsys_model::clients::Error,
     },
 
     #[snafu(display("The arguments given were invalid: {}", why))]
@@ -92,7 +96,7 @@ pub(crate) enum Error {
     JsonSerialize { source: serde_json::Error },
 
     #[snafu(display("Could not create map: {}", source))]
-    ConfigMap { source: model::Error },
+    ConfigMap { source: testsys_model::Error },
 
     #[snafu(display("Could not extract registry url from '{}'", uri))]
     MissingRegistry { uri: String },
@@ -100,7 +104,7 @@ pub(crate) enum Error {
     #[snafu(display("{}: {}", message, source))]
     ModelClient {
         message: String,
-        source: model::clients::Error,
+        source: testsys_model::clients::Error,
     },
 
     #[snafu(display("No stdout from request"))]
@@ -128,11 +132,13 @@ pub(crate) enum Error {
     Set {
         name: String,
         what: String,
-        source: model::clients::Error,
+        source: testsys_model::clients::Error,
     },
 
     #[snafu(display("Unable to create client: {}", source))]
-    TestClientNew { source: model::clients::Error },
+    TestClientNew {
+        source: testsys_model::clients::Error,
+    },
 
     #[snafu(display("Unable to create Test CRD from '{}': {}", path.display(), source))]
     TestFileParse {

--- a/bottlerocket/testsys/src/install.rs
+++ b/bottlerocket/testsys/src/install.rs
@@ -5,17 +5,17 @@ use k8s_openapi::{
     api::core::v1::Secret, apiextensions_apiserver::pkg::apis::apiextensions::v1 as apiexts,
 };
 use kube::{Api, Client, CustomResourceExt};
-use model::constants::NAMESPACE;
-use model::system::{
-    agent_cluster_role, agent_cluster_role_binding, agent_service_account, controller_cluster_role,
-    controller_cluster_role_binding, controller_deployment, controller_service_account,
-    testsys_namespace, AgentType,
-};
-use model::{Resource, Test};
 use snafu::ResultExt;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use structopt::StructOpt;
+use testsys_model::constants::NAMESPACE;
+use testsys_model::system::{
+    agent_cluster_role, agent_cluster_role_binding, agent_service_account, controller_cluster_role,
+    controller_cluster_role_binding, controller_deployment, controller_service_account,
+    testsys_namespace, AgentType,
+};
+use testsys_model::{Resource, Test};
 
 const CONTROLLER_SECRET: &str = "testsys-controller-pull-cred";
 

--- a/bottlerocket/testsys/src/logs.rs
+++ b/bottlerocket/testsys/src/logs.rs
@@ -5,12 +5,12 @@ use kube::{
     api::{ListParams, LogParams},
     Api, Client, ResourceExt,
 };
-use model::{
+use snafu::ResultExt;
+use structopt::StructOpt;
+use testsys_model::{
     clients::{CrdClient, TestClient},
     constants::NAMESPACE,
 };
-use snafu::ResultExt;
-use structopt::StructOpt;
 
 /// Retrieve the logs for a testsys test and all resources it depends on.
 #[derive(Debug, StructOpt)]

--- a/bottlerocket/testsys/src/restart_test.rs
+++ b/bottlerocket/testsys/src/restart_test.rs
@@ -1,8 +1,8 @@
 use crate::error::{self, Result};
 use kube::Client;
-use model::clients::{CrdClient, TestClient};
 use snafu::ResultExt;
 use structopt::StructOpt;
+use testsys_model::clients::{CrdClient, TestClient};
 
 /// Restart an object from a testsys cluster.
 #[derive(Debug, StructOpt)]

--- a/bottlerocket/testsys/src/results.rs
+++ b/bottlerocket/testsys/src/results.rs
@@ -5,10 +5,10 @@ use kube::{
     api::{AttachParams, ListParams},
     Api, Client, ResourceExt,
 };
-use model::constants::{NAMESPACE, TESTSYS_RESULTS_FILE};
 use snafu::ResultExt;
 use std::path::PathBuf;
 use structopt::StructOpt;
+use testsys_model::constants::{NAMESPACE, TESTSYS_RESULTS_FILE};
 use tokio::io::AsyncWriteExt;
 
 /// Retrieve the results of a test.

--- a/bottlerocket/testsys/src/run_aws_ecs.rs
+++ b/bottlerocket/testsys/src/run_aws_ecs.rs
@@ -6,17 +6,17 @@ use bottlerocket_types::agent_config::{
 use kube::ResourceExt;
 use kube::{api::ObjectMeta, Client};
 use maplit::btreemap;
-use model::clients::{CrdClient, ResourceClient, TestClient};
-use model::constants::NAMESPACE;
-use model::{
-    Agent, Configuration, DestructionPolicy, Resource, ResourceSpec, SecretName, Test, TestSpec,
-};
 use serde_json::Value;
 use snafu::ResultExt;
 use std::collections::BTreeMap;
 use std::fs::read_to_string;
 use std::str::FromStr;
 use structopt::StructOpt;
+use testsys_model::clients::{CrdClient, ResourceClient, TestClient};
+use testsys_model::constants::NAMESPACE;
+use testsys_model::{
+    Agent, Configuration, DestructionPolicy, Resource, ResourceSpec, SecretName, Test, TestSpec,
+};
 
 #[derive(Clone, Debug)]
 enum CustomUserDataMode {

--- a/bottlerocket/testsys/src/run_aws_k8s.rs
+++ b/bottlerocket/testsys/src/run_aws_k8s.rs
@@ -7,14 +7,14 @@ use bottlerocket_types::agent_config::{
 use kube::Client;
 use kube::ResourceExt;
 use maplit::btreemap;
-use model::clients::{CrdClient, ResourceClient, TestClient};
-use model::{DestructionPolicy, Resource, SecretName, Test};
 use snafu::OptionExt;
 use snafu::ResultExt;
 use std::collections::BTreeMap;
 use std::fs::read_to_string;
 use std::str::FromStr;
 use structopt::StructOpt;
+use testsys_model::clients::{CrdClient, ResourceClient, TestClient};
+use testsys_model::{DestructionPolicy, Resource, SecretName, Test};
 
 #[derive(Clone, Debug)]
 enum CustomUserDataMode {

--- a/bottlerocket/testsys/src/run_file.rs
+++ b/bottlerocket/testsys/src/run_file.rs
@@ -1,13 +1,13 @@
 use crate::error::{self, Result};
 use kube::Client;
-use model::{
-    clients::{CrdClient, ResourceClient, TestClient},
-    Resource, Test,
-};
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use std::path::PathBuf;
 use structopt::StructOpt;
+use testsys_model::{
+    clients::{CrdClient, ResourceClient, TestClient},
+    Resource, Test,
+};
 
 /// Run a test stored in a YAML file at `path`.
 #[derive(Debug, StructOpt)]

--- a/bottlerocket/testsys/src/run_sonobuoy.rs
+++ b/bottlerocket/testsys/src/run_sonobuoy.rs
@@ -1,12 +1,12 @@
 use crate::error::{self, Result};
 use bottlerocket_types::agent_config::{SonobuoyConfig, SonobuoyMode, AWS_CREDENTIALS_SECRET_NAME};
 use kube::{api::ObjectMeta, Client};
-use model::clients::CrdClient;
-use model::constants::NAMESPACE;
-use model::{clients::TestClient, Agent, Configuration, SecretName, Test, TestSpec};
 use snafu::ResultExt;
 use std::{collections::BTreeMap, fs::read_to_string, path::PathBuf};
 use structopt::StructOpt;
+use testsys_model::clients::CrdClient;
+use testsys_model::constants::NAMESPACE;
+use testsys_model::{clients::TestClient, Agent, Configuration, SecretName, Test, TestSpec};
 
 /// Run a test stored in a YAML file at `path`.
 #[derive(Debug, StructOpt)]

--- a/bottlerocket/testsys/src/run_vmware.rs
+++ b/bottlerocket/testsys/src/run_vmware.rs
@@ -6,11 +6,6 @@ use bottlerocket_types::agent_config::{
 };
 use kube::ResourceExt;
 use kube::{api::ObjectMeta, Client};
-use model::clients::{CrdClient, ResourceClient, TestClient};
-use model::constants::NAMESPACE;
-use model::{
-    Agent, Configuration, DestructionPolicy, Resource, ResourceSpec, SecretName, Test, TestSpec,
-};
 use serde_json::Value;
 use snafu::ResultExt;
 use std::collections::BTreeMap;
@@ -18,6 +13,11 @@ use std::fs::read_to_string;
 use std::path::PathBuf;
 use std::str::FromStr;
 use structopt::StructOpt;
+use testsys_model::clients::{CrdClient, ResourceClient, TestClient};
+use testsys_model::constants::NAMESPACE;
+use testsys_model::{
+    Agent, Configuration, DestructionPolicy, Resource, ResourceSpec, SecretName, Test, TestSpec,
+};
 
 #[derive(Clone, Debug)]
 enum CustomUserDataMode {

--- a/bottlerocket/testsys/src/set.rs
+++ b/bottlerocket/testsys/src/set.rs
@@ -1,8 +1,8 @@
 use crate::error::{self, Result};
 use kube::Client;
-use model::clients::{CrdClient, TestClient};
 use snafu::ResultExt;
 use structopt::StructOpt;
+use testsys_model::clients::{CrdClient, TestClient};
 
 /// Set the field of a testsys test.
 #[derive(Debug, StructOpt)]

--- a/bottlerocket/testsys/src/status.rs
+++ b/bottlerocket/testsys/src/status.rs
@@ -4,14 +4,14 @@ use k8s_openapi::api::core::v1::Pod;
 use kube::api::ListParams;
 use kube::core::object::HasStatus;
 use kube::{Api, Client, ResourceExt};
-use model::clients::{CrdClient, ResourceClient, TestClient};
-use model::constants::{LABEL_COMPONENT, NAMESPACE};
-use model::{Resource, TaskState, Test};
 use serde::Serialize;
 use snafu::ResultExt;
 use structopt::StructOpt;
 use tabled::{Alignment, Column, Full, MaxWidth, Modify, Style, Table, Tabled};
 use termion::terminal_size;
+use testsys_model::clients::{CrdClient, ResourceClient, TestClient};
+use testsys_model::constants::{LABEL_COMPONENT, NAMESPACE};
+use testsys_model::{Resource, TaskState, Test};
 
 /// Check the status of a TestSys object.
 #[derive(Debug, StructOpt)]

--- a/bottlerocket/testsys/tests/cli_test.rs
+++ b/bottlerocket/testsys/tests/cli_test.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "integ")]
 mod data;
 use assert_cmd::Command;
-use model::{constants::NAMESPACE, Resource, Test};
 use selftest::Cluster;
+use testsys_model::{constants::NAMESPACE, Resource, Test};
 use tokio::time::Duration;
 
 /// The amount of time we will wait for the controller to run, a test-agent to run, etc. before we

--- a/bottlerocket/types/Cargo.toml
+++ b/bottlerocket/types/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 configuration-derive = { version = "0.0.5", path = "../../agent/configuration-derive" }
 builder-derive = { version = "0.0.5", path = "../../agent/builder-derive" }
-model = { version = "0.0.5", path = "../../model" }
+testsys-model = { version = "0.0.5", path = "../../model" }
 serde = "1"
 serde_plain = "1"
 serde_yaml = "0.8"

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -522,10 +522,10 @@ pub struct EcsWorkloadTestConfig {
 #[cfg(test)]
 mod test {
     use crate::agent_config::{Ec2Config, EcsClusterConfig, EcsTestConfig, MigrationConfig};
-    use model::{Resource, Test};
     use serde_json::Value as JsonValue;
     use std::fs::read_to_string;
     use std::path::PathBuf;
+    use testsys_model::{Resource, Test};
 
     use super::{
         EcsWorkloadTestConfig, EksClusterConfig, SonobuoyConfig, VSphereK8sClusterConfig,

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "4.0", features = ["derive"] }
 env_logger = "0.10"
 futures = "0.3"
 log = "0.4"
-model = { path = "../model" }
+testsys-model = { path = "../model" }
 serde = "1"
 serde_json = "1"
 serde_plain = "1"

--- a/cli/src/add_secret.rs
+++ b/cli/src/add_secret.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use model::test_manager::TestManager;
-use model::SecretName;
+use testsys_model::test_manager::TestManager;
+use testsys_model::SecretName;
 
 /// Add a secret to the cluster.
 #[derive(Debug, Parser)]

--- a/cli/src/delete.rs
+++ b/cli/src/delete.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use futures::TryStreamExt;
-use model::test_manager::{DeleteEvent, TestManager};
+use testsys_model::test_manager::{DeleteEvent, TestManager};
 
 /// Delete all objects from a testsys cluster.
 #[derive(Debug, Parser)]

--- a/cli/src/describe.rs
+++ b/cli/src/describe.rs
@@ -1,8 +1,8 @@
 use anyhow::{Error, Result};
 use clap::Parser;
-use model::clients::CrdClient;
-use model::test_manager::TestManager;
-use model::CrdExt;
+use testsys_model::clients::CrdClient;
+use testsys_model::test_manager::TestManager;
+use testsys_model::CrdExt;
 
 /// Retrieve the YAML description of a test or resource.
 #[derive(Debug, Parser)]

--- a/cli/src/install.rs
+++ b/cli/src/install.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use model::test_manager::{ImageConfig, TestManager};
+use testsys_model::test_manager::{ImageConfig, TestManager};
 
 /// The install subcommand is responsible for putting all of the necessary components for testsys in
 /// a k8s cluster.

--- a/cli/src/logs.rs
+++ b/cli/src/logs.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Error, Result};
 use clap::Parser;
 use futures::StreamExt;
-use model::test_manager::{ResourceState, TestManager};
+use testsys_model::test_manager::{ResourceState, TestManager};
 
 /// Restart an object from a testsys cluster.
 #[derive(Debug, Parser)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,8 +21,8 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use env_logger::Builder;
 use log::LevelFilter;
-use model::test_manager::TestManager;
 use std::path::PathBuf;
+use testsys_model::test_manager::TestManager;
 
 /// The command line interface for setting up a Bottlerocket TestSys cluster and running tests.
 #[derive(Debug, Parser)]

--- a/cli/src/restart.rs
+++ b/cli/src/restart.rs
@@ -1,7 +1,7 @@
 use crate::restart_test;
 use anyhow::Result;
 use clap::Parser;
-use model::test_manager::TestManager;
+use testsys_model::test_manager::TestManager;
 
 /// Restart testsys tests.
 #[derive(Debug, Parser)]

--- a/cli/src/restart_test.rs
+++ b/cli/src/restart_test.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use model::test_manager::TestManager;
+use testsys_model::test_manager::TestManager;
 
 /// Restart an object from a testsys cluster.
 #[derive(Debug, Parser)]

--- a/cli/src/results.rs
+++ b/cli/src/results.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use clap::{value_parser, Parser};
-use model::test_manager::TestManager;
 use std::path::PathBuf;
+use testsys_model::test_manager::TestManager;
 
 /// Retrieve the results of a test.
 #[derive(Debug, Parser)]

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -1,7 +1,7 @@
 use crate::run_file;
 use anyhow::Result;
 use clap::Parser;
-use model::test_manager::TestManager;
+use testsys_model::test_manager::TestManager;
 
 /// Run testsys tests.
 #[derive(Debug, Parser)]

--- a/cli/src/run_file.rs
+++ b/cli/src/run_file.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use clap::{value_parser, Parser};
-use model::test_manager::{read_manifest, TestManager};
 use std::path::PathBuf;
+use testsys_model::test_manager::{read_manifest, TestManager};
 
 /// Run a test stored in a YAML file at `path`.
 #[derive(Debug, Parser)]

--- a/cli/src/status.rs
+++ b/cli/src/status.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use model::test_manager::{CrdState, CrdType, SelectionParams, StatusProgress, TestManager};
 use terminal_size::{Height, Width};
+use testsys_model::test_manager::{
+    CrdState, CrdType, SelectionParams, StatusProgress, TestManager,
+};
 
 /// Check the status of a TestSys object.
 #[derive(Debug, Parser)]

--- a/cli/src/uninstall.rs
+++ b/cli/src/uninstall.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use model::test_manager::TestManager;
+use testsys_model::test_manager::TestManager;
 
 /// The uninstall subcommand is responsible for removing all testsys components from a k8s cluster.
 #[derive(Debug, Parser)]

--- a/cli/tests/cli_test.rs
+++ b/cli/tests/cli_test.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "integ")]
 mod data;
 use assert_cmd::Command;
-use model::{constants::NAMESPACE, Resource, Test};
 use selftest::Cluster;
+use testsys_model::{constants::NAMESPACE, Resource, Test};
 use tokio::time::Duration;
 
 /// The amount of time we will wait for the controller to run, a test-agent to run, etc. before we

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -15,7 +15,7 @@ kube = { version = "0.75", default-features = true, features = ["derive"] }
 kube-runtime = "0.75"
 lazy_static = "1"
 log = "0.4"
-model = { version = "0.0.5", path = "../model" }
+testsys-model = { version = "0.0.5", path = "../model" }
 schemars = "=0.8.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/controller/src/job/error.rs
+++ b/controller/src/job/error.rs
@@ -1,6 +1,6 @@
 use http::StatusCode;
-use model::clients::HttpStatusCode;
 use snafu::Snafu;
+use testsys_model::clients::HttpStatusCode;
 
 pub(crate) type JobResult<T> = std::result::Result<T, JobError>;
 

--- a/controller/src/job/job_builder.rs
+++ b/controller/src/job/job_builder.rs
@@ -7,13 +7,13 @@ use k8s_openapi::api::core::v1::{
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::api::PostParams;
 use kube::Api;
-use model::constants::{
+use std::collections::BTreeMap;
+use testsys_model::constants::{
     APP_COMPONENT, APP_CREATED_BY, APP_INSTANCE, APP_MANAGED_BY, APP_NAME, APP_PART_OF, CONTROLLER,
     NAMESPACE, RESOURCE_AGENT, RESOURCE_AGENT_SERVICE_ACCOUNT, SECRETS_PATH, TESTSYS, TEST_AGENT,
     TEST_AGENT_SERVICE_ACCOUNT,
 };
-use model::Agent;
-use std::collections::BTreeMap;
+use testsys_model::Agent;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum JobType {

--- a/controller/src/job/mod.rs
+++ b/controller/src/job/mod.rs
@@ -8,8 +8,8 @@ use k8s_openapi::chrono::{Duration, Utc};
 use kube::api::{DeleteParams, PropagationPolicy};
 use kube::Api;
 use log::debug;
-use model::constants::NAMESPACE;
 use snafu::ensure;
+use testsys_model::constants::NAMESPACE;
 
 lazy_static::lazy_static! {
     /// The maximum amount of time for a test to begin running (in seconds).

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -67,7 +67,7 @@ fn init_logger() {
             // RUST_LOG does not exist; use default log level for this crate only.
             Builder::new()
                 .filter(Some(env!("CARGO_CRATE_NAME")), DEFAULT_LEVEL_FILTER)
-                .filter(Some("model"), DEFAULT_LEVEL_FILTER)
+                .filter(Some("testsys_model"), DEFAULT_LEVEL_FILTER)
                 .init();
         }
     }

--- a/controller/src/resource_controller/action.rs
+++ b/controller/src/resource_controller/action.rs
@@ -5,9 +5,9 @@ use crate::utils::parse_duration;
 use kube::core::object::HasSpec;
 use kube::ResourceExt;
 use log::{debug, trace};
-use model::clients::{AllowNotFound, CrdClient, TestClient};
-use model::constants::{FINALIZER_CREATION_JOB, FINALIZER_MAIN, FINALIZER_RESOURCE};
-use model::{CrdExt, DestructionPolicy, ResourceAction, TaskState, TestUserState};
+use testsys_model::clients::{AllowNotFound, CrdClient, TestClient};
+use testsys_model::constants::{FINALIZER_CREATION_JOB, FINALIZER_MAIN, FINALIZER_RESOURCE};
+use testsys_model::{CrdExt, DestructionPolicy, ResourceAction, TaskState, TestUserState};
 
 /// The action that the controller needs to take in order to reconcile the [`Resource`].
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/controller/src/resource_controller/context.rs
+++ b/controller/src/resource_controller/context.rs
@@ -3,11 +3,11 @@ use crate::job::{delete_job, get_job_state, JobBuilder, JobState, JobType};
 use anyhow::Context as AnyhowContext;
 use kube::Api;
 use log::debug;
-use model::clients::{CrdClient, ResourceClient};
-use model::constants::{ENV_RESOURCE_ACTION, ENV_RESOURCE_NAME};
-use model::test_manager::ResourceState;
-use model::{CrdExt, Resource, ResourceAction};
 use std::sync::Arc;
+use testsys_model::clients::{CrdClient, ResourceClient};
+use testsys_model::constants::{ENV_RESOURCE_ACTION, ENV_RESOURCE_NAME};
+use testsys_model::test_manager::ResourceState;
+use testsys_model::{CrdExt, Resource, ResourceAction};
 
 /// This is used by `kube-runtime` to pass any custom information we need when [`reconcile`] is
 /// called.

--- a/controller/src/resource_controller/mod.rs
+++ b/controller/src/resource_controller/mod.rs
@@ -14,11 +14,13 @@ use kube::{Api, Client};
 use kube_runtime::controller::Action as RequeueAction;
 use kube_runtime::{controller, Controller};
 use log::{debug, error, trace, warn};
-use model::clients::CrdClient;
-use model::constants::{FINALIZER_CREATION_JOB, FINALIZER_MAIN, FINALIZER_RESOURCE, NAMESPACE};
-use model::{CrdExt, ErrorResources, Resource, ResourceAction, ResourceError};
 use std::ops::Deref;
 use std::sync::Arc;
+use testsys_model::clients::CrdClient;
+use testsys_model::constants::{
+    FINALIZER_CREATION_JOB, FINALIZER_MAIN, FINALIZER_RESOURCE, NAMESPACE,
+};
+use testsys_model::{CrdExt, ErrorResources, Resource, ResourceAction, ResourceError};
 
 pub(crate) async fn run_resource_controller(client: Client) {
     let context = new_context(client.clone());

--- a/controller/src/test_controller/action.rs
+++ b/controller/src/test_controller/action.rs
@@ -5,10 +5,10 @@ use crate::utils::parse_duration;
 use anyhow::Context;
 use kube::{Api, ResourceExt};
 use log::trace;
-use model::clients::{CrdClient, HttpStatusCode, StatusCode};
-use model::constants::{FINALIZER_MAIN, FINALIZER_TEST_JOB, NAMESPACE};
-use model::{CrdExt, Outcome, Resource, ResourceAction, TaskState};
 use std::fmt::{Display, Formatter};
+use testsys_model::clients::{CrdClient, HttpStatusCode, StatusCode};
+use testsys_model::constants::{FINALIZER_MAIN, FINALIZER_TEST_JOB, NAMESPACE};
+use testsys_model::{CrdExt, Outcome, Resource, ResourceAction, TaskState};
 
 /// The action that the controller needs to take in order to reconcile the `Test`.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/controller/src/test_controller/context.rs
+++ b/controller/src/test_controller/context.rs
@@ -2,9 +2,9 @@ use crate::error::Result;
 use crate::job::{delete_job, get_job_state, JobState};
 use anyhow::Context as AnyhowContext;
 use kube::{Api, Client};
-use model::clients::{CrdClient, TestClient};
-use model::Test;
 use std::sync::Arc;
+use testsys_model::clients::{CrdClient, TestClient};
+use testsys_model::Test;
 
 /// This is used by `kube-runtime` to pass any custom information we need when [`reconcile`] is
 /// called.

--- a/controller/src/test_controller/mod.rs
+++ b/controller/src/test_controller/mod.rs
@@ -7,8 +7,8 @@ use kube::api::ListParams;
 use kube_runtime::controller::Action as RequeueAction;
 use kube_runtime::{controller, Controller};
 use log::{debug, error};
-use model::Test;
 use std::sync::Arc;
+use testsys_model::Test;
 
 mod action;
 mod context;

--- a/controller/src/test_controller/reconcile.rs
+++ b/controller/src/test_controller/reconcile.rs
@@ -6,11 +6,11 @@ use crate::test_controller::context::{Context, TestInterface};
 use anyhow::Context as AnyhowContext;
 use kube_runtime::controller::Action as RequeueAction;
 use log::{debug, error, trace};
-use model::clients::CrdClient;
-use model::constants::{ENV_TEST_NAME, FINALIZER_MAIN, FINALIZER_TEST_JOB};
-use model::{TaskState, Test};
 use std::ops::Deref;
 use std::sync::Arc;
+use testsys_model::clients::CrdClient;
+use testsys_model::constants::{ENV_TEST_NAME, FINALIZER_MAIN, FINALIZER_TEST_JOB};
+use testsys_model::{TaskState, Test};
 
 /// `reconcile` is called when a new `Test` object arrives, or when a `Test` object has been
 /// re-queued. This is the entrypoint to the controller logic.

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -63,12 +63,12 @@ Once a resource is marked for deletion (`cli delete`), the `destroy` function of
 
 For more info, see the [design](DESIGN.md) document.
 
-### [Model](model)
+### [TestSys-Model](model)
 
-The model library contains the infrastructure that TestSys is built upon.
+The testsys-model library contains the infrastructure that TestSys is built upon.
 This includes the CRDs for [tests](model/src/test.rs) and [resources](model/src/resource.rs) as well as [everything](model/system) needed to be installed to the TestSys cluster.
 
-All interactions with the TestSys cluster should be done using the model library through `TestManager`, `TestClient`, or `ResourceClient`.
+All interactions with the TestSys cluster should be done using the testsys-model library through `TestManager`, `TestClient`, or `ResourceClient`.
 
 The model provides [TestManager](model/src/test_manager/manager.rs) which can be used as an entry point for user interactions with TestSys.
 To see how to use the TestManager look at the [example CLI](cli).

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "model"
+name = "testsys-model"
 version = "0.0.5"
 edition = "2021"
 publish = false

--- a/model/src/clients/resource_client.rs
+++ b/model/src/clients/resource_client.rs
@@ -33,7 +33,7 @@ lazy_static::lazy_static! {
 /// # Example
 ///
 /// ```
-///# use model::clients::{CrdClient, ResourceClient};
+///# use testsys_model::clients::{CrdClient, ResourceClient};
 ///# async fn no_run() {
 /// let resource_client = ResourceClient::new().await.unwrap();
 /// let test = resource_client.get("my-resource").await.unwrap();

--- a/model/src/clients/test_client.rs
+++ b/model/src/clients/test_client.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 /// # Example
 ///
 /// ```
-///# use model::clients::{CrdClient, TestClient};
+///# use testsys_model::clients::{CrdClient, TestClient};
 ///# async fn no_run() {
 /// let test_client = TestClient::new().await.unwrap();
 /// let test = test_client.get("my-test").await.unwrap();

--- a/selftest/Cargo.toml
+++ b/selftest/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3"
 k8s-openapi = { version = "0.16", default-features = false, features = ["v1_20"] }
 kube = { version = "0.75", default-features = true }
 lazy_static = "1"
-model = { version = "0.0.5", path = "../model"}
+testsys-model = { version = "0.0.5", path = "../model"}
 serde = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["time"] }

--- a/selftest/src/cluster.rs
+++ b/selftest/src/cluster.rs
@@ -7,10 +7,6 @@ use kube::{
     config::{KubeConfigOptions, Kubeconfig},
     Api, Client, Config,
 };
-use model::clients::{CrdClient, HttpStatusCode, ResourceClient, StatusCode};
-use model::constants::{LABEL_COMPONENT, LABEL_PROVIDER_NAME, NAMESPACE};
-use model::test_manager::ResourceState;
-use model::{Resource, Test};
 use std::fmt::Debug;
 use std::{convert::TryInto, fs::File};
 use std::{
@@ -18,6 +14,10 @@ use std::{
     path::{Path, PathBuf},
 };
 use tempfile::TempDir;
+use testsys_model::clients::{CrdClient, HttpStatusCode, ResourceClient, StatusCode};
+use testsys_model::constants::{LABEL_COMPONENT, LABEL_PROVIDER_NAME, NAMESPACE};
+use testsys_model::test_manager::ResourceState;
+use testsys_model::{Resource, Test};
 use tokio::time::Duration;
 
 pub const KUBECONFIG_FILENAME: &str = "kubeconfig.yaml";


### PR DESCRIPTION
**Description of changes:**

This commit simply renames `model` as `testsys-model` to avoid confusion with similarly named crates.

**Testing done:**

`cargo check`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
