### PR TITLE
testsys-launcher: update inputs to allow multiple assumedby roles

### DIFF
--- a/deploy/testsys-launcher/cdk.json
+++ b/deploy/testsys-launcher/cdk.json
@@ -43,6 +43,7 @@
     "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
     "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
     "@aws-cdk/aws-redshift:columnId": true,
-    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true
+    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
+    "testsysAdminAssumedBy": "Administrator"
   }
 }


### PR DESCRIPTION
**Description of changes:**

testsysAdminAssumedBy parameter has been changed from a run time CFNParameter to a build time CDK context. It may be updated either in cdk.json, or by providing

```
cdk deploy --context
testsysAdminAssumedBy=comma,seperated,list,of,role,names
```

This value is a comma seperated list of strings in order to support cli inputs



**Testing done:**
Deployed stack to AWS account


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
