### PR TITLE
metal-k8s-cluster: remove invalid '--force-cleanup' flag

### DIFF
--- a/bottlerocket/agents/src/bin/metal-k8s-cluster-resource-agent/metal_k8s_cluster_provider.rs
+++ b/bottlerocket/agents/src/bin/metal-k8s-cluster-resource-agent/metal_k8s_cluster_provider.rs
@@ -228,7 +228,6 @@ impl Create for MetalK8sClusterCreator {
             .args(["--kubeconfig", &mgmt_kubeconfig_path])
             .args(["-f", &eksa_config_path])
             .args(["--hardware-csv", &hardware_csv_path])
-            .arg("--force-cleanup")
             .arg("--skip-ip-check")
             .args(["-v", "4"])
             .stdout(Stdio::inherit())


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
The `--force-cleanup` flag is no longer supported in eks-anywhere version 0.17.0


**Testing done:**
N/A

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
