### PR TITLE
sonobuoy-test-agent: add non-blocking-taints for control plane nodes

### DIFF
--- a/bottlerocket/agents/src/sonobuoy.rs
+++ b/bottlerocket/agents/src/sonobuoy.rs
@@ -77,7 +77,7 @@ where
         .args(k8s_image_arg)
         .args(e2e_repo_arg)
         .args(sonobuoy_image_arg)
-        .arg("--plugin-env=e2e.E2E_EXTRA_ARGS=--non-blocking-taints=sonobuoy")
+        .arg("--plugin-env=e2e.E2E_EXTRA_ARGS=--non-blocking-taints=sonobuoy,node-role.kubernetes.io/control-plane,node-role.kubernetes.io/master")
         .status()
         .context(error::SonobuoyProcessSnafu)?;
 


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
We're override the default `non-blocking-taints`, this adds the default list back so sonobuoy can test against clusters that have control plane nodes.


**Testing done:**
I can run full E2E conformance with the `sonobuoy-test-agent` against VMware clusters.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
