### PR TITLE
sonobuoy-test-agent: pass '--sonobuoy-image' to 'sonobuoy run'

### DIFF
--- a/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
@@ -137,6 +137,7 @@ where
         rerun_failed_sonobuoy(
             TEST_CLUSTER_KUBECONFIG_PATH,
             e2e_repo_config,
+            self.config.sonobuoy_image.to_owned(),
             &self.results_dir,
             info_client,
         )

--- a/bottlerocket/agents/src/sonobuoy.rs
+++ b/bottlerocket/agents/src/sonobuoy.rs
@@ -58,6 +58,14 @@ where
             vec![]
         }
     };
+    let sonobuoy_image_arg = match &sonobuoy_config.sonobuoy_image {
+        Some(sonobuoy_image_arg) => {
+            vec!["--sonobuoy-image", sonobuoy_image_arg]
+        }
+        None => {
+            vec![]
+        }
+    };
     info!("Running sonobuoy");
     let status = Command::new("/usr/bin/sonobuoy")
         .args(kubeconfig_arg.to_owned())
@@ -68,6 +76,7 @@ where
         .arg(&sonobuoy_config.mode.to_string())
         .args(k8s_image_arg)
         .args(e2e_repo_arg)
+        .args(sonobuoy_image_arg)
         .status()
         .context(error::SonobuoyProcessSnafu)?;
 
@@ -99,6 +108,7 @@ where
 pub async fn rerun_failed_sonobuoy<I>(
     kubeconfig_path: &str,
     e2e_repo_config_path: Option<&str>,
+    sonobuoy_image: Option<String>,
     results_dir: &Path,
     info_client: &I,
 ) -> Result<TestResults, error::Error>
@@ -115,11 +125,20 @@ where
             vec![]
         }
     };
+    let sonobuoy_image_arg = match &sonobuoy_image {
+        Some(sonobuoy_image_arg) => {
+            vec!["--sonobuoy-image", sonobuoy_image_arg]
+        }
+        None => {
+            vec![]
+        }
+    };
     info!("Rerunning sonobuoy");
     let status = Command::new("/usr/bin/sonobuoy")
         .args(kubeconfig_arg.to_owned())
         .arg("run")
         .args(e2e_repo_arg)
+        .args(sonobuoy_image_arg)
         .arg("--rerun-failed")
         .arg(results_filepath.as_os_str())
         .status()

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -72,6 +72,7 @@ pub struct SonobuoyConfig {
     /// leave this as `None` and let the sonobuoy binary choose the right value.
     pub kubernetes_version: Option<K8sVersion>,
     pub kube_conformance_image: Option<String>,
+    pub sonobuoy_image: Option<String>,
     pub assume_role: Option<String>,
 }
 


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Resolves https://github.com/bottlerocket-os/bottlerocket-test-system/issues/797


**Description of changes:**
```
    sonobuoy-test-agent: pass '--sonobuoy-image' to 'sonobuoy run'
    
    In airgapped testing environments, sonobuoy might not have access to the
    Sonobuoy container image for the worker and aggregator pods.
    
    This lets us configure the source of that image to point to a mirror
    image repo.

```


**Testing done:**

sonobuoy-test-agent configuration:
```
Spec:
  Agent:
    Capabilities:
    Configuration:
      Assume Role:             <nil>
      e2eRepoConfigBase64:   <blah>
      Kube Conformance Image:  123.dkr.ecr.cn-north-1.amazonaws.com.cn/conformance:v1.25.6
      kubeconfigBase64:        ${x86-64-aws-k8s-125.encodedKubeconfig}
      Kubernetes Version:      <nil>
      Mode:                    certified-conformance
      Plugin:                  e2e
      Sonobuoy Image:          123.dkr.ecr.cn-north-1.amazonaws.com.cn/sonobuoy:v0.56.4
    Image:                     123.dkr.ecr.cn-north-1.amazonaws.com.cn/testsys:sonobuoy-test-agent-etung-test
    Keep Running:              false
    Name:                      agent
    Privileged:                <nil>
    Pull Secret:               <nil>
    Secrets:
    Timeout:  <nil>

```

Checking the `sonobuoy` pod in the target test cluster, and it shows the expected image:
```
$ kubectl --kubeconfig ../bottlerocket_release_scripts/shared-testing/cn-x86-64-aws-k8s-125-config describe pod sonobuoy -n sonobuoy
...
Name:         sonobuoy
Namespace:    sonobuoy
Priority:     0
Node:         ip-192-168-78-55.cn-north-1.compute.internal/192.168.78.55
Start Time:   Wed, 29 Mar 2023 00:18:02 +0000
Status:       Running
IP:           192.168.66.124
IPs:
  IP:  192.168.66.124
Containers:
  kube-sonobuoy:
    Container ID:  containerd://dd4b0de1a1bfbf973da29086e64b0f67e4ea930422b252e2aa0c19b2a3b07799
    Image:         123.dkr.ecr.cn-north-1.amazonaws.com.cn/sonobuoy:v0.56.4
    Image ID:      123.dkr.ecr.cn-north-1.amazonaws.com.cn/sonobuoy@sha256:be5e6a32469df1409c647c2a45b6bb1da40d67af1a49175c10928f0b62f161b3
    Port:          <none>
    Host Port:     <none>
..
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
