### PR TITLE
samples: changed CLUSTER_NAME to depend on TEST_TYPE

### DIFF
--- a/bottlerocket/samples/Makefile.toml
+++ b/bottlerocket/samples/Makefile.toml
@@ -65,7 +65,15 @@ CONTROLLER_IMAGE_URI = { value = "${AGENT_IMAGE_REGISTRY}/controller:v${AGENT_IM
 METADATA_URL = { script=["echo ${METADATA_BASE_URL}/${VARIANT}/${ARCH}"], condition = { env_not_set = ["METADATA_URL"] } }
 
 [tasks.cluster-name.env]
-CLUSTER_NAME = { script=["echo $(echo ${ARCH} | tr '_' '-')-$(echo ${VARIANT} | tr -d '.')"], condition = { env_not_set = ["CLUSTER_NAME"] } }
+CLUSTER_NAME = { script=['''
+    BASE_NAME=$(echo ${ARCH} | tr '_' '-')-$(echo ${VARIANT} | tr -d '.')
+    if echo ${TEST_TYPE} | grep 'migration' > /dev/null; then
+        BASE_NAME=$(echo ${BASE_NAME}-migration)
+    elif echo ${TEST_TYPE} | grep 'workload' > /dev/null; then
+        BASE_NAME=$(echo ${BASE_NAME}-workload)
+    fi
+    echo "${BASE_NAME}-test-cluster"
+'''], condition = { env_not_set = ["CLUSTER_NAME"] } }
 
 [tasks.ova-name.env]
 OVA_NAME = { script=["echo bottlerocket-${VARIANT}-x86_64-${STARTING_VERSION}.ova"], condition = { env_not_set = ["OVA_NAME"] } }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Changed `CLUSTER_NAME` to be generated from `ARCH`, `VARIANT`, and `TEST_TYPE` instead of just `ARCH` and `VARIANT`. This will avoid conflicts when running multiple different tests with the same `ARCH` and `VARIANT`.

**Testing done:**

Generated each test from the `eks` folder and made sure `CLUSTER_NAME` had the expected value.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
