### PR TITLE
Dependencies: Switch from openssl to rustls

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,9 +48,5 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v3
-<<<<<<< HEAD
       - run: rustup default 1.67.1
-=======
-      - run: rustup default 1.62.1
->>>>>>> ba886f0 (Increase runners rust version to 1.62.1)
       - run: make cargo-deny

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,3 +50,4 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup default 1.67.1
       - run: make cargo-deny
+      

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,5 +48,9 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v3
+<<<<<<< HEAD
       - run: rustup default 1.67.1
+=======
+      - run: rustup default 1.62.1
+>>>>>>> ba886f0 (Increase runners rust version to 1.62.1)
       - run: make cargo-deny

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,11 +18,8 @@ dependencies = [
  "agent-common",
  "aws-config",
  "aws-credential-types",
-<<<<<<< HEAD
  "aws-sdk-iam",
  "aws-sdk-ssm",
-=======
->>>>>>> 8ec8d75 (updated: Update `aws_config` -> 0.54)
  "aws-sdk-sts",
  "aws-smithy-types",
  "aws-types",
@@ -427,11 +424,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "sha2",
-<<<<<<< HEAD
  "time",
-=======
- "time 0.3.15",
->>>>>>> 8ec8d75 (updated: Update `aws_config` -> 0.54)
  "tracing",
 ]
 
@@ -589,15 +582,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
-<<<<<<< HEAD
 name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
-=======
->>>>>>> 8ec8d75 (updated: Update `aws_config` -> 0.54)
 name = "base64-simd"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,7 +939,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
-<<<<<<< HEAD
 ]
 
 [[package]]
@@ -959,8 +948,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
  "dirs-sys",
-=======
->>>>>>> 8ec8d75 (updated: Update `aws_config` -> 0.54)
 ]
 
 [[package]]
@@ -2889,7 +2876,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "tokio-pipe"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2900,8 +2886,6 @@ dependencies = [
 ]
 
 [[package]]
-=======
->>>>>>> 8ec8d75 (updated: Update `aws_config` -> 0.54)
 name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -121,18 +121,18 @@ checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.60"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -455,7 +455,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "lazy_static",
  "pin-project-lite",
  "tokio",
@@ -641,7 +641,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "sha2",
  "snafu",
  "test-agent",
@@ -662,7 +662,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "testsys-model",
 ]
 
@@ -686,7 +686,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 1.0.107",
  "testsys-model",
 ]
 
@@ -774,7 +774,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -810,7 +810,7 @@ name = "configuration-derive"
 version = "0.0.6"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -899,7 +899,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -910,7 +910,7 @@ checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -921,7 +921,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1144,7 +1144,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1354,10 +1354,25 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
+ "rustls 0.20.6",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+dependencies = [
+ "http",
+ "hyper",
+ "log",
+ "rustls 0.21.0",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.24.0",
 ]
 
 [[package]]
@@ -1474,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e712e62827c382a77b87f590532febb1f8b2fdbc3eefa1ee37fe7281687075ef"
+checksum = "1f54898088ccb91df1b492cc80029a6fdf1c48ca0db7c6822a8babad69c94658"
 dependencies = [
  "serde",
  "serde_json",
@@ -1497,11 +1512,11 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1985030683a2bac402cbda61222195de80d3f66b4c87ab56e5fea379bd98c3"
+checksum = "cd990069640f9db34b3b0f7a1afc62a05ffaa3be9b66aa3c313f58346df7f788"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.21.0",
  "bytes",
  "chrono",
  "serde",
@@ -1521,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.78.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ee2ba94546e32a5aef943e5831c6ac25592ff8dcfa8b2a06e0aaea90c69188"
+checksum = "ca82ee1786dc8770d1ad4e319003e3d68cd86bc1204ed9e40f591ffef8e6492c"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1533,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.78.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9ca1f597bd48ed26f45f601bf2fa3aaa0933b8d1652d883b8444519b72af4a"
+checksum = "90b1d8deb705ef2463b2ce142b0ff98c815f8f0ac393d13c8f4c2b26491daf66"
 dependencies = [
  "base64 0.20.0",
  "bytes",
@@ -1546,7 +1561,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.24.0",
  "hyper-timeout",
  "jsonpath_lib",
  "k8s-openapi",
@@ -1554,12 +1569,12 @@ dependencies = [
  "pem",
  "pin-project",
  "rand",
- "rustls",
+ "rustls 0.21.0",
  "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.9.21",
  "thiserror",
  "tokio",
  "tokio-tungstenite",
@@ -1571,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.78.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f2c6d1a2d1584859499eb05a41c5a44713818041621fa7515cfdbdf4769ea7"
+checksum = "b16c1653fd0bda69a6bdb363167edbb72d28817db340d2fe8cb89dc07d354e05"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1589,24 +1604,25 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.78.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1dfe288fd87029f87c5713ddf585a4221e1b5be8f8c7c02ba28f5211f2a6d7"
+checksum = "47f6f25cba90928fd269fec0c5c22bea5f0d48d4376dadef90ce9a8e71f92803"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "kube-runtime"
-version = "0.78.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7995aaf15656bf3694cd455578d59119acc3ca55f71e9a1b579a34a47d17ecce"
+checksum = "ed8442b2f1d6c1d630677ade9e5d5ebe793dec099a75fb582d56d77b8eb8cee8"
 dependencies = [
  "ahash",
+ "async-trait",
  "backoff",
  "derivative",
  "futures",
@@ -1902,7 +1918,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1959,7 +1975,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -1976,18 +1992,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2080,7 +2096,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "ipnet",
  "js-sys",
  "log",
@@ -2088,13 +2104,13 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.6",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2171,6 +2187,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,6 +2217,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
  "base64 0.13.1",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2237,7 +2275,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2323,9 +2361,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
@@ -2342,13 +2380,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -2359,14 +2397,14 @@ checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2405,6 +2443,19 @@ dependencies = [
  "ryu",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2487,7 +2538,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2539,6 +2590,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tabled"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2559,7 +2621,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2675,7 +2737,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "snafu",
  "tabled",
  "tokio",
@@ -2685,22 +2747,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -2774,7 +2836,7 @@ checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2793,9 +2855,19 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.6",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls 0.21.0",
+ "tokio",
 ]
 
 [[package]]
@@ -2897,11 +2969,11 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.20.0",
  "bitflags",
  "bytes",
  "futures-core",
@@ -2909,6 +2981,7 @@ dependencies = [
  "http",
  "http-body",
  "http-range-header",
+ "mime",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -2948,7 +3021,7 @@ checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3002,7 +3075,7 @@ checksum = "89851716b67b937e393b3daa8423e67ddfc4bbbf1654bcf05488e95e0828db0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3037,6 +3110,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "untrusted"
@@ -3150,7 +3229,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -3184,7 +3263,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,21 +1080,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,28 +1346,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-openssl"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee5d7a8f718585d1c3c61dfde28ef5b0bb14734b4db13f5ada856cdc6c612b"
-dependencies = [
- "http",
- "hyper",
- "linked_hash_set",
- "once_cell",
- "openssl",
- "openssl-sys",
- "parking_lot",
- "tokio",
- "tokio-openssl",
- "tower-layer",
-]
-
-[[package]]
 name = "hyper-rustls"
-version = "0.23.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
@@ -1579,15 +1546,16 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-openssl",
+ "hyper-rustls",
  "hyper-timeout",
  "jsonpath_lib",
  "k8s-openapi",
  "kube-core",
- "openssl",
  "pem",
  "pin-project",
  "rand",
+ "rustls",
+ "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",
@@ -1673,15 +1641,6 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linked_hash_set"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1833,49 +1792,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -1996,12 +1916,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "ppv-lite86"
@@ -2864,18 +2778,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-openssl"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08f9ffb7809f1b20c1b398d92acf4cc719874b3b2b2d9ea2f09b4a80350878a"
-dependencies = [
- "futures-util",
- "openssl",
- "openssl-sys",
- "tokio",
-]
-
-[[package]]
 name = "tokio-pipe"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3174,12 +3076,6 @@ dependencies = [
  "getrandom",
  "serde",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,8 +18,11 @@ dependencies = [
  "agent-common",
  "aws-config",
  "aws-credential-types",
+<<<<<<< HEAD
  "aws-sdk-iam",
  "aws-sdk-ssm",
+=======
+>>>>>>> 8ec8d75 (updated: Update `aws_config` -> 0.54)
  "aws-sdk-sts",
  "aws-smithy-types",
  "aws-types",
@@ -424,7 +427,11 @@ dependencies = [
  "percent-encoding",
  "regex",
  "sha2",
+<<<<<<< HEAD
  "time",
+=======
+ "time 0.3.15",
+>>>>>>> 8ec8d75 (updated: Update `aws_config` -> 0.54)
  "tracing",
 ]
 
@@ -582,12 +589,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
+<<<<<<< HEAD
 name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+=======
+>>>>>>> 8ec8d75 (updated: Update `aws_config` -> 0.54)
 name = "base64-simd"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +949,7 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+<<<<<<< HEAD
 ]
 
 [[package]]
@@ -948,6 +959,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
  "dirs-sys",
+=======
+>>>>>>> 8ec8d75 (updated: Update `aws_config` -> 0.54)
 ]
 
 [[package]]
@@ -2876,6 +2889,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "tokio-pipe"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2886,6 +2900,8 @@ dependencies = [
 ]
 
 [[package]]
+=======
+>>>>>>> 8ec8d75 (updated: Update `aws_config` -> 0.54)
 name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,8 @@ RUN mkdir -p /usr/share/licenses/testsys && \
     chown -R builder:builder /usr/share/licenses/testsys
 
 ARG ARCH
-# We need these environment variables set for building the `openssl-sys` crate
-ENV PKG_CONFIG_PATH=/${ARCH}-bottlerocket-linux-musl/sys-root/usr/lib/pkgconfig
-ENV PKG_CONFIG_ALLOW_CROSS=1
+
 ENV CARGO_HOME=/src/.cargo
-ENV OPENSSL_STATIC=true
 
 # Build bottlerocket agents
 WORKDIR /src/bottlerocket/agents/

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ TAG_IMAGES = $(addprefix tag-, $(IMAGES))
 # Store targets to push images
 PUSH_IMAGES = $(addprefix push-, $(IMAGES))
 
-.PHONY: build sdk-openssl example-test-agent example-test-agent-cli example-resource-agent \
+.PHONY: build example-test-agent example-test-agent-cli example-resource-agent \
 	images fetch integ-test show-variables cargo-deny tools $(IMAGES) \
 	tag-images $(TAG_IMAGES) push-images $(PUSH_IMAGES) print-image-names \
 	help

--- a/agent/resource-agent/examples/duplicator_resource_agent/Dockerfile
+++ b/agent/resource-agent/examples/duplicator_resource_agent/Dockerfile
@@ -4,11 +4,9 @@ FROM ${BUILDER_IMAGE} as build
 
 ARG ARCH
 USER root
-# We need these environment variables set for building the `openssl-sys` crate
-ENV PKG_CONFIG_PATH=/${ARCH}-bottlerocket-linux-musl/sys-root/usr/lib/pkgconfig
-ENV PKG_CONFIG_ALLOW_CROSS=1
+
 ENV CARGO_HOME=/src/.cargo
-ENV OPENSSL_STATIC=true
+
 ADD ./ /src/
 WORKDIR /src/agent/resource-agent
 RUN --mount=type=cache,mode=0777,target=/src/target \

--- a/agent/resource-agent/examples/example_resource_agent/Dockerfile
+++ b/agent/resource-agent/examples/example_resource_agent/Dockerfile
@@ -4,11 +4,9 @@ FROM ${BUILDER_IMAGE} as build
 
 ARG ARCH
 USER root
-# We need these environment variables set for building the `openssl-sys` crate
-ENV PKG_CONFIG_PATH=/${ARCH}-bottlerocket-linux-musl/sys-root/usr/lib/pkgconfig
-ENV PKG_CONFIG_ALLOW_CROSS=1
+
 ENV CARGO_HOME=/src/.cargo
-ENV OPENSSL_STATIC=true
+
 ADD ./ /src/
 WORKDIR /src/agent/resource-agent
 RUN --mount=type=cache,mode=0777,target=/src/target \

--- a/agent/test-agent-cli/examples/example_test_agent_cli/Dockerfile
+++ b/agent/test-agent-cli/examples/example_test_agent_cli/Dockerfile
@@ -4,12 +4,9 @@ FROM ${BUILDER_IMAGE} as build
 
 ARG ARCH
 USER root
-# We need these environment variables set for building the `openssl-sys` crate
-ENV PKG_CONFIG_PATH=/${ARCH}-bottlerocket-linux-musl/sys-root/usr/lib/pkgconfig
-ENV PKG_CONFIG_ALLOW_CROSS=1
+
 ENV CARGO_HOME=/src/.cargo
-ENV OPENSSL_STATIC=true
-ENV CARGO_HOME=/src/.cargo
+
 ADD ./ /src/
 WORKDIR /src/agent/test-agent-cli
 RUN --mount=type=cache,mode=0777,target=/src/target \

--- a/agent/test-agent/examples/example_test_agent/Dockerfile
+++ b/agent/test-agent/examples/example_test_agent/Dockerfile
@@ -4,11 +4,9 @@ FROM ${BUILDER_IMAGE} as build
 
 ARG ARCH
 USER root
-# We need these environment variables set for building the `openssl-sys` crate
-ENV PKG_CONFIG_PATH=/${ARCH}-bottlerocket-linux-musl/sys-root/usr/lib/pkgconfig
-ENV PKG_CONFIG_ALLOW_CROSS=1
+
 ENV CARGO_HOME=/src/.cargo
-ENV OPENSSL_STATIC=true
+
 ADD ./ /src/
 WORKDIR /src/agent/test-agent
 RUN --mount=type=cache,mode=0777,target=/src/target \

--- a/bottlerocket/agents/Cargo.toml
+++ b/bottlerocket/agents/Cargo.toml
@@ -22,8 +22,8 @@ aws-smithy-types = "0.54"
 base64 = "0.20"
 env_logger = "0.10"
 hex ="0.4"
-k8s-openapi = { version = "0.17", default-features = false, features = ["v1_24"] }
-kube = { version = "0.78", default-features = false, features = ["config", "derive", "client"] }
+k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }
+kube = { version = "0.82", default-features = false, features = ["config", "derive", "client"] }
 log = "0.4"
 maplit = "1"
 openssh = { version = "0.9", features = ["native-mux"] }

--- a/clarify.toml
+++ b/clarify.toml
@@ -70,6 +70,13 @@ license-files = [
     { path = "third-party/chromium/LICENSE", hash = 0x9b209a1a },
 ]
 
+[clarify.rustls-webpki]
+expression = "ISC"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+    { path = "third-party/chromium/LICENSE", hash = 0x9b209a1a },
+]
+
 [clarify.unicode-ident]
 expression = "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
 license-files = [

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -11,7 +11,7 @@ env_logger = "0.10"
 futures = "0.3"
 http = "0"
 k8s-openapi = { version = "0.17", default-features = false, features = ["v1_24"] }
-kube = { version = "0.78", default-features = true, features = ["derive"] }
+kube = { version = "0.78", default-features = false, features = ["derive", "client", "rustls-tls"] }
 kube-runtime = "0.78"
 lazy_static = "1"
 log = "0.4"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -10,9 +10,9 @@ anyhow = "1"
 env_logger = "0.10"
 futures = "0.3"
 http = "0"
-k8s-openapi = { version = "0.17", default-features = false, features = ["v1_24"] }
-kube = { version = "0.78", default-features = false, features = ["derive", "client", "rustls-tls"] }
-kube-runtime = "0.78"
+k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }
+kube = { version = "0.82", default-features = false, features = ["derive", "client", "rustls-tls"] }
+kube-runtime = "0.82"
 lazy_static = "1"
 log = "0.4"
 testsys-model = { version = "0.0.6", path = "../model" }

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -4,11 +4,9 @@ FROM ${BUILDER_IMAGE} as build
 
 ARG ARCH
 USER root
-# We need these environment variables set for building the `openssl-sys` crate
-ENV PKG_CONFIG_PATH=/${ARCH}-bottlerocket-linux-musl/sys-root/usr/lib/pkgconfig
-ENV PKG_CONFIG_ALLOW_CROSS=1
+
 ENV CARGO_HOME=/src/.cargo
-ENV OPENSSL_STATIC=true
+
 ADD ./ /src/
 WORKDIR /src/controller
 RUN --mount=type=cache,mode=0777,target=/src/target \

--- a/controller/src/resource_controller/mod.rs
+++ b/controller/src/resource_controller/mod.rs
@@ -9,10 +9,9 @@ use crate::resource_controller::action::{
 use crate::resource_controller::context::{new_context, Context, ResourceInterface};
 use anyhow::Context as AnyhowContext;
 use futures::StreamExt;
-use kube::api::ListParams;
 use kube::{Api, Client};
 use kube_runtime::controller::Action as RequeueAction;
-use kube_runtime::{controller, Controller};
+use kube_runtime::{controller, watcher, Controller};
 use log::{debug, error, trace, warn};
 use std::ops::Deref;
 use std::sync::Arc;
@@ -26,7 +25,7 @@ pub(crate) async fn run_resource_controller(client: Client) {
     let context = new_context(client.clone());
     Controller::new(
         Api::<Resource>::namespaced(client, NAMESPACE),
-        ListParams::default(),
+        watcher::Config::default(),
     )
     .run(reconcile, handle_reconciliation_error, context)
     .for_each(|reconciliation_result| async move {

--- a/controller/src/test_controller/mod.rs
+++ b/controller/src/test_controller/mod.rs
@@ -3,9 +3,8 @@ use crate::error::ReconciliationError;
 use crate::test_controller::context::{new_context, Context};
 use crate::test_controller::reconcile::reconcile;
 use futures::StreamExt;
-use kube::api::ListParams;
 use kube_runtime::controller::Action as RequeueAction;
-use kube_runtime::{controller, Controller};
+use kube_runtime::{controller, watcher, Controller};
 use log::{debug, error};
 use std::sync::Arc;
 use testsys_model::Test;
@@ -16,7 +15,7 @@ mod reconcile;
 
 pub(super) async fn run_test_controller(client: kube::Client) {
     let context = new_context(client);
-    Controller::new(context.api().clone(), ListParams::default())
+    Controller::new(context.api().clone(), watcher::Config::default())
         .run(reconcile, handle_reconciliation_error, context)
         .for_each(|reconciliation_result| async move {
             if let Err(reconciliation_err) = reconciliation_result {

--- a/deny.toml
+++ b/deny.toml
@@ -19,8 +19,8 @@ allow = [
     "ISC",
     "MIT",
     "OpenSSL",
-    "Unicode-DFS-2016"
-    #"Unlicense",
+    "Unicode-DFS-2016",
+    # "Unlicense",
     #"Zlib"
 ]
 
@@ -38,6 +38,13 @@ license-files = [
 
 [[licenses.clarify]]
 name = "webpki"
+expression = "ISC"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+]
+
+[[licenses.clarify]]
+name = "rustls-webpki"
 expression = "ISC"
 license-files = [
     { path = "LICENSE", hash = 0x001c7e6c },

--- a/deny.toml
+++ b/deny.toml
@@ -19,8 +19,8 @@ allow = [
     "ISC",
     "MIT",
     "OpenSSL",
-    "Unicode-DFS-2016",
-    # "Unlicense",
+    "Unicode-DFS-2016"
+    #"Unlicense",
     #"Zlib"
 ]
 

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3"
 http = "0.2"
 json-patch = "0.3"
 k8s-openapi = { version = "0.17", default-features = false, features = ["v1_24"] }
-kube = { version = "0.78", default-features = false, features = ["config", "derive", "jsonpatch", "client", "ws", "openssl-tls"] }
+kube = { version = "0.78", default-features = false, features = ["config", "derive", "jsonpatch", "client", "ws", "rustls-tls"] }
 lazy_static = "1"
 log = "0.4"
 maplit = "1.0.2"

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -13,9 +13,9 @@ bytes = "1.3"
 chrono = { version = "0.4", default-features = false, features = ["clock"]}
 futures = "0.3"
 http = "0.2"
-json-patch = "0.3"
-k8s-openapi = { version = "0.17", default-features = false, features = ["v1_24"] }
-kube = { version = "0.78", default-features = false, features = ["config", "derive", "jsonpatch", "client", "ws", "rustls-tls"] }
+json-patch = "1"
+k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }
+kube = { version = "0.82", default-features = false, features = ["config", "derive", "jsonpatch", "client", "ws", "rustls-tls"] }
 lazy_static = "1"
 log = "0.4"
 maplit = "1.0.2"

--- a/selftest/Cargo.toml
+++ b/selftest/Cargo.toml
@@ -10,8 +10,8 @@ license = "MIT OR Apache-2.0"
 anyhow = "1"
 envy = "0"
 futures = "0.3"
-k8s-openapi = { version = "0.17", default-features = false, features = ["v1_24"] }
-kube = { version = "0.78", default-features = false, features = ["client", "rustls-tls"] }
+k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }
+kube = { version = "0.82", default-features = false, features = ["client", "rustls-tls"] }
 lazy_static = "1"
 testsys-model = { version = "0.0.6", path = "../model"}
 serde = "1"

--- a/selftest/Cargo.toml
+++ b/selftest/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 envy = "0"
 futures = "0.3"
 k8s-openapi = { version = "0.17", default-features = false, features = ["v1_24"] }
-kube = { version = "0.78", default-features = true }
+kube = { version = "0.78", default-features = false, features = ["client", "rustls-tls"] }
 lazy_static = "1"
 testsys-model = { version = "0.0.6", path = "../model"}
 serde = "1"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Switches from openssl-tls to rustls-tls.

**Testing done:**

Make images.
Tested with `cargo make test`
```
 NAME                                 TYPE        STATE       PASSED   SKIPPED   FAILED
 x86-64-aws-k8s-124                   Resource    completed
 x86-64-aws-k8s-124-instances-xzko    Resource    running
 x86-64-aws-k8s-124-quick             Test        pass        1        6972      0
 ```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
