### PR TITLE
karpenter: Remove extra `{` and `}` from ConfigMap username

### DIFF
--- a/bottlerocket/agents/src/bin/ec2-karpenter-resource-agent/ec2_karpenter_provider.rs
+++ b/bottlerocket/agents/src/bin/ec2-karpenter-resource-agent/ec2_karpenter_provider.rs
@@ -292,7 +292,7 @@ impl Create for Ec2KarpenterCreator {
                 "--arn",
                 "arn:aws:iam::{account_id}:role/KarpenterInstanceNodeRole",
                 "--username",
-                "system:node:{{{{EC2PrivateDNSName}}}}",
+                "system:node:{{EC2PrivateDNSName}}",
                 "--group",
                 "system:bootstrappers",
                 "--group",


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
