### PR TITLE
Samples: Use latest AMIs for testing

### DIFF
--- a/bottlerocket/samples/Makefile.toml
+++ b/bottlerocket/samples/Makefile.toml
@@ -9,7 +9,14 @@ CLUSTER_TYPE = { value = "eks", condition = { env_not_set = ["CLUSTER_TYPE"] } }
 ASSUME_ROLE = { value = "~", condition = { env_not_set = ["ASSUME_ROLE"] } }
 AWS_REGION = { value = "us-west-2", condition = { env_not_set = ["AWS_REGION"] } }
 UPGRADE_VERSION = { value = "v1.11.1", condition = { env_not_set = ["UPGRADE_VERSION"] } }
-STARTING_VERSION = { value = "v1.11.0", condition = { env_not_set = ["STARTING_VERSION"] } }
+STARTING_VERSION = { script = ["""\
+        aws ssm get-parameter \
+            --region us-west-2 \
+            --name "/aws/service/bottlerocket/aws-k8s-1.24/arm64/latest/image_version" \
+            --query Parameter.Value \
+            --output text \
+        | awk -F- '{printf "v%s", $1}' \
+    """], condition = { env_not_set = ["STARTING_VERSION"] } }
 SONOBUOY_MODE = { value = "quick", condition = { env_not_set = ["SONOBUOY_MODE"] } }
 TARGETS_URL = { value = "https://updates.bottlerocket.aws/targets", condition = { env_not_set = ["TARGETS_URL"] } }
 K8S_VERSION = { value = "v1.24", condition = { env_not_set = ["K8S_VERSION"] } }
@@ -111,6 +118,7 @@ OVA_NAME = { script=["echo bottlerocket-${VARIANT}-x86_64-${STARTING_VERSION}.ov
 
 [tasks.bottlerocket-ami-id]
 condition = { env_not_set = ["BOTTLEROCKET_AMI_ID"], env_contains = { VARIANT = "aws" } }
+script = ["echo Using AMI: ${BOTTLEROCKET_AMI_ID}"]
 
 [tasks.bottlerocket-ami-id.env]
 BOTTLEROCKET_AMI_ID = { script=['''


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Samples should use the latest Bottlerocket AMIs for testing instead of a set version. 

**Testing done:**

`cargo make create ecs-migration-test`

Verified that a 1.12.0 ami was selected and the migrations go:
* 1.12.0 -> 1.11.1
* 1.11.1 -> 1.12.0

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
