### PR TITLE
testsys-launcher: CFN param for number of cluster nodes

### DIFF
--- a/deploy/testsys-launcher/README.md
+++ b/deploy/testsys-launcher/README.md
@@ -38,4 +38,5 @@ Bottlerocket nodes on the cluster consume the latest releases and stay up to dat
 
 ## Optional Parameters
 
-* `TestsysAssumerRole` name of the role that can assume the `testsys-admin` role to perform cluster operations _(string)_ - Default: "Administrator"
+* `TestsysAssumerRole`    name of the role that can assume the `testsys-admin` role to perform cluster operations _(string)_ - Default: "Administrator"
+* `TestsysNodegroupSize`  number of instances for the testsys node-group _(number)_ - Default: "3"

--- a/deploy/testsys-launcher/testsys-launcher.go
+++ b/deploy/testsys-launcher/testsys-launcher.go
@@ -18,7 +18,7 @@ type TestsysLauncherStackProps struct {
 
 // NewTestsysCluster creates a new EKS 1.25 cluster with the default capacity
 // set to 0 and a custom managed nodegroup using bottlerocket AMIs
-func NewTestsysCluster(stack constructs.Construct) eks.Cluster {
+func NewTestsysCluster(stack constructs.Construct, size float64) eks.Cluster {
 	testsysClusterProps := eks.ClusterProps{
 		Version:     eks.KubernetesVersion_V1_25(),
 		ClusterName: jsii.String("testsys"),
@@ -41,7 +41,7 @@ func NewTestsysCluster(stack constructs.Construct) eks.Cluster {
 		InstanceTypes: &[]ec2.InstanceType{
 			ec2.NewInstanceType(jsii.String("m5.xlarge")),
 		},
-		MinSize:  jsii.Number(5),
+		MinSize:  jsii.Number(size),
 		AmiType:  eks.NodegroupAmiType_BOTTLEROCKET_X86_64,
 		NodeRole: nodeRole,
 	})
@@ -83,8 +83,14 @@ func NewTestsysLauncherStack(scope constructs.Construct, id string, props *Tests
 		Default:     jsii.String("Administrator"),
 	})
 
+	testsysNodegroupSize := awscdk.NewCfnParameter(stack, jsii.String("TestsysNodegroupSize"), &awscdk.CfnParameterProps{
+		Type:        jsii.String("Number"),
+		Description: jsii.String("The minimum size of the testsys nodegroup"),
+		Default:     jsii.Number(3),
+	})
+
 	// Start testsys deployments
-	testsysCluster := NewTestsysCluster(stack)
+	testsysCluster := NewTestsysCluster(stack, *testsysNodegroupSize.ValueAsNumber())
 	NewTestsysAdminUser(stack, testsysCluster, *testsysAdminAssumedBy.ValueAsString())
 
 	return stack


### PR DESCRIPTION
**Issue number:**

N/a

**Description of changes:**

Parameter for determining the number of nodes for the testsys cluster

**Testing done:**

Deployed cdk stack and 3 instances came up

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
