### PR TITLE
testsys-launcher: add imdsv2-only hack

### DIFF
--- a/deploy/testsys-launcher/hack/imdsv2-only.sh
+++ b/deploy/testsys-launcher/hack/imdsv2-only.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# The following is a convenience script that can be used to require IMDSv2
+
+instances=$(aws ec2 describe-instances \
+    --filters "Name=tag-value,Values=testsys" "Name=instance-state-code,Values=16" \
+    --query "Reservations[*].Instances[*].[InstanceId]" \
+    --output text)
+
+for instance in ${instances}; do
+    aws ec2 modify-instance-metadata-options \
+        --instance-id "${instance}" \
+        --http-tokens required \
+        --http-endpoint enabled
+done
+


### PR DESCRIPTION
**Description of changes:**

Since there isn't an easy way to force IMDSv2 on instances launched by the ASG, you can just run this script to restrict IMDS on the nodes.

**Testing done:**

Ran the script against my testsys cluster.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
