### PR TITLE
metal, vsphere-cluster-resource: retrieve EKS-A binary at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,6 +752,7 @@ dependencies = [
  "base64 0.20.0",
  "bottlerocket-types",
  "env_logger",
+ "flate2",
  "hex",
  "k8s-openapi",
  "kube",
@@ -766,6 +767,7 @@ dependencies = [
  "serde_yaml 0.8.26",
  "sha2",
  "snafu",
+ "tar",
  "tempfile",
  "test-agent",
  "testsys-model",
@@ -1004,6 +1006,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,6 +1235,16 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "windows-sys",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -161,10 +161,6 @@ RUN amazon-linux-extras install -y docker
 COPY --from=tools /eksctl /usr/bin/eksctl
 COPY --from=tools /licenses/eksctl /licenses/eksctl
 
-# Copy eksctl-anywhere
-COPY --from=tools /eksctl-anywhere /usr/bin/eksctl-anywhere
-COPY --from=tools /licenses/eksctl-anywhere /licenses/eksctl-anywhere
-
 # Copy govc
 COPY --from=build /usr/libexec/tools/govc /usr/local/bin/govc
 COPY --from=build /usr/share/licenses/govmomi /licenses/govmomi
@@ -193,10 +189,6 @@ RUN amazon-linux-extras install -y docker
 # Copy eksctl
 COPY --from=tools /eksctl /usr/bin/eksctl
 COPY --from=tools /licenses/eksctl /licenses/eksctl
-
-# Copy eksctl-anywhere
-COPY --from=tools /eksctl-anywhere /usr/bin/eksctl-anywhere
-COPY --from=tools /licenses/eksctl-anywhere /licenses/eksctl-anywhere
 
 # Copy kubectl
 COPY --from=tools /kubectl /usr/local/bin/kubectl

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,6 @@ TESTSYS_BUILD_HOST_PLATFORM=$(shell uname | tr '[:upper:]' '[:lower:]')
 # On some hosts we get an x509 certificate error and need to set GOPROXY to "direct"
 TESTSYS_BUILD_GOPROXY ?= direct
 
-# Default eksctl_anywhere source ref so it can be overridden
-TESTSYS_EKSA_REF ?= tags/v0.17.1
-
 # The set of agent images. Add new agent artifacts here when added to the
 # project
 AGENT_IMAGES = sonobuoy-test-agent ec2-resource-agent eks-resource-agent ecs-resource-agent \
@@ -139,7 +136,6 @@ tools:
 		--build-arg BUILDER_IMAGE="$(BUILDER_IMAGE)" \
 		--build-arg GOARCH="$(TESTSYS_BUILD_HOST_GOARCH)" \
 		--build-arg GOPROXY="$(TESTSYS_BUILD_GOPROXY)" \
-		--build-arg EKSA_REF="$(TESTSYS_EKSA_REF)" \
 		--network=host \
 		-f ./tools/Dockerfile \
 		-t bottlerocket-test-tools \
@@ -155,7 +151,6 @@ $(AGENT_IMAGES): show-variables fetch
 		--build-arg TOOLS_IMAGE="$(TOOLS_IMAGE)" \
 		--build-arg GOARCH="$(TESTSYS_BUILD_HOST_GOARCH)" \
 		--build-arg GOPROXY="$(TESTSYS_BUILD_GOPROXY)" \
-		--build-arg EKSA_REF="$(TESTSYS_EKSA_REF)" \
 		--network=host \
 		--target $@ \
 		--tag $@ \

--- a/bottlerocket/agents/Cargo.toml
+++ b/bottlerocket/agents/Cargo.toml
@@ -22,6 +22,7 @@ aws-sdk-cloudformation = "0.24"
 aws-smithy-types = "0.54"
 base64 = "0.20"
 env_logger = "0.10"
+flate2 = "1.0"
 hex ="0.4"
 k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }
 kube = { version = "0.82", default-features = false, features = ["config", "derive", "client"] }
@@ -37,6 +38,7 @@ serde_plain = "1"
 serde_yaml = "0.8"
 sha2 = "0.10"
 snafu = "0.7"
+tar = "0.4"
 tempfile = "3"
 test-agent = { version = "0.0.8", path = "../../agent/test-agent" }
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread", "time"] }

--- a/bottlerocket/agents/src/bin/metal-k8s-cluster-resource-agent/metal_k8s_cluster_provider.rs
+++ b/bottlerocket/agents/src/bin/metal-k8s-cluster-resource-agent/metal_k8s_cluster_provider.rs
@@ -27,7 +27,7 @@ use agent_utils::aws::aws_config;
 use agent_utils::base64_decode_write_file;
 use agent_utils::ssm::{create_ssm_activation, ensure_ssm_service_role, wait_for_ssm_ready};
 use bottlerocket_agents::clusters::{
-    retrieve_workload_cluster_kubeconfig, write_validate_mgmt_kubeconfig,
+    install_eks_a_binary, retrieve_workload_cluster_kubeconfig, write_validate_mgmt_kubeconfig,
 };
 use bottlerocket_types::agent_config::{
     CustomUserData, MetalK8sClusterConfig, AWS_CREDENTIALS_SECRET_NAME,
@@ -232,6 +232,8 @@ impl Create for MetalK8sClusterCreator {
                 eksa_config_path
             ),
         )?;
+
+        install_eks_a_binary(&spec.configuration.eks_a_release_manifest_url, &resources).await?;
 
         info!("Creating cluster");
         memo.current_status = "Creating cluster".to_string();
@@ -536,6 +538,9 @@ impl Destroy for MetalK8sClusterDestroyer {
         let configuration = spec
             .context(resources, "The spec was not provided for destruction")?
             .configuration;
+
+        install_eks_a_binary(&configuration.eks_a_release_manifest_url, &resources).await?;
+
         base64_decode_write_file(
             &configuration.mgmt_cluster_kubeconfig_base64,
             &mgmt_kubeconfig_path,

--- a/bottlerocket/agents/src/clusters.rs
+++ b/bottlerocket/agents/src/clusters.rs
@@ -1,10 +1,16 @@
 use agent_utils::base64_decode_write_file;
+use flate2::read::GzDecoder;
 use k8s_openapi::api::core::v1::Secret;
 use kube::config::Kubeconfig;
 use kube::{Api, Config};
-use log::debug;
-use resource_agent::provider::{IntoProviderError, ProviderResult, Resources};
+use log::{debug, info};
+use reqwest::IntoUrl;
+use resource_agent::provider::{IntoProviderError, ProviderError, ProviderResult, Resources};
+use serde::Deserialize;
 use std::convert::TryFrom;
+use std::env;
+use std::fmt::Display;
+use std::path::PathBuf;
 
 /// Write out and check CAPI management cluster is accessible and valid
 pub async fn write_validate_mgmt_kubeconfig(
@@ -59,4 +65,134 @@ pub async fn retrieve_workload_cluster_kubeconfig(
         )?
         .trim_matches('"')
         .to_string())
+}
+
+pub async fn get_eks_a_archive_url<S>(
+    eks_a_release_manifest_url: S,
+    resources: &Resources,
+) -> ProviderResult<String>
+where
+    S: AsRef<str> + IntoUrl + Display,
+{
+    let manifest = reqwest::get(eks_a_release_manifest_url.to_string())
+        .await
+        .context(
+            resources,
+            format!(
+                "Unable to request EKS-A release manifest '{}'",
+                eks_a_release_manifest_url
+            ),
+        )?
+        .text()
+        .await
+        .context(
+            resources,
+            format!(
+                "Unable to retrieve EKS-A release manifest at '{}'",
+                eks_a_release_manifest_url
+            ),
+        )?;
+    let deserialized_manifest = serde_yaml::Deserializer::from_str(&manifest)
+        .map(|config| {
+            serde_yaml::Value::deserialize(config)
+                .context(resources, "Unable to deserialize eksa config file")
+        })
+        .collect::<ProviderResult<Vec<_>>>()?;
+
+    let latest_release_version = deserialized_manifest
+        .iter()
+        .find(|config| {
+            config.get("kind") == Some(&serde_yaml::Value::String("Release".to_string()))
+        })
+        .and_then(|release| release.get("spec"))
+        .and_then(|spec| spec.get("latestVersion"))
+        .and_then(|ver| ver.as_str())
+        .context(resources, "Unable to get latest version for EKS-A")?;
+
+    let arch = match env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        rest => rest,
+    };
+    deserialized_manifest
+        .iter()
+        .find(|manifests| {
+            manifests.get("kind") == Some(&serde_yaml::Value::String("Release".to_string()))
+        })
+        .and_then(|manifest| manifest.get("spec"))
+        .and_then(|spec| spec.get("releases"))
+        .and_then(|list| list.as_sequence())
+        .and_then(|releases| {
+            releases.iter().find(|release| {
+                release.get("version")
+                    == Some(&serde_yaml::Value::String(
+                        latest_release_version.to_string(),
+                    ))
+            })
+        })
+        .and_then(|release| release.get("eksACLI"))
+        .and_then(|list| list.get(env::consts::OS.to_ascii_lowercase()))
+        .and_then(|binaries| binaries.get(arch.to_ascii_lowercase()))
+        .and_then(|binaries| binaries.get("uri"))
+        .and_then(|uri| uri.as_str())
+        .context(
+            resources,
+            format!(
+                "Unable to get the URL for the latest EKS-A version ({})",
+                latest_release_version
+            ),
+        )
+        .map(|s| s.to_string())
+}
+
+pub async fn fetch_eks_a_binary(
+    archive_url: String,
+    dest: PathBuf,
+    resources: &Resources,
+) -> ProviderResult<()> {
+    if !archive_url.ends_with("tar.gz") {
+        return Err(ProviderError::new_with_context(
+            resources,
+            format!(
+                "EKS-A binary archive at '{}' is not tar.gz compressed",
+                archive_url
+            ),
+        ));
+    }
+    let tar_bytes = reqwest::get(&archive_url)
+        .await
+        .context(
+            resources,
+            format!("Unable to request binary at '{}'", archive_url),
+        )?
+        .bytes()
+        .await
+        .context(resources, "Unable to retrieve binary archive bytes.")?;
+
+    // Decompress tar.gz archive
+    let decoder = GzDecoder::new(&tar_bytes[..]);
+    let mut archive = tar::Archive::new(decoder);
+    archive
+        .unpack(dest)
+        .context(resources, "Failed to unpack EKS-A binary archive.")
+}
+
+const USR_LOCAL_BIN: &str = "/usr/local/bin/";
+const DEFAULT_EKS_A_RELEASE_MANIFEST: &str =
+    "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml";
+
+pub async fn install_eks_a_binary(
+    eks_a_release_manifest_url: &Option<String>,
+    resources: &Resources,
+) -> ProviderResult<()> {
+    let eks_a_release_manifest_url = eks_a_release_manifest_url
+        .to_owned()
+        .unwrap_or(DEFAULT_EKS_A_RELEASE_MANIFEST.to_string());
+    info!(
+        "Using EKS-A release manifest '{}'",
+        eks_a_release_manifest_url
+    );
+    let eks_a_archive_url = get_eks_a_archive_url(eks_a_release_manifest_url, resources).await?;
+    info!("Fetching EKS-A binary archive from '{}'", eks_a_archive_url);
+    fetch_eks_a_binary(eks_a_archive_url, PathBuf::from(USR_LOCAL_BIN), resources).await
 }

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -184,6 +184,10 @@ pub struct VSphereK8sClusterConfig {
     /// Workloads folder to create the K8s cluster control plane in
     pub vcenter_workload_folder: String,
 
+    /// URL for an EKS-A release manifest that contains URLs for EKS-A binary archives.
+    /// Defaults to upstream EKS-A release channels.
+    pub eks_a_release_manifest_url: Option<String>,
+
     /// Base64-encoded Kubeconfig for the CAPI management cluster
     pub mgmt_cluster_kubeconfig_base64: String,
 }
@@ -193,7 +197,11 @@ pub struct VSphereK8sClusterConfig {
 #[serde(rename_all = "camelCase")]
 #[crd("Resource")]
 pub struct MetalK8sClusterConfig {
-    // Base64-encoded Kubeconfig for the CAPI management cluster
+    /// URL for an EKS-A release manifest that contains URLs for EKS-A binary archives.
+    /// Defaults to upstream EKS-A release channels.
+    pub eks_a_release_manifest_url: Option<String>,
+
+    /// Base64-encoded Kubeconfig for the CAPI management cluster
     pub mgmt_cluster_kubeconfig_base64: String,
 
     /// The role that should be assumed when activating SSM for the machines.

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -59,37 +59,6 @@ RUN curl -L "${EKSCTL_BINARY_URL}" \
     rm "eksctl_${EKSCTL_VERSION}_${GOOS}_${GOARCH}.tar.gz"
 
 # =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
-FROM build-go as eksctl-anywhere-build
-
-USER root
-RUN mkdir -p /usr/share/licenses/eksctl-anywhere && \
-    chown -R builder:builder /usr/share/licenses/eksctl-anywhere
-
-# Build the eksctl-anywhere from source. Override by setting pull location from
-# docker build (e.g. "--build-arg EKSA_REF=heads/main" to build from current main).
-ARG EKSA_REF=tags/v0.17.1
-ARG EKSA_SOURCE_URL="https://github.com/aws/eks-anywhere/archive/refs/${EKSA_REF}.tar.gz"
-
-USER builder
-WORKDIR /home/builder/
-RUN mkdir eksctl-anywhere && \
-    curl -L "${EKSA_SOURCE_URL}" -o "eksctl_anywhere.tar.gz" && \
-    tar -xf "eksctl_anywhere.tar.gz" \
-      --strip-components 1 -C eksctl-anywhere && \
-    rm "eksctl_anywhere.tar.gz"
-
-USER builder
-WORKDIR /home/builder/eksctl-anywhere/
-RUN go mod vendor
-RUN cp -p LICENSE /usr/share/licenses/eksctl-anywhere && \
-    /usr/libexec/tools/bottlerocket-license-scan \
-      --clarify /clarify.toml \
-      --spdx-data /usr/libexec/tools/spdx-data \
-      --out-dir /usr/share/licenses/eksctl-anywhere/vendor \
-      go-vendor ./vendor
-RUN make eks-a
-
-# =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^= =^..^=
 FROM build-go as kubernetes-build
 
 USER root
@@ -253,14 +222,6 @@ COPY --from=aws-iam-authenticator-build \
 # eksctl
 COPY --from=eksctl-build /home/builder/eksctl/eksctl /eksctl
 COPY --from=eksctl-build /usr/share/licenses/eksctl /licenses/eksctl
-
-# eksctl-anywhere
-COPY --from=eksctl-anywhere-build \
-     /home/builder/eksctl-anywhere/bin/eksctl-anywhere \
-     /eksctl-anywhere
-COPY --from=eksctl-anywhere-build \
-     /usr/share/licenses/eksctl-anywhere \
-     /licenses/eksctl-anywhere
 
 # kubeadm and kubectl
 COPY --from=kubernetes-build /home/builder/kubernetes/kubeadm /kubeadm


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
```

    metal,vsphere-cluster-resource: retrieve EKS-A binary at runtime
    
    Adds a new field for specifying the EKS-A release manifest URL to both
    the metal and vSphere cluster resource agent configurations. At runtime,
    the agents will download the EKS-A binary archive tagged as the latest
    release in the EKS-A release manifest. If a manifest is not specified,
    then the agents defaults to using the upstream official EKS-A release
    manifest.

```
```
    don't build EKS-A binary into the testsys agent images
    
    We now fetch the EKS-A binaries at agent runtime. No longer need to bake
    in the EKS-A binary.

```



**Testing done:**
Able to create vSphere cluster using default EKS-A release manifest:

```
[2023-09-12T23:28:23Z INFO  bottlerocket_agents::clusters] Using EKS-A release manifest 'https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml'                    
[2023-09-12T23:28:23Z INFO  bottlerocket_agents::clusters] Fetching EKS-A binary archive from 'https://anywhere-assets.eks.amazonaws.com/releases/eks-a/47/artifacts/eks-a/v0.17.2/l
inux/amd64/eksctl-anywhere-v0.17.2-linux-amd64.tar.gz'              
```

Full logs:
<details>

```bash
$ kubectl --kubeconfig testsys.kubeconfig logs -f x86-64-vmware-ked61420d-716c-43f8-bfac-572ba59680ba-creatijwhh4 -n testsys                                                        
[2023-09-12T23:28:23Z INFO  resource_agent::agent] Initializing Agent                                                                                                               
[2023-09-12T23:28:23Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Getting vSphere secret                                                                
[2023-09-12T23:28:23Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Creating working directory                                                            
[2023-09-12T23:28:23Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Checking existing cluster                                                             
[2023-09-12T23:28:23Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Creation policy is 'IfNotExists' and cluster 'x86-64-vmware-k8s-128' does not exist: creating cluster                                                                                                                                                                     
[2023-09-12T23:28:23Z INFO  bottlerocket_agents::clusters] Using EKS-A release manifest 'https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml'                    
[2023-09-12T23:28:23Z INFO  bottlerocket_agents::clusters] Fetching EKS-A binary archive from 'https://anywhere-assets.eks.amazonaws.com/releases/eks-a/47/artifacts/eks-a/v0.17.2/l
inux/amd64/eksctl-anywhere-v0.17.2-linux-amd64.tar.gz'                                                                                                                              
[2023-09-12T23:28:23Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Creating cluster                                                                      
[2023-09-12T23:28:23Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Downloading OVA 'bottlerocket-vmware-k8s-1.27-x86_64-v1.15.0.ova'                     
[2023-09-12T23:28:33Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Importing OVA and creating a VM template out of it                                    
[2023-09-12T23:28:46Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Tagging VM template                                                                   
2023-09-12T23:29:42.104Z        V4      Reading bundles manifest        {"url": "https://anywhere-assets.eks.amazonaws.com/releases/bundles/47/manifest.yaml"}                      
2023-09-12T23:29:42.456Z        V4      Relative network path specified, using path /SDDC-Datacenter/network/sddc-cgw-network-2               
....
```
</details>

Using a custom EKS-A release manifest, cluster creation works:

```bash
[2023-09-12T23:46:27Z INFO  bottlerocket_agents::clusters] Using EKS-A release manifest 'https://.cloudfront.net/baremetal/eksctl-anywhere-manifest.yaml'
[2023-09-12T23:46:27Z INFO  bottlerocket_agents::clusters] Fetching EKS-A binary archive from 'https://.cloudfront.net/baremetal/eksctl-anywhere-linux-amd64.tar.gz'
```
Full logs:
<details>

```bash
$ kubectl --kubeconfig testsys.kubeconfig logs -f x86-64-vmware-k6aec44d1-503c-4f92-abf0-1ca35d41ae2d-creatif5r6l -n testsys
[2023-09-12T23:46:27Z INFO  resource_agent::agent] Initializing Agent
[2023-09-12T23:46:27Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Getting vSphere secret
[2023-09-12T23:46:27Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Creating working directory
[2023-09-12T23:46:27Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Checking existing cluster
[2023-09-12T23:46:27Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Creation policy is 'IfNotExists' and cluster 'x86-64-vmware-k8s-128' does not exist: creating cluster
[2023-09-12T23:46:27Z INFO  bottlerocket_agents::clusters] Using EKS-A release manifest 'https://.cloudfront.net/baremetal/eksctl-anywhere-manifest.yaml'
[2023-09-12T23:46:27Z INFO  bottlerocket_agents::clusters] Fetching EKS-A binary archive from 'https://.cloudfront.net/baremetal/eksctl-anywhere-linux-amd64.tar.gz'
[2023-09-12T23:46:29Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Creating cluster
[2023-09-12T23:46:29Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Downloading OVA 'bottlerocket-vmware-k8s-1.28-x86_64-v1.15.0.ova'
[2023-09-12T23:46:33Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Importing OVA and creating a VM template out of it
[2023-09-12T23:46:45Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Tagging VM template
2023-09-12T23:47:41.247Z        V4      Reading bundles manifest        {"url": "https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/bundle-release.yaml"}
2023-09-12T23:47:41.345Z        V4      Relative network path specified, using path /SDDC-Datacenter/network/sddc-cgw-network-2
2023-09-12T23:47:41.345Z        V1      SSHUsername is not set or is empty for VSphereMachineConfig, using default      {"c": "x86-64-vmware-k8s-128-node", "user": "ec2-user"}
2023-09-12T23:47:41.432Z        V2      Pulling docker image    {"image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.17.1-eks-a-v0.0.0-dev-build.7550"}
2023-09-12T23:47:48.032Z        V3      Initializing long running container     {"name": "eksa_1694562461432403955", "image": "public.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools:v0.17.1-eks-a-v0.0.0-dev-build.7550"}
2023-09-12T23:47:51.714Z        V4      Task start      {"task_name": "setup-validate"}
2023-09-12T23:47:51.714Z        V0      Performing setup and validations
2023-09-12T23:47:51.732Z        V0      ✅ Connected to server
2023-09-12T23:47:52.091Z        V0      ✅ Authenticated to vSphere
2023-09-12T23:47:52.833Z        V0      ✅ Datacenter validated
2023-09-12T23:47:53.165Z        V0      ✅ Network validated
2023-09-12T23:47:54.162Z        V3      CloneMode not set, defaulting to fullClone      {"VSphereMachineConfig": "x86-64-vmware-k8s-128-node"}
2023-09-12T23:47:54.162Z        V4      Relative datastore path specified, using path /SDDC-Datacenter/datastore/WorkloadDatastore
2023-09-12T23:47:54.541Z        V0      ✅ Datastore validated
2023-09-12T23:47:54.826Z        V0      ✅ Folder validated
2023-09-12T23:47:55.116Z        V0      ✅ Resource pool validated
2023-09-12T23:47:57.555Z        V0      ✅ Machine config tags validated
2023-09-12T23:47:57.555Z        V0      ✅ Control plane and Workload templates validated
2023-09-12T23:47:58.958Z        V0      Provided sshAuthorizedKey is not set or is empty, auto-generating new key pair...       {"vSphereMachineConfig": "x86-64-vmware-k8s-128-node"}
2023-09-12T23:48:00.293Z        V0      Private key saved to x86-64-vmware-k8s-128/eks-a-id_rsa. Use 'ssh -i x86-64-vmware-k8s-128/eks-a-id_rsa <username>@<Node-IP-Address>' to login to your cluster node
2023-09-12T23:48:02.425Z        V0      ✅ cloudadmin@vmc.local user vSphere privileges validated
2023-09-12T23:48:02.425Z        V0      ✅ Vsphere Provider setup is valid
2023-09-12T23:48:02.425Z        V0      ✅ Validate OS is compatible with registry mirror configuration
2023-09-12T23:48:02.425Z        V0      ✅ Validate certificate for registry mirror
2023-09-12T23:48:02.425Z        V0      ✅ Validate authentication for git provider
2023-09-12T23:48:02.425Z        V0      ✅ Validate cluster's eksaVersion matches EKS-A version
2023-09-12T23:48:03.335Z        V0      ✅ Validate cluster name
2023-09-12T23:48:03.335Z        V0      ✅ Validate gitops
2023-09-12T23:48:03.335Z        V0      ✅ Validate identity providers' name
2023-09-12T23:48:04.054Z        V0      ✅ Validate management cluster has eksa crds
2023-09-12T23:48:05.054Z        V0      ✅ Validate management cluster name is valid
2023-09-12T23:48:05.929Z        V0      ✅ Validate management cluster eksaVersion compatibility
2023-09-12T23:48:05.929Z        V4      Task finished   {"task_name": "setup-validate", "duration": "14.214849493s"}
2023-09-12T23:48:05.929Z        V4      ----------------------------------
2023-09-12T23:48:05.929Z        V4      Task start      {"task_name": "bootstrap-cluster-init"}
2023-09-12T23:48:05.929Z        V4      Task finished   {"task_name": "bootstrap-cluster-init", "duration": "2.044µs"}
2023-09-12T23:48:05.930Z        V4      ----------------------------------
2023-09-12T23:48:05.930Z        V4      Task start      {"task_name": "workload-cluster-init"}
2023-09-12T23:48:05.930Z        V0      Creating new workload cluster
2023-09-12T23:48:06.846Z        V3      Waiting for external etcd to be ready   {"cluster": "x86-64-vmware-k8s-128"}
2023-09-12T23:50:15.185Z        V3      External etcd is ready
2023-09-12T23:50:15.185Z        V3      Waiting for control plane to be available
...
2023-09-12T23:53:12.975Z        V4      Nodes ready     {"total": 3}
2023-09-12T23:53:12.975Z        V4      Task finished   {"task_name": "workload-cluster-init", "duration": "5m7.045290773s"}
2023-09-12T23:53:12.975Z        V4      ----------------------------------
2023-09-12T23:53:12.975Z        V4      Task start      {"task_name": "install-resources-on-management-cluster"}
2023-09-12T23:53:12.975Z        V4      Task finished   {"task_name": "install-resources-on-management-cluster", "duration": "1.514µs"}
2023-09-12T23:53:12.975Z        V4      ----------------------------------
2023-09-12T23:53:12.975Z        V4      Task start      {"task_name": "capi-management-move"}
2023-09-12T23:53:12.975Z        V4      Task finished   {"task_name": "capi-management-move", "duration": "616ns"}
2023-09-12T23:53:12.975Z        V4      ----------------------------------
2023-09-12T23:53:12.975Z        V4      Task start      {"task_name": "eksa-components-install"}
2023-09-12T23:53:12.975Z        V0      Creating EKS-A CRDs instances on workload cluster
2023-09-12T23:53:12.978Z        V4      Applying eksa yaml resources to cluster
2023-09-12T23:53:13.616Z        V1      Applying Bundles to cluster
2023-09-12T23:53:14.317Z        V1      Applying EKSARelease to cluster
2023-09-12T23:53:14.942Z        V4      Applying eksd manifest to cluster
....
2023-09-12T23:53:20.060Z        V4      Task finished   {"task_name": "eksa-components-install", "duration": "7.084643615s"}
2023-09-12T23:53:20.060Z        V4      ----------------------------------
2023-09-12T23:53:20.060Z        V4      Task start      {"task_name": "gitops-manager-install"}
2023-09-12T23:53:20.060Z        V0      Installing GitOps Toolkit on workload cluster
2023-09-12T23:53:20.060Z        V0      GitOps field not specified, bootstrap flux skipped
2023-09-12T23:53:20.060Z        V4      Task finished   {"task_name": "gitops-manager-install", "duration": "88.987µs"}
2023-09-12T23:53:20.060Z        V4      ----------------------------------
2023-09-12T23:53:20.060Z        V4      Task start      {"task_name": "write-cluster-config"}
2023-09-12T23:53:20.060Z        V0      Writing cluster config file
2023-09-12T23:53:20.062Z        V4      Task finished   {"task_name": "write-cluster-config", "duration": "2.409873ms"}
2023-09-12T23:53:20.062Z        V4      ----------------------------------
2023-09-12T23:53:20.063Z        V4      Task start      {"task_name": "delete-kind-cluster"}
2023-09-12T23:53:20.063Z        V0      🎉 Cluster created!
2023-09-12T23:53:20.063Z        V4      Task finished   {"task_name": "delete-kind-cluster", "duration": "15.9µs"}
2023-09-12T23:53:20.063Z        V4      ----------------------------------
2023-09-12T23:53:20.063Z        V4      Task start      {"task_name": "install-curated-packages"}
--------------------------------------------------------------------------------------
The Amazon EKS Anywhere Curated Packages are only available to customers with the 
Amazon EKS Anywhere Enterprise Subscription
--------------------------------------------------------------------------------------
...
2023-09-12T23:53:20.855Z        V4      Tasks completed {"duration": "5m29.14094338s"}
2023-09-12T23:53:20.856Z        V3      Logging out from current govc session
2023-09-12T23:53:21.484Z        V3      Cleaning up long running container      {"name": "eksa_1694562461432403955"}
[2023-09-12T23:53:22Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Scaling default NodeGroup machinedeployments replicas to 0
machinedeployment.cluster.x-k8s.io/x86-64-vmware-k8s-128-md-0 scaled
[2023-09-12T23:53:22Z INFO  vsphere_k8s_cluster_resource_agent::vsphere_k8s_cluster_provider] Cluster created

```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
