### PR TITLE
karpenter: Fix instance-profile creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ TESTSYS_BUILD_GOPROXY ?= direct
 # project
 AGENT_IMAGES = sonobuoy-test-agent ec2-resource-agent eks-resource-agent ecs-resource-agent \
                migration-test-agent vsphere-vm-resource-agent vsphere-k8s-cluster-resource-agent \
-               ecs-test-agent k8s-workload-agent ecs-workload-agent metal-k8s-cluster-resource-agent
+               ecs-test-agent k8s-workload-agent ecs-workload-agent metal-k8s-cluster-resource-agent \
+               ec2-karpenter-resource-agent
 
 # The set of container images. Add additional artifacts here when added
 # to the project


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

There was an issue creating the instance profile since it was missing `assume_role_policy_document`. This also fixes an issue where the `account_id` was not substituted in for iamidentitymapping creation.

**Testing done:**

Tested on an account with an existing instance profile, and an account without the instance profile. Both tests ran successfully.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
