### PR TITLE
Add hello-testsys workload test definition

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,12 +6,14 @@ on:
       - 'docs/**'
       - 'tools/**'
       - '.github/dependabot.yml'
+      - 'bottlerocket/tests/workload/**'
   push:
     paths-ignore:
       - '**.md'
       - 'docs/**'
       - 'tools/**'
       - '.github/dependabot.yml'
+      - 'bottlerocket/tests/workload/**'
     branches: [develop]
 jobs:
   build:
@@ -50,4 +52,3 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup default 1.67.1
       - run: make cargo-deny
-      

--- a/bottlerocket/tests/workload/README.md
+++ b/bottlerocket/tests/workload/README.md
@@ -7,9 +7,14 @@ This directory contains the source files and artifacts for running TestSys workl
 New workload tests should be added under this subdirectory.
 The current list of tests are detailed below.
 
+**hello, testsys**
+
+This simple workload test verifies that the most basic of containers can run on the target host.
+See [hello-testsys.yaml](hello-testsys.yaml) for an example configuration.
+
 **NVIDIA smoketests**
 
-This workload tests executes various CUDA samples to verify GPU functionality for Bottlerocket hosts running on NVIDIA instances.
+This workload test executes various CUDA samples to verify GPU functionality for Bottlerocket hosts running on NVIDIA instances.
 See [nvidia-smoke.yaml](nvidia-smoke.yaml) for an example configuration.
 
 ---

--- a/bottlerocket/tests/workload/hello-testsys.yaml
+++ b/bottlerocket/tests/workload/hello-testsys.yaml
@@ -1,0 +1,16 @@
+kind: Test
+metadata:
+  name: workload-agent
+  namespace: testsys
+spec:
+  agent:
+    name: workload-agent
+    image: <WORKLOAD-AGENT-IMAGE>
+    keepRunning: false
+    configuration:
+      kubeconfigBase64: <BASE64-KUBECONFIG>
+      plugins:
+        - name: simple-workload
+          image: <SIMPLE-WORKLOAD-IMAGE>
+  resources: []
+  dependsOn: []

--- a/bottlerocket/tests/workload/hello-testsys/Dockerfile
+++ b/bottlerocket/tests/workload/hello-testsys/Dockerfile
@@ -1,0 +1,26 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+RUN dnf update && \
+    dnf install -y gzip tar && \
+    dnf clean all
+
+RUN cat > run.sh <<EOF
+#!/usr/bin/env bash
+set -e
+
+# Collect the test output where sonobuoy expects plugins to place them
+results_dir="\${RESULTS_DIR:-/tmp/results}"
+mkdir -p "\${results_dir}"
+
+# Hello!
+echo "hello, testsys" | tee "\${results_dir}/hello-testsys.log"
+
+# Save results
+cd "\${results_dir}"
+tar czf results.tar.gz ./*
+echo "\${results_dir}/results.tar.gz" > "\${results_dir}/done"
+EOF
+
+RUN chmod +x ./run.sh
+
+ENTRYPOINT ["./run.sh"]

--- a/bottlerocket/tests/workload/hello-testsys/Makefile
+++ b/bottlerocket/tests/workload/hello-testsys/Makefile
@@ -1,0 +1,59 @@
+.DEFAULT_GOAL:=publish
+
+#### Variables
+PUBLISH_IMAGES_REGISTRY ?=
+TAG ?= latest
+REPOSITORY ?= hello-testsys
+
+#### Format the registry portion of the image tag, if needed
+REGISTRY ?=
+ifdef PUBLISH_IMAGES_REGISTRY
+REGISTRY = "$(PUBLISH_IMAGES_REGISTRY)/"
+endif
+
+ifndef REGISTRY
+$(error "The PUBLISH_IMAGES_REGISTRY value must be provided (e.g. PUBLISH_IMAGES_REGISTRY=861807767978.dkr.ecr.us-east-2.amazonaws.com make)")
+endif
+
+define build-image
+	docker buildx build . -t $(REPOSITORY)-$1 --platform $2 --load
+endef
+
+define tag-image
+	docker tag $(REPOSITORY)-$1 $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+define push-image
+	docker push $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+#### Actual build targets
+.PHONY: build
+build: x86_64 aarch64
+
+.PHONY: x86_64
+x86_64:
+	$(call build-image,$@,linux/amd64)
+	$(call tag-image,x86_64)
+
+.PHONY: aarch64
+aarch64:
+	$(call build-image,$@,linux/aarch64)
+	$(call tag-image,aarch64)
+
+.PHONY: push-platforms
+push-platforms: build
+	$(call push-image,x86_64)
+	$(call push-image,aarch64)
+
+.PHONY: create-manifest
+create-manifest: push-platforms
+	- docker manifest rm $(REGISTRY)$(REPOSITORY):$(TAG)
+	docker manifest create \
+		$(REGISTRY)$(REPOSITORY):$(TAG) \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-x86_64 \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-aarch64 \
+
+.PHONY: publish
+publish: create-manifest
+	docker manifest push $(REGISTRY)$(REPOSITORY):$(TAG)

--- a/bottlerocket/tests/workload/hello-testsys/README.md
+++ b/bottlerocket/tests/workload/hello-testsys/README.md
@@ -1,0 +1,67 @@
+# Hello TestSys test
+
+This container image can be used as a TestSys workload test to validate the Bottlerocket variants.
+
+## Build requirements
+
+Due to missing packages needed for cross-compiling, and unexpected handling in the sample Makefile logic when compiling for one platform for another, the build for this image requires two Buildx hosts - one for each architecture.
+
+In order to build the image for both architectures, you need to set up the `buildx` docker plugin.
+[This guide describes](https://github.com/docker/buildx#installing) the installation process.
+
+By default, the install of `docker buildx` uses the `docker` driver type.
+This driver is not able to build for all platform targets we need.
+You will need to run the following to create a new builder using the `docker-container` driver:
+
+```bash
+docker buildx create --use --bootstrap
+docker buildx ls
+```
+
+You should see a `*` next to your newly created builder denoting it as the currently active builder to use.
+If it is not, you can switch builder contexts by running:
+
+```sh
+docker buildx use $BUILDER_NAME
+```
+
+You then need to add another "context" to the builder for a second host that can build the other platform architecture.
+If you are running these steps on an `amd64` host, you will need to add an `arm64` host to the builder, or vice versa.
+
+First, verify you are able to access the remote host via SSH:
+
+```sh
+docker -H ssh://user@hostname info
+```
+
+The output from that command should show information about the Docker instance running on the remote host.
+You can then add that host to your Buildx builder by running:
+
+```sh
+docker buildx create --name $BUILDER_NAME --append ssh://user@hostname
+```
+
+Supported platforms can be verified by running:
+
+```bash
+docker buildx inspect | grep Platforms
+```
+
+The output from this command should show both `linux/amd64` and `linux/arm64` platforms.
+
+By default, the image will be tagged `<PUBLISH_IMAGES_REGISTRY>/hello-testsys:<TAG>`, so make sure you already have a `hello-testsys` repository in your registry.
+You can change the name of the repo by overriding the `PUBLISH_IMAGES_REGISTRY` env variable while building the image.
+
+**NOTE:** This assumes that you have already configured your credentials to be able to perform a `docker push` to your registry.
+
+## Building the image
+
+To build the image for both `x86_64` and `aarch64`, run the following:
+
+```sh
+PUBLISH_IMAGES_REGISTRY=<YOUR_REGISTRY> make
+```
+
+The command will build, tag, and push the images to your `PUBLISH_IMAGES_REGISTRY` using the name `hello-testsys:<TAG>`.
+
+Since this is a multi-arch image, you can use it in both `x86_64` and `aarch64` clusters.

--- a/bottlerocket/tests/workload/nvidia-smoke/Dockerfile
+++ b/bottlerocket/tests/workload/nvidia-smoke/Dockerfile
@@ -36,4 +36,4 @@ FROM nvidia/cuda:11.4.3-base-ubi8
 COPY ./run.sh /
 COPY --from=builder /samples/* /samples/
 RUN chmod +x ./run.sh
-ENTRYPOINT ["sh", "-c", "/run.sh"]
+ENTRYPOINT ["./run.sh"]


### PR DESCRIPTION
**Description of changes:**

`hello-testsys` is a simple workload test to verify that the most basic of containers can run on the target host.

Also adds a small fix to the `nvidia-smoke` workload test to honor the shebang in the script.

**Testing done:**

```json
{
    "plugin": "simple-workload",
    "node": "global",
    "status": "complete",
    "result-status": "passed",
    "result-counts": {
        "passed": 1
    }
}
 ```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
