### PR TITLE
samples: small fixes to Makefile variables

### DIFF
--- a/bottlerocket/samples/Makefile.toml
+++ b/bottlerocket/samples/Makefile.toml
@@ -3,7 +3,6 @@ skip_core_tasks = true
 
 [env]
 AGENT_IMAGE_REGISTRY = { value = "public.ecr.aws/bottlerocket-test-system", condition = { env_not_set = ["AGENT_IMAGE_REGISTRY"] } }
-AGENTS = ["eks-resource-agent"]
 METADATA_BASE_URL = { value = "https://updates.bottlerocket.aws/2020-07-07", condition = { env_not_set = ["METADATA_BASE_URL"] } }
 ARCH = { value = "x86_64", condition = { env_not_set = ["ARCH"] } }
 CLUSTER_TYPE = { value = "eks", condition = { env_not_set = ["CLUSTER_TYPE"] } }
@@ -13,7 +12,7 @@ UPGRADE_VERSION = { value = "v1.11.1", condition = { env_not_set = ["UPGRADE_VER
 STARTING_VERSION = { value = "v1.11.0", condition = { env_not_set = ["STARTING_VERSION"] } }
 SONOBUOY_MODE = { value = "quick", condition = { env_not_set = ["SONOBUOY_MODE"] } }
 TARGETS_URL = { value = "https://updates.bottlerocket.aws/targets", condition = { env_not_set = ["TARGETS_URL"] } }
-K8S_VERSION = { value = "1.24", condition = { env_not_set = ["K8S_VERSION"] } }
+K8S_VERSION = { value = "v1.24", condition = { env_not_set = ["K8S_VERSION"] } }
 
 # The following variables need values only if a workload test file is being created. `WORKLOAD_TEST_NAME` is an identifier for the workload test. `WORKLOAD_TEST_IMAGE_URI` is the URI to the workload test image.
 
@@ -62,7 +61,7 @@ VSPHERE_VM_RESOURCE_AGENT_IMAGE_URI = { value = "${AGENT_IMAGE_REGISTRY}/vsphere
 CONTROLLER_IMAGE_URI = { value = "${AGENT_IMAGE_REGISTRY}/controller:v${AGENT_IMAGE_VERSION}", condition = { env_not_set = ["CONTROLLER_IMAGE_URI"] } }
 
 [tasks.metadata-url.env]
-METADATA_URL = { script=["echo ${METADATA_BASE_URL}/${VARIANT}/${ARCH}"], condition = { env_not_set = ["METADATA_URL"] } }
+METADATA_URL = { script=["echo ${METADATA_BASE_URL}/${VARIANT}/${ARCH}/"], condition = { env_not_set = ["METADATA_URL"] } }
 
 [tasks.cluster-name.env]
 CLUSTER_NAME = { script=['''
@@ -106,7 +105,7 @@ fi
 [tasks.mgmt-cluster-kubeconfig-base64.env]
 MGMT_CLUSTER_KUBECONFIG_BASE64 = {script=['''
 if [ -n "${MGMT_CLUSTER_KUBECONFIG_PATH}" ]; then
-    cat ${MGMT_CLUSTER_KUBECONFIG_PATH} | base64
+    cat ${MGMT_CLUSTER_KUBECONFIG_PATH} | base64 -w 0
 fi
 ''']}
 
@@ -177,7 +176,7 @@ script = '''
 [tasks.workload-preconditions]
 condition = { env_contains = { "TEST_TYPE" = "workload" } }
 script = '''
-if [ -z ${WORKLOAD_TEST_NAME} ] || [ -z ${WORKLOAD_TEST_IMAGE} ]; then
+if [ -z ${WORKLOAD_TEST_NAME} ] || [ -z ${WORKLOAD_TEST_IMAGE_URI} ]; then
     echo "WORKLOAD_TEST_NAME or WORKLOAD_TEST_IMAGE_URI not set"
     exit 1
 fi
@@ -207,15 +206,7 @@ echo "${OUTPUT_FILE}"
 '''
 
 [tasks.create-inner.env]
-OUTPUT_FILE = {script=['''
-if echo ${TEST_TYPE} | grep 'migration' > /dev/null; then
-    echo "output/${CLUSTER_NAME}-migration.yaml"
-elif echo ${TEST_TYPE} | grep 'workload' > /dev/null; then
-    echo "output/${CLUSTER_NAME}-workload.yaml"
-else
-    echo "output/${CLUSTER_NAME}.yaml"
-fi
-''']}
+OUTPUT_FILE = { script = [ "echo 'output/${CLUSTER_NAME}.yaml'" ] }
 
 [tasks.create]
 script = '''

--- a/bottlerocket/samples/eks/vmware-migration-test.yaml
+++ b/bottlerocket/samples/eks/vmware-migration-test.yaml
@@ -26,8 +26,8 @@ metadata:
 spec:
   agent:
     configuration:
-      awsRegion: ${REGION}
-      instanceIds: \${${CLUSTER_NAME}-vms.ids}
+      awsRegion: ${AWS_REGION}
+      instanceIds: \${${CLUSTER_NAME}-vms.instanceIds}
       migrateToVersion: ${UPGRADE_VERSION}
       tufRepo:
         metadataUrl: ${METADATA_URL}
@@ -69,8 +69,8 @@ metadata:
 spec:
   agent:
     configuration:
-      awsRegion: ${REGION}
-      instanceIds: \${${CLUSTER_NAME}-vms.ids}
+      awsRegion: ${AWS_REGION}
+      instanceIds: \${${CLUSTER_NAME}-vms.instanceIds}
       migrateToVersion: ${STARTING_VERSION}
       tufRepo:
         metadataUrl: ${METADATA_URL}
@@ -114,6 +114,7 @@ spec:
     name: agent
     image: ${VSPHERE_K8S_CLUSTER_RESOURCE_AGENT_IMAGE_URI}
     keepRunning: true
+    privileged: true
     configuration:
       controlPlaneEndpointIp: ${CONTROL_PLANE_ENDPOINT_IP}
       creationPolicy: ifNotExists
@@ -124,12 +125,12 @@ spec:
         metadataUrl: ${METADATA_URL}
         targetsUrl: ${TARGETS_URL}
       version: ${K8S_VERSION}
-      vcenterDatacenter: ${VCENTER_DATACENTER}
-      vcenterDatastore: ${VCENTER_DATASTORE}
-      vcenterHostUrl: ${VCENTER_HOST_URL}
-      vcenterNetwork: ${VCENTER_NETWORK}
-      vcenterResourcePool: ${VCENTER_RESOURCE_POOL}
-      vcenterWorkloadFolder: ${VCENTER_WORKLOAD_FOLDER}
+      vcenterDatacenter: ${GOVC_DATACENTER}
+      vcenterDatastore: ${GOVC_DATASTORE}
+      vcenterHostUrl: ${GOVC_URL}
+      vcenterNetwork: ${GOVC_NETWORK}
+      vcenterResourcePool: ${GOVC_RESOURCE_POOL}
+      vcenterWorkloadFolder: ${GOVC_FOLDER}
     secrets:
       vsphereCredentials: vsphere-creds
   dependsOn: []
@@ -155,12 +156,12 @@ spec:
       tufRepo:
         metadataUrl: ${METADATA_URL}
         targetsUrl: ${TARGETS_URL}
-      vcenterDatacenter: ${VCENTER_DATACENTER}
-      vcenterDatastore: ${VCENTER_DATASTORE}
-      vcenterHostUrl: ${VCENTER_HOST_URL}
-      vcenterNetwork: ${VCENTER_NETWORK}
-      vcenterResourcePool: ${VCENTER_RESOURCE_POOL}
-      vcenterWorkloadFolder: ${VCENTER_WORKLOAD_FOLDER}
+      vcenterDatacenter: ${GOVC_DATACENTER}
+      vcenterDatastore: ${GOVC_DATASTORE}
+      vcenterHostUrl: ${GOVC_URL}
+      vcenterNetwork: ${GOVC_NETWORK}
+      vcenterResourcePool: ${GOVC_RESOURCE_POOL}
+      vcenterWorkloadFolder: ${GOVC_FOLDER}
       vmCount: 2
     secrets:
       vsphereCredentials: vsphere-creds

--- a/bottlerocket/samples/eks/vmware-sonobuoy-test.yaml
+++ b/bottlerocket/samples/eks/vmware-sonobuoy-test.yaml
@@ -28,6 +28,7 @@ spec:
     name: agent
     image: ${VSPHERE_K8S_CLUSTER_RESOURCE_AGENT_IMAGE_URI}
     keepRunning: true
+    privileged: true
     configuration:
       controlPlaneEndpointIp: ${CONTROL_PLANE_ENDPOINT_IP}
       creationPolicy: ifNotExists
@@ -38,12 +39,12 @@ spec:
         metadataUrl: ${METADATA_URL}
         targetsUrl: ${TARGETS_URL}
       version: ${K8S_VERSION}
-      vcenterDatacenter: ${VCENTER_DATACENTER}
-      vcenterDatastore: ${VCENTER_DATASTORE}
-      vcenterHostUrl: ${VCENTER_HOST_URL}
-      vcenterNetwork: ${VCENTER_NETWORK}
-      vcenterResourcePool: ${VCENTER_RESOURCE_POOL}
-      vcenterWorkloadFolder: ${VCENTER_WORKLOAD_FOLDER}
+      vcenterDatacenter: ${GOVC_DATACENTER}
+      vcenterDatastore: ${GOVC_DATASTORE}
+      vcenterHostUrl: ${GOVC_URL}
+      vcenterNetwork: ${GOVC_NETWORK}
+      vcenterResourcePool: ${GOVC_RESOURCE_POOL}
+      vcenterWorkloadFolder: ${GOVC_FOLDER}
     secrets:
       vsphereCredentials: vsphere-creds
   dependsOn: []
@@ -69,12 +70,12 @@ spec:
       tufRepo:
         metadataUrl: ${METADATA_URL}
         targetsUrl: ${TARGETS_URL}
-      vcenterDatacenter: ${VCENTER_DATACENTER}
-      vcenterDatastore: ${VCENTER_DATASTORE}
-      vcenterHostUrl: ${VCENTER_HOST_URL}
-      vcenterNetwork: ${VCENTER_NETWORK}
-      vcenterResourcePool: ${VCENTER_RESOURCE_POOL}
-      vcenterWorkloadFolder: ${VCENTER_WORKLOAD_FOLDER}
+      vcenterDatacenter: ${GOVC_DATACENTER}
+      vcenterDatastore: ${GOVC_DATASTORE}
+      vcenterHostUrl: ${GOVC_URL}
+      vcenterNetwork: ${GOVC_NETWORK}
+      vcenterResourcePool: ${GOVC_RESOURCE_POOL}
+      vcenterWorkloadFolder: ${GOVC_FOLDER}
       vmCount: 2
     secrets:
       vsphereCredentials: vsphere-creds

--- a/bottlerocket/samples/kind/vmware-sonobuoy-test.yaml
+++ b/bottlerocket/samples/kind/vmware-sonobuoy-test.yaml
@@ -28,6 +28,7 @@ spec:
     name: agent
     image: ${VSPHERE_K8S_CLUSTER_RESOURCE_AGENT_IMAGE_URI}
     keepRunning: true
+    privileged: true
     configuration:
       controlPlaneEndpointIp: ${CONTROL_PLANE_ENDPOINT_IP}
       creationPolicy: ifNotExists
@@ -38,12 +39,12 @@ spec:
         metadataUrl: ${METADATA_URL}
         targetsUrl: ${TARGETS_URL}
       version: ${K8S_VERSION}
-      vcenterDatacenter: ${VCENTER_DATACENTER}
-      vcenterDatastore: ${VCENTER_DATASTORE}
-      vcenterHostUrl: ${VCENTER_HOST_URL}
-      vcenterNetwork: ${VCENTER_NETWORK}
-      vcenterResourcePool: ${VCENTER_RESOURCE_POOL}
-      vcenterWorkloadFolder: ${VCENTER_WORKLOAD_FOLDER}
+      vcenterDatacenter: ${GOVC_DATACENTER}
+      vcenterDatastore: ${GOVC_DATASTORE}
+      vcenterHostUrl: ${GOVC_URL}
+      vcenterNetwork: ${GOVC_NETWORK}
+      vcenterResourcePool: ${GOVC_RESOURCE_POOL}
+      vcenterWorkloadFolder: ${GOVC_FOLDER}
     secrets:
       vsphereCredentials: vsphere-creds
   dependsOn: []
@@ -69,12 +70,12 @@ spec:
       tufRepo:
         metadataUrl: ${METADATA_URL}
         targetsUrl: ${TARGETS_URL}
-      vcenterDatacenter: ${VCENTER_DATACENTER}
-      vcenterDatastore: ${VCENTER_DATASTORE}
-      vcenterHostUrl: ${VCENTER_HOST_URL}
-      vcenterNetwork: ${VCENTER_NETWORK}
-      vcenterResourcePool: ${VCENTER_RESOURCE_POOL}
-      vcenterWorkloadFolder: ${VCENTER_WORKLOAD_FOLDER}
+      vcenterDatacenter: ${GOVC_DATACENTER}
+      vcenterDatastore: ${GOVC_DATASTORE}
+      vcenterHostUrl: ${GOVC_URL}
+      vcenterNetwork: ${GOVC_NETWORK}
+      vcenterResourcePool: ${GOVC_RESOURCE_POOL}
+      vcenterWorkloadFolder: ${GOVC_FOLDER}
       vmCount: 2
     secrets:
       vsphereCredentials: vsphere-creds

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -807,7 +807,7 @@ mod test {
     fn vmware_migration_test() {
         let s = read_eks_file("vmware-migration-test.yaml");
         let s = s
-            .replace("\\${${CLUSTER_NAME}-vms.ids}", r#"["a", "b", "c"]"#)
+            .replace("\\${${CLUSTER_NAME}-vms.instanceIds}", r#"["a", "b", "c"]"#)
             .replace("\\${${CLUSTER_NAME}.publicSubnetIds}", r#"["a", "b", "c"]"#)
             .replace("\\${${CLUSTER_NAME}.securityGroups}", r#"["a", "b", "c"]"#)
             .replace("${K8S_VERSION}", "v1.24")
@@ -870,7 +870,7 @@ mod test {
     fn vmware_sonobuoy_test() {
         let s = read_eks_file("vmware-sonobuoy-test.yaml");
         let s = s
-            .replace("\\${${CLUSTER_NAME}-vms.ids}", r#"["a", "b", "c"]"#)
+            .replace("\\${${CLUSTER_NAME}-vms.instanceIds}", r#"["a", "b", "c"]"#)
             .replace("\\${${CLUSTER_NAME}.publicSubnetIds}", r#"["a", "b", "c"]"#)
             .replace("\\${${CLUSTER_NAME}.securityGroups}", r#"["a", "b", "c"]"#)
             .replace("${K8S_VERSION}", "v1.24")
@@ -1003,7 +1003,7 @@ mod test {
     fn vmware_sonobuoy_test_kind() {
         let s = read_kind_file("vmware-sonobuoy-test.yaml");
         let s = s
-            .replace("\\${${CLUSTER_NAME}-vms.ids}", r#"["a", "b", "c"]"#)
+            .replace("\\${${CLUSTER_NAME}-vms.instanceIds}", r#"["a", "b", "c"]"#)
             .replace("\\${${CLUSTER_NAME}.publicSubnetIds}", r#"["a", "b", "c"]"#)
             .replace(
                 "\\\\${${CLUSTER_NAME}.securityGroups}",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Removed a redundant env variable, fixed the name of `WORKLOAD_TEST_IMAGE_URI`, and simplified `OUTPUT_FILE` since `CLUSTER_NAME` now already contains the `TEST_TYPE` as of https://github.com/bottlerocket-os/bottlerocket-test-system/pull/760.

Changed the prefix of `VCENTER` variables to `GOVC` to match what they are called in the rest of TestSys.

**Testing done:**

Started with a clean environment (which I didn't do in #760 and that's why I missed the `WORKLOAD_TEST_IMAGE` bug) and generated all samples in `eks`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
