### PR TITLE
docs: updated QUICKSTART to use cli instead of testsys

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -21,14 +21,14 @@ export EKS_REGION="us-west-2"
 export CARGO_HOME="${TESTSYS_DIR}/.cargo"
 K8S_VER="1.21"
 REGION="${EKS_RESION}"
-alias testsys="${TESTSYS_DIR}/.cargo/bin/testsys"
+alias cli="${TESTSYS_DIR}/.cargo/bin/cli"
 ```
 
-Install the `testsys` command line tool into the local CARGO_HOME and build the containers we need:
+Install the `cli` command line tool into the local CARGO_HOME and build the containers we need:
 
 ```shell
 cd "${TESTSYS_DIR}"
-cargo install --path "${TESTSYS_DIR}/bottlerocket/testsys" --force
+cargo install --path "${TESTSYS_DIR}/cli" --force
 
 make controller
 make ec2-resource-agent
@@ -60,81 +60,75 @@ Next we install the TestSys namespace, controller and CRD schemas into the TestS
 We also set our kubeconfig context to the testsys namespace for convenience.
 
 ```shell
-testsys install --controller-uri controller:eks
+cli install --controller-uri controller:eks
 kubectl config set-context --current --namespace="testsys"
 ```
 
 We will be creating an EKS cluster and EC2 instances, so we need to create a Kubernetes secret with our AWS credentials.
 
 ```shell
-testsys add secret map  \
+cli add-secret map  \
  --name "aws-creds" \
  "access-key-id=$(aws configure get default.aws_access_key_id)" \
  "secret-access-key=$(aws configure get default.aws_secret_access_key)"
 ```
 
 Now we are ready to run a Bottlerocket test.
-We get the latest AMI ID.
-Then we pass it to TestSys which will create an EKS cluster, launch Bottlerocket nodes and run a Sonobuoy test in 'quick' mode.
-
-**Caution**: The command below specifies `never` as the `--cluster-destruction-policy`.
-This is because creating a cluster takes a long time, and we might want to re-use it.
-To delete the cluster manually, use `eksctl delete cluster "external-cluster"` or delete the relevant CloudFormation stacks.
-You can also change the `--cluster-destruction-policy` to `onDeletion` in the command below.
-If you do, then when you `kubectl delete resource external-cluster`, the EKS cluster will be deleted.
+The test can be customized with environment variables.
+Information on these can be found in [Makefile.toml](../bottlerocket/samples/Makefile.toml) and [RUNBOOK.md](../bottlerocket/samples/RUNBOOK.md) in the [bottlerocket/samples](../bottlerocket/samples/) directory.
+The following commands will create a test file, pass it to TestSys which will run it on an EKS cluster, launch Bottlerocket nodes and run a Sonobuoy test in 'quick' mode.
 
 ```shell
-ARCH="x86_64"
-VARIANT="aws-k8s-${K8S_VER}"
-export AMI_ID=$(aws ssm get-parameter \
-  --region "${REGION}" \
-  --name "/aws/service/bottlerocket/${VARIANT}/${ARCH}/latest/image_id" \
-  --query Parameter.Value --output text)
-
-testsys run aws-k8s \
-  --name "testsys-demo" \
-  --test-agent-image "sonobuoy-test-agent:eks" \
-  --keep-running \
-  --sonobuoy-mode "quick" \
-  --aws-secret "aws-creds" \
-  --region "${REGION}" \
-  --cluster-name "${EKS_CLUSTER_NAME}" \
-  --cluster-creation-policy "ifNotExists" \
-  --cluster-destruction-policy "never" \
-  --cluster-provider-image "eks-resource-agent:eks" \
-  --ami "${AMI_ID}" \
-  --ec2-provider-image "ec2-resource-agent:eks"
+cd bottlerocket/samples
+export CLUSTER_NAME=${EKS_CLUSTER_NAME}
+export ARCH="x86_64"
+export VARIANT="aws-k8s-${K8S_VER}"
+export CLUSTER_TYPE="kind"
+export SONOBUOY_TEST_AGENT_IMAGE_URI="sonobuoy-test-agent:eks"
+export EKS_RESOURCE_AGENT_IMAGE_URI="eks-resource-agent:eks"
+export EC2_RESOURCE_AGENT_IMAGE_URI="ec2-resource-agent:eks"
+cargo make run sonobuoy-test
 ```
 
 ## Test Results
 
-Executing the `testsys run aws-k8s` command will kick off the setup and execution of the Sonobuoy tests on an EKS cluster using Bottlerocket as the host OS for the cluster nodes.
+Executing the `cargo make run sonobuoy-test` command will kick off the setup and execution of the Sonobuoy tests on an EKS cluster using Bottlerocket as the host OS for the cluster nodes.
 
-To get the status and results of test execution, run the `testsys status` command for a high level summary:
+To get the status and results of test execution, run the `cli status` command for a high level summary:
 
 ```shell
- NAME           TYPE   STATE    PASSED   SKIPPED   FAILED
- testsys-demo   Test   passed   1        5772      0
+ NAME                         TYPE       STATE       PASSED   SKIPPED   FAILED
+ external-cluster             Resource   completed                                                                                                                                                                                      
+ external-cluster-instances   Resource   completed
+ external-cluster-test        Test       passed      1        5772      0
 ```
 
-**Note:** run `testsys status --help` to learn about more options.
+**Note:** run `cli status --help` to learn about more options.
 Notably the `-c` and `-r` arguments for getting controller and resource status.
 
 When the test run has completed you may get the full logs of the test results.
 The content of the resulting tar file will vary depending on the tests being run.
 
 ```shell
-testsys results --destination testresults.tar --test-name testsys-demo
+cli results --destination testresults.tar --test-name testsys-demo
 tar -xvf testresults.tar
 ```
 
 ## Cleanup
 
-If you used the `--cluster-destruction-policy never` as given above, there will be an EKS cluster running at the end of execution.
+Most of the cleanup can be done by using this command:
+
+```shell
+cli delete
+```
+
+This will delete all tests and resources where `destructionPolicy` is `onDeletion`.
+
+If you used `destructionPolicy: never`, there will be an EKS cluster running at the end of execution.
 This can be very convenient to keep around for subsequent test runs.
 
 It does however consume resources and incur usage charges.
-If you are done running tests and would like to clean up, run the following to delete the EKS cluster.
+If you are done running tests and would like to clean up the EKS cluster, run the following to delete it.
 
 ```shell
 eksctl delete cluster external-cluster


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Updated `QUICKSTART.md` to use the `cli` CLI instead of the old `testsys` CLI since it is being removed in https://github.com/bottlerocket-os/bottlerocket-test-system/pull/754.

**Testing done:**

Ran through the new instructions, letting the test complete and pass.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
