### PR TITLE
EC2: Set security group to `None` if an empty `Vec` is provided

### DIFF
--- a/bottlerocket/agents/src/bin/ec2-resource-agent/ec2_provider.rs
+++ b/bottlerocket/agents/src/bin/ec2-resource-agent/ec2_provider.rs
@@ -245,7 +245,11 @@ where
                 .min_count(instance_count)
                 .max_count(instance_count)
                 .subnet_id(subnet_id)
-                .set_security_group_ids(Some(spec.configuration.security_groups.clone()))
+                .set_security_group_ids(if spec.configuration.security_groups.is_empty() {
+                    None
+                } else {
+                    Some(spec.configuration.security_groups.clone())
+                })
                 .image_id(&spec.configuration.node_ami)
                 .instance_type(InstanceType::from(instance_type.as_str()))
                 .tag_specifications(tag_specifications(
@@ -298,7 +302,7 @@ where
                 }
                 Err(err) => {
                     warn!(
-                    "An error occurred while trying to create instances of type {} using subnet {}: {}",
+                    "An error occurred while trying to create instances of type {} using subnet {}: {:?}",
                     instance_type, subnet_id, err
                 );
                 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

A n ew rust sdk version introduced a bug where we could no longer add an empty list of security groups and instead needed to add `None`.

**Testing done:**

Ran `cargo make test` with the updated EC2 agent and verified that the instances were launched.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
