### PR TITLE
Remove extraneous `default()` calls

### DIFF
--- a/agent/resource-agent/examples/duplicator_resource_agent/main.rs
+++ b/agent/resource-agent/examples/duplicator_resource_agent/main.rs
@@ -38,8 +38,8 @@ async fn main() {
 async fn run(data: BootstrapData) -> AgentResult<()> {
     // We specify all of our custom types with this PhantomData struct.
     let types = Types {
-        info_client: PhantomData::<DefaultInfoClient>::default(),
-        agent_client: PhantomData::<DefaultAgentClient>::default(),
+        info_client: PhantomData::<DefaultInfoClient>,
+        agent_client: PhantomData::<DefaultAgentClient>,
     };
 
     // We build the agent component and use it to either create or destroy resources.

--- a/agent/resource-agent/examples/example_resource_agent/main.rs
+++ b/agent/resource-agent/examples/example_resource_agent/main.rs
@@ -38,8 +38,8 @@ async fn main() {
 async fn run(data: BootstrapData) -> AgentResult<()> {
     // We specify all of our custom types with this PhantomData struct.
     let types = Types {
-        info_client: PhantomData::<DefaultInfoClient>::default(),
-        agent_client: PhantomData::<DefaultAgentClient>::default(),
+        info_client: PhantomData::<DefaultInfoClient>,
+        agent_client: PhantomData::<DefaultAgentClient>,
     };
 
     // We build the agent component and use it to either create or destroy resources.


### PR DESCRIPTION

**Issue number:**

N/A

**Description of changes:**

Starting with Rust 1.71.0, [clippy has added another check](https://rust-lang.github.io/rust-clippy/master/index.html#/default_constructed_unit_structs) that looks for `default` being called on unit structs. There are a few instances in the testsys codebase where this happens, so attempting to build with the latest rust toolchain will fail.

This removes the calls to `default()` since they are not necessary.

**Testing done:**

Ran `make build` and verified compilation now completes successfully when using latest stable (rustc 1.71.0).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
