### PR TITLE
testsys-launcher: Script for naming ec2 instances

### DIFF
--- a/deploy/testsys-launcher/README.md
+++ b/deploy/testsys-launcher/README.md
@@ -25,6 +25,10 @@ aws eks update-kubeconfig \
     --role-arn arn:aws:iam::123456789:role/testsys-admin
 ```
 
+_Note:_ node instances themselves are not automatically given the "Name" tag.
+You may want to name them by hand or use the `hack/name-instances.sh` script
+to name all nodes launched by the testsys launcher "testsys-node".
+
 ## Run a sample test
 
 [Refer to `TESTING.md` in the main Bottlerocket repository](https://github.com/bottlerocket-os/bottlerocket/blob/develop/TESTING.md)

--- a/deploy/testsys-launcher/hack/name-instances.sh
+++ b/deploy/testsys-launcher/hack/name-instances.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# The following is a convenience script that can be used to give nodes in the
+# "testsys" cluster the "Name" tag.
+
+instances=$(aws ec2 describe-instances \
+    --filters "Name=tag-value,Values=testsys" "Name=instance-state-code,Values=16" \
+    --query "Reservations[*].Instances[*].[InstanceId]" \
+    --output text)
+
+for instance in $instances; do
+    aws ec2 create-tags --resources $instance --tags "Key=Name,Value=testsys-node"
+    echo "${instance} tagged"
+done
+


### PR DESCRIPTION
**Issue number:**

N/a - related to https://github.com/aws/aws-cdk/issues/20133 where tags do not propegate down to the auto-scaling group (or the instances) for the node group.

**Description of changes:**

Adds a `hack/name-instances.sh` script that can be used to name instances in the testsys cluster "testsys-node".

**Testing done:**

```
❯ ./hack/name-instances.sh
i-0a6dd7241d2ed62cb tagged
i-0b45283a3d44adf78 tagged
i-016a20b12d38513c5 tagged
i-0c601c9c129c266ea tagged
i-08a76f38f8b9d7080 tagged
```

And instances are named correctly in the EC2 web console.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
