### PR TITLE
TestManager: Ensure no resources are in the cluster before deleting the namespace

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -68,7 +68,7 @@ async fn main() {
     let args = Args::parse();
     init_logger(args.log_level);
     if let Err(e) = run(args).await {
-        eprintln!("{}", e);
+        eprintln!("{:?}", e);
         std::process::exit(1);
     }
 }

--- a/model/src/test_manager/error.rs
+++ b/model/src/test_manager/error.rs
@@ -50,6 +50,9 @@ pub enum Error {
     #[snafu(display("Unable to find {}", what))]
     NotFound { what: String },
 
+    #[snafu(display("Some resources are still in the cluster"))]
+    ResourceExisting,
+
     #[snafu(display("Unable to send event: {}", source))]
     Sender {
         source: futures::channel::mpsc::SendError,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

```
Author: ecpullen <pullenep@amazon.com>
Date:   Thu Feb 9 18:06:32 2023 +0000

    cli: Print underlying errors with anyhow
```
Show the underlying error when a command fails.

```
Author: ecpullen <pullenep@amazon.com>
Date:   Thu Feb 9 17:57:00 2023 +0000

    TestManager: Ensure no resources for uninstall
    
    If a resource is present in the cluster while the namespace is being
    deleted, there is a chance the resource deletion fails and puts the
    cluster in a bad state. To prevent that, all resources must be deleted
    before the namespace is deleted.
```

**Testing done:**

`cli install` followed by `cli uninstall`

With resources:
```
$ cli uninstall
Unable to uninstall testsys from the cluster. (Some artifacts may be left behind)

Caused by:
    Some resources are still in the cluster
```

After the resources are cleaned up:
```
$ cli uninstall
testsys components were successfully uninstalled.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
