### PR TITLE
samples: added assume_role for k8s-workload and k8s_version for eks

### DIFF
--- a/bottlerocket/agents/src/bin/eks-resource-agent/eks_provider.rs
+++ b/bottlerocket/agents/src/bin/eks-resource-agent/eks_provider.rs
@@ -26,7 +26,7 @@ use testsys_model::{Configuration, SecretName};
 /// The default region for the cluster.
 const DEFAULT_REGION: &str = "us-west-2";
 /// The default cluster version.
-const DEFAULT_VERSION: &str = "1.21";
+const DEFAULT_VERSION: &str = "1.24";
 const TEST_CLUSTER_CONFIG_PATH: &str = "/local/eksctl_config.yaml";
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]

--- a/bottlerocket/samples/eks/k8s-workload-test.yaml
+++ b/bottlerocket/samples/eks/k8s-workload-test.yaml
@@ -10,6 +10,7 @@ spec:
     keepRunning: true
     configuration:
       kubeconfigBase64: \${${CLUSTER_NAME}.encodedKubeconfig}
+      assumeRole: ${ASSUME_ROLE}
       tests:
       - name: ${WORKLOAD_TEST_NAME}
         image: ${WORKLOAD_TEST_IMAGE_URI}
@@ -32,6 +33,7 @@ spec:
       clusterName: ${CLUSTER_NAME}
       region: ${AWS_REGION}
       assumeRole: ${ASSUME_ROLE}
+      version: ${K8S_VERSION}
   dependsOn: []
   destructionPolicy: onDeletion
 ---

--- a/bottlerocket/samples/eks/sonobuoy-migration-test.yaml
+++ b/bottlerocket/samples/eks/sonobuoy-migration-test.yaml
@@ -112,6 +112,7 @@ spec:
       clusterName: ${CLUSTER_NAME}
       region: ${AWS_REGION}
       assumeRole: ${ASSUME_ROLE}
+      version: ${K8S_VERSION}
   dependsOn: []
   destructionPolicy: onDeletion
 ---

--- a/bottlerocket/samples/eks/sonobuoy-test.yaml
+++ b/bottlerocket/samples/eks/sonobuoy-test.yaml
@@ -32,6 +32,7 @@ spec:
       clusterName: ${CLUSTER_NAME}
       region: ${AWS_REGION}
       assumeRole: ${ASSUME_ROLE}
+      version: ${K8S_VERSION}
   dependsOn: []
   destructionPolicy: onDeletion
 ---

--- a/bottlerocket/samples/kind/k8s-workload-test.yaml
+++ b/bottlerocket/samples/kind/k8s-workload-test.yaml
@@ -10,6 +10,7 @@ spec:
     keepRunning: true
     configuration:
       kubeconfigBase64: \${${CLUSTER_NAME}.encodedKubeconfig}
+      assumeRole: ${ASSUME_ROLE}
       tests:
       - name: ${WORKLOAD_TEST_NAME}
         image: ${WORKLOAD_TEST_IMAGE_URI}
@@ -34,6 +35,7 @@ spec:
       clusterName: ${CLUSTER_NAME}
       region: ${AWS_REGION}
       assumeRole: ${ASSUME_ROLE}
+      version: ${K8S_VERSION}
     secrets:
       awsCredentials: aws-creds
   dependsOn: []

--- a/bottlerocket/samples/kind/sonobuoy-test.yaml
+++ b/bottlerocket/samples/kind/sonobuoy-test.yaml
@@ -35,6 +35,7 @@ spec:
       clusterName: ${CLUSTER_NAME}
       region: ${AWS_REGION}
       assumeRole: ${ASSUME_ROLE}
+      version: ${K8S_VERSION}
     secrets:
       awsCredentials: aws-creds
   dependsOn: []

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -703,6 +703,7 @@ mod test {
             .replace("\\${${CLUSTER_NAME}-instances.ids}", r#"["a", "b", "c"]"#)
             .replace("\\${${CLUSTER_NAME}.publicSubnetIds}", r#"["a", "b", "c"]"#)
             .replace("\\${${CLUSTER_NAME}.securityGroups}", r#"["a", "b", "c"]"#)
+            .replace("${K8S_VERSION}", "v1.24")
             .replace("${", "<")
             .replace("}", ">");
 
@@ -764,6 +765,7 @@ mod test {
             .replace("\\${${CLUSTER_NAME}.publicSubnetIds}", r#"["a", "b", "c"]"#)
             .replace("\\${${CLUSTER_NAME}.securityGroups}", r#"["a", "b", "c"]"#)
             .replace("${SONOBUOY_MODE}", "quick")
+            .replace("${K8S_VERSION}", "v1.24")
             .replace("${", "<")
             .replace("}", ">");
 
@@ -797,6 +799,7 @@ mod test {
             .replace("\\${${CLUSTER_NAME}.publicSubnetIds}", r#"["a", "b", "c"]"#)
             .replace("\\${${CLUSTER_NAME}.securityGroups}", r#"["a", "b", "c"]"#)
             .replace("${GPU}", "true")
+            .replace("${K8S_VERSION}", "v1.24")
             .replace("${INSTANCE_TYPES}", r#"["a", "b", "c"]"#)
             .replace("${", "<")
             .replace("}", ">");
@@ -994,6 +997,7 @@ mod test {
             .replace("\\${${CLUSTER_NAME}.publicSubnetIds}", r#"["a", "b", "c"]"#)
             .replace("\\${${CLUSTER_NAME}.securityGroups}", r#"["a", "b", "c"]"#)
             .replace("${SONOBUOY_MODE}", "quick")
+            .replace("${K8S_VERSION}", "v1.24")
             .replace("${", "<")
             .replace("}", ">");
 

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -549,8 +549,8 @@ mod test {
     use testsys_model::{Resource, Test};
 
     use super::{
-        EcsWorkloadTestConfig, EksClusterConfig, SonobuoyConfig, VSphereK8sClusterConfig,
-        VSphereVmConfig, WorkloadConfig,
+        EcsWorkloadTestConfig, EksClusterConfig, MetalK8sClusterConfig, SonobuoyConfig,
+        VSphereK8sClusterConfig, VSphereVmConfig, WorkloadConfig,
     };
 
     fn samples_dir() -> PathBuf {
@@ -922,6 +922,31 @@ mod test {
         let ec2_resource: Resource = serde_yaml::from_str(yaml).unwrap();
         let _: VSphereVmConfig = serde_json::from_value(JsonValue::Object(
             ec2_resource.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+    }
+
+    #[test]
+    fn metal_sonobuoy_test() {
+        let s = read_eks_file("metal-sonobuoy-test.yaml");
+        let s = s
+            .replace("${SONOBUOY_MODE}", "quick")
+            .replace("${", "<")
+            .replace("}", ">")
+            .replace("\\", "");
+
+        let docs: Vec<&str> = s.split("---").collect();
+        let &yaml = docs.get(0).unwrap();
+        let test_1_initial: Test = serde_yaml::from_str(yaml).unwrap();
+        let _: SonobuoyConfig = serde_json::from_value(JsonValue::Object(
+            test_1_initial.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+
+        let &yaml = docs.get(1).unwrap();
+        let cluster_resource: Resource = serde_yaml::from_str(yaml).unwrap();
+        let _: MetalK8sClusterConfig = serde_json::from_value(JsonValue::Object(
+            cluster_resource.spec.agent.configuration.unwrap(),
         ))
         .unwrap();
     }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Added k8s_version variable to the samples for EKS tests, assume_role to the k8s-workload test samples, and updated the default k8s version for cluster creation to 1.24 from 1.21 (since this is no longer supported). Updated EKS unit tests and added one for the metal sample.

**Testing done:**

- Ran a k8s-workload-test with the assumed role
- Ran a sonobuoy EKS test without specifying K8S_VERSION: 1.24 cluster is created
- Ran a sonobuoy EKS test setting K8S_VERSION to 1.23: 1.23 cluster is created

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
