### PR TITLE
Sonobuoy fixes

### DIFF
--- a/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
@@ -139,7 +139,7 @@ where
         rerun_failed_sonobuoy(
             TEST_CLUSTER_KUBECONFIG_PATH,
             e2e_repo_config,
-            self.config.sonobuoy_image.to_owned(),
+            &self.config,
             &self.results_dir,
             info_client,
         )

--- a/bottlerocket/agents/src/sonobuoy.rs
+++ b/bottlerocket/agents/src/sonobuoy.rs
@@ -109,7 +109,7 @@ where
 pub async fn rerun_failed_sonobuoy<I>(
     kubeconfig_path: &str,
     e2e_repo_config_path: Option<&str>,
-    sonobuoy_image: Option<String>,
+    sonobuoy_config: &SonobuoyConfig,
     results_dir: &Path,
     info_client: &I,
 ) -> Result<TestResults, error::Error>
@@ -118,6 +118,21 @@ where
 {
     let kubeconfig_arg = vec!["--kubeconfig", kubeconfig_path];
     let results_filepath = results_dir.join(SONOBUOY_RESULTS_FILENAME);
+    let version = sonobuoy_config
+        .kubernetes_version
+        .as_ref()
+        .map(|version| version.full_version_with_v());
+    let k8s_image_arg = match (&sonobuoy_config.kube_conformance_image, &version) {
+        (Some(image), None) | (Some(image), Some(_)) => {
+            vec!["--kube-conformance-image", image]
+        }
+        (None, Some(version)) => {
+            vec!["--kubernetes-version", version]
+        }
+        _ => {
+            vec![]
+        }
+    };
     let e2e_repo_arg = match e2e_repo_config_path {
         Some(e2e_repo_config_path) => {
             vec!["--e2e-repo-config", e2e_repo_config_path]
@@ -126,7 +141,7 @@ where
             vec![]
         }
     };
-    let sonobuoy_image_arg = match &sonobuoy_image {
+    let sonobuoy_image_arg = match &sonobuoy_config.sonobuoy_image {
         Some(sonobuoy_image_arg) => {
             vec!["--sonobuoy-image", sonobuoy_image_arg]
         }
@@ -138,6 +153,7 @@ where
     let status = Command::new("/usr/bin/sonobuoy")
         .args(kubeconfig_arg.to_owned())
         .arg("run")
+        .args(k8s_image_arg)
         .args(e2e_repo_arg)
         .args(sonobuoy_image_arg)
         .arg("--rerun-failed")

--- a/bottlerocket/agents/src/sonobuoy.rs
+++ b/bottlerocket/agents/src/sonobuoy.rs
@@ -11,6 +11,9 @@ use std::time::Duration;
 use test_agent::InfoClient;
 use testsys_model::{Outcome, TestResults};
 
+/// Timeout for sonobuoy status to become available (seconds)
+const SONOBUOY_STATUS_TIMEOUT: u64 = 900;
+
 /// Runs the sonobuoy conformance tests according to the provided configuration and returns a test
 /// result at the end.
 pub async fn run_sonobuoy<I>(
@@ -93,7 +96,7 @@ where
         .for_each(|e| error!("Unable to send test update: {}", e));
     info!("Sonobuoy testing has started, waiting for status to be available");
     tokio::time::timeout(
-        Duration::from_secs(300),
+        Duration::from_secs(SONOBUOY_STATUS_TIMEOUT),
         wait_for_sonobuoy_status(kubeconfig_path, None),
     )
     .await
@@ -166,7 +169,7 @@ where
 
     info!("Sonobuoy testing has started, waiting for status to be available");
     tokio::time::timeout(
-        Duration::from_secs(300),
+        Duration::from_secs(SONOBUOY_STATUS_TIMEOUT),
         wait_for_sonobuoy_status(kubeconfig_path, None),
     )
     .await

--- a/bottlerocket/agents/src/workload.rs
+++ b/bottlerocket/agents/src/workload.rs
@@ -13,6 +13,8 @@ use std::time::Duration;
 use test_agent::InfoClient;
 use testsys_model::TestResults;
 
+/// Timeout for sonobuoy status to become available (seconds)
+const SONOBUOY_STATUS_TIMEOUT: u64 = 900;
 const SONOBUOY_BIN_PATH: &str = "/usr/bin/sonobuoy";
 
 /// Runs the workload conformance tests according to the provided configuration and returns a test
@@ -84,7 +86,7 @@ where
 
     info!("Workload testing has started, waiting for status to be available");
     tokio::time::timeout(
-        Duration::from_secs(300),
+        Duration::from_secs(SONOBUOY_STATUS_TIMEOUT),
         wait_for_sonobuoy_status(kubeconfig_path, Some("testsys-workload")),
     )
     .await
@@ -130,7 +132,7 @@ where
 
     info!("Workload testing has started, waiting for status to be available");
     tokio::time::timeout(
-        Duration::from_secs(300),
+        Duration::from_secs(SONOBUOY_STATUS_TIMEOUT),
         wait_for_sonobuoy_status(kubeconfig_path, Some("testsys-workload")),
     )
     .await


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
56cc188  sonobuoy: Increase status timeout to 15 mins
* When testing in clusters with slower networking speeds, we noticed that the 5 minute timeout was not quite long enough.

fc5c832 sonobuoy: Use kubeconformance image in retries
* The kubeconformance image was not used when retrying sonobuoy tests.


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
