### PR TITLE
TestManager: Add flexibility to displayed columns

### DIFF
--- a/model/src/test_manager/manager.rs
+++ b/model/src/test_manager/manager.rs
@@ -3,7 +3,7 @@ use super::{
     SelectionParams, StatusSnapshot,
 };
 use crate::clients::{AllowNotFound, CrdClient, ResourceClient, TestClient};
-use crate::constants::{LABEL_COMPONENT, TESTSYS_RESULTS_FILE};
+use crate::constants::TESTSYS_RESULTS_FILE;
 use crate::system::AgentType;
 use crate::{Crd, CrdName, Resource, SecretName, TaskState, Test, TestUserState};
 use bytes::Bytes;
@@ -296,34 +296,10 @@ impl TestManager {
     /// returned can be used to print a table containing each objects status (including rerun tests)
     /// or to print a json representation containing all included objects as well as the controller
     /// status.
-    pub async fn status(
-        &self,
-        selection_params: &SelectionParams,
-        include_controller: bool,
-    ) -> Result<StatusSnapshot> {
-        let controller_status = if include_controller {
-            let pod_api: Api<Pod> = self.namespaced_api();
-            let pods = pod_api
-                .list(&ListParams {
-                    label_selector: Some(format!("{}={}", LABEL_COMPONENT, "controller")),
-                    ..Default::default()
-                })
-                .await
-                .context(error::KubeSnafu {
-                    action: "get controller pod",
-                })?
-                .items;
-            if let Some(pod) = pods.first() {
-                pod.status.clone()
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+    pub async fn status(&self, selection_params: &SelectionParams) -> Result<StatusSnapshot> {
         let crds = self.list(selection_params).await?;
 
-        Ok(StatusSnapshot::new(controller_status, crds))
+        Ok(StatusSnapshot::new(crds))
     }
 
     /// Retrieve the logs of a test.

--- a/model/src/test_manager/mod.rs
+++ b/model/src/test_manager/mod.rs
@@ -3,7 +3,7 @@ pub use error::{Error, Result};
 pub use manager::{read_manifest, TestManager};
 use serde::{Deserialize, Serialize};
 use serde_plain::derive_fromstr_from_deserialize;
-pub use status::StatusSnapshot;
+pub use status::{StatusColumn, StatusSnapshot};
 use std::collections::HashMap;
 
 mod delete;
@@ -85,10 +85,3 @@ pub enum ResourceState {
 }
 
 derive_fromstr_from_deserialize!(ResourceState);
-
-/// `StatusProgress` represents whether a `Test`'s `other_info` should be included or not.
-#[derive(Debug)]
-pub enum StatusProgress {
-    WithTests,
-    Resources,
-}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

This pr allows users to have full control over the status that is displayed. Several useful status columns are provided see `cli/src/status.rs`. This will enable improved status display in the Bottlerocket repo.

The following status was created using the accompanying code snippet.
```sh
 VARIANT            ARCH        TYPE           CLUSTER                    PASSED      FAILED      SKIPPED 
 aws-k8s-1.23       x86_64      migration      x86-64-aws-k8s-124              1        6972            0 
 aws-k8s-1.23       x86_64      migration      x86-64-aws-k8s-124              2           0            0 
 aws-k8s-1.23       x86_64      migration      x86-64-aws-k8s-124              1        6972            0 
 aws-k8s-1.23       x86_64      migration      x86-64-aws-k8s-124              2           0            0 
 aws-k8s-1.23       x86_64      migration      x86-64-aws-k8s-124              1        6972            0 
 aws-k8s-1.24       x86_64      workload       x86-64-aws-k8s-124                                         
 aws-k8s-1.23       x86_64      cluster        x86-64-aws-k8s-124                                         
 aws-k8s-1.24       x86_64      instances      x86-64-aws-k8s-124                                        
```

```rust
status.new_column("VARIANT", |crd| {
            crd.labels()
                .get("testsys/variant")
                .cloned()
                .into_iter()
                .collect()
        });
        status.new_column("ARCH", |crd| {
            crd.labels()
                .get("testsys/arch")
                .cloned()
                .into_iter()
                .collect()
        });
        status.new_column("TYPE", |crd| {
            crd.labels()
                .get("testsys/type")
                .cloned()
                .into_iter()
                .collect()
        });
        status.new_column("CLUSTER", |crd| {
            crd.labels()
                .get("testsys/cluster")
                .cloned()
                .into_iter()
                .collect()
        });

        status.add_column(StatusColumn::passed());
        status.add_column(StatusColumn::failed());
        status.add_column(StatusColumn::skipped());
```

User are also able to provide multiple values for a single crd such as listing all of a crds labels.
```sh
 NAME                                    ARCH       LABELS                                
 x86-64-aws-k8s-124-1-initial            foo        testsys/arch=x86_64                   
                                                    testsys/build-id=ee669023             
                                                    testsys/cluster=x86-64-aws-k8s-124    
                                                    testsys/flavor=migration              
                                                    testsys/test-type=migration           
                                                    testsys/type=migration                
                                                    testsys/variant=aws-k8s-1.23          
 x86-64-aws-k8s-124-2-migrate            foo        testsys/arch=x86_64                   
                                                    testsys/build-id=ee669023             
                                                    testsys/cluster=x86-64-aws-k8s-124    
                                                    testsys/test-type=migration           
                                                    testsys/type=migration                
                                                    testsys/variant=aws-k8s-1.23          
 x86-64-aws-k8s-124-3-migrated           foo        testsys/arch=x86_64                   
                                                    testsys/build-id=ee669023             
                                                    testsys/cluster=x86-64-aws-k8s-124    
                                                    testsys/flavor=migration              
                                                    testsys/test-type=migration           
                                                    testsys/type=migration                
                                                    testsys/variant=aws-k8s-1.23          
 x86-64-aws-k8s-124-4-migrate            foo        testsys/arch=x86_64                   
                                                    testsys/build-id=ee669023             
                                                    testsys/cluster=x86-64-aws-k8s-124    
                                                    testsys/test-type=migration           
                                                    testsys/type=migration                
                                                    testsys/variant=aws-k8s-1.23          
 x86-64-aws-k8s-124-5-final              foo        testsys/arch=x86_64                   
                                                    testsys/build-id=ee669023             
                                                    testsys/cluster=x86-64-aws-k8s-124    
                                                    testsys/flavor=migration              
                                                    testsys/test-type=migration           
                                                    testsys/type=migration                
                                                    testsys/variant=aws-k8s-1.23          
 x86-64-aws-k8s-124-test                 foo        testsys/arch=x86_64                   
                                                    testsys/build-id=3ebb33a9             
                                                    testsys/cluster=x86-64-aws-k8s-124    
                                                    testsys/test-type=workload            
                                                    testsys/type=workload                 
                                                    testsys/variant=aws-k8s-1.24          
```

**Testing done:**

```sh
cli status
```

```sh
 NAME                                    TYPE           STATE             PASSED      FAILED      SKIPPED 
 x86-64-aws-k8s-124-1-initial            Test           passed                 1        6972            0 
 x86-64-aws-k8s-124-2-migrate            Test           passed                 2           0            0 
 x86-64-aws-k8s-124-3-migrated           Test           passed                 1        6972            0 
 x86-64-aws-k8s-124-4-migrate            Test           passed                 2           0            0 
 x86-64-aws-k8s-124-5-final              Test           passed                 1        6972            0 
 x86-64-aws-k8s-124-test                 Test           error                                             
 x86-64-aws-k8s-124                      Resource       completed                                         
 x86-64-aws-k8s-124-instances-lnka       Resource       completed                                         
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
