### PR TITLE
Remove workaround for eksctl build

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -44,12 +44,6 @@ RUN mkdir eksctl && \
     rm "eksctl_${EKSCTL_VERSION}.tar.gz"
 
 WORKDIR /home/builder/eksctl/
-# TODO - remove this workaround for a bad go.sum hash
-# caused by https://github.com/blizzy78/varnamelen/issues/13#issuecomment-1079040934
-# these sed statement replace a hash that has changed. -i.bak makes these compatible with BSD/macOS sed.
-RUN \
-  sed -i 's,github.com/blizzy78/varnamelen v0.6.1 h1:kttPCLzXFa+0nt++Cw9fb7GrSSM4KkyIAoX/vXsbuqA=,github.com/blizzy78/varnamelen v0.6.1 h1:iYAU/3A6cpfRm2ZI0P/lece4jsc7GEbzsxTu+vBCChQ=,' go.sum ; \
-  sed -i 's,github.com/blizzy78/varnamelen v0.6.1/go.mod h1:zy2Eic4qWqjrxa60jG34cfL0VXcSwzUrIx68eJPb4Q8=,github.com/blizzy78/varnamelen v0.6.1/go.mod h1:mGBHm+Uo4e8JnZEKHRoZgVEOQdSBdQfY/x+k4NAXBWA=,' go.sum
 RUN go mod vendor
 RUN cp -p LICENSE /usr/share/licenses/eksctl && \
     /usr/libexec/tools/bottlerocket-license-scan \


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

There was a release of eksctl that would fail due to a retagged dependency causing a hash mismatch. To get past this we added some handling to update the go.mod/go.sum files when building eksctl as part of our tools build.

eksctl has now moved past that broken version of the dependency, and the current version we use no longer needs this workaround, so this cleans up that extra handling.

**Testing done:**

`make tools`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
