### PR TITLE
samples: Re-order crds in ecs samples

### DIFF
--- a/bottlerocket/samples/eks/ecs-migration-test.yaml
+++ b/bottlerocket/samples/eks/ecs-migration-test.yaml
@@ -1,4 +1,44 @@
 apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: testsys
+spec:
+  agent:
+    name: ecs-provider
+    image: ${ECS_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: ${CLUSTER_NAME}
+      region: ${AWS_REGION}
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: []
+  destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Resource
+metadata:
+  name: ${CLUSTER_NAME}-instances
+  namespace: testsys
+spec:
+  agent:
+    name: ec2-provider
+    image: ${EC2_RESOURCE_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      clusterType: ecs
+      instanceCount: 2
+      nodeAmi: ${BOTTLEROCKET_AMI_ID}
+      region: ${AWS_REGION}
+      instanceProfileArn: \${${CLUSTER_NAME}.iamInstanceProfileArn}
+      subnetIds: \${${CLUSTER_NAME}.publicSubnetIds}
+      instanceTypes: ["m5.large"]
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: [${CLUSTER_NAME}]
+  destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
 kind: Test
 metadata:
   name: ${CLUSTER_NAME}-test-1-initial
@@ -90,43 +130,4 @@ spec:
       assumeRole: ${ASSUME_ROLE}
   dependsOn: [${CLUSTER_NAME}-test-4-migrate]
   resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
----
-apiVersion: testsys.system/v1
-kind: Resource
-metadata:
-  name: ${CLUSTER_NAME}
-  namespace: testsys
-spec:
-  agent:
-    name: ecs-provider
-    image: ${ECS_RESOURCE_AGENT_IMAGE_URI}
-    keepRunning: true
-    configuration:
-      clusterName: ${CLUSTER_NAME}
-      region: ${AWS_REGION}
-      assumeRole: ${ASSUME_ROLE}
-  dependsOn: []
-  destructionPolicy: onDeletion
----
-apiVersion: testsys.system/v1
-kind: Resource
-metadata:
-  name: ${CLUSTER_NAME}-instances
-  namespace: testsys
-spec:
-  agent:
-    name: ec2-provider
-    image: ${EC2_RESOURCE_AGENT_IMAGE_URI}
-    keepRunning: true
-    configuration:
-      clusterName: \${${CLUSTER_NAME}.clusterName}
-      clusterType: ecs
-      instanceCount: 2
-      nodeAmi: ${BOTTLEROCKET_AMI_ID}
-      region: ${AWS_REGION}
-      instanceProfileArn: \${${CLUSTER_NAME}.iamInstanceProfileArn}
-      subnetIds: \${${CLUSTER_NAME}.publicSubnetIds}
-      instanceTypes: ["m5.large"]
-      assumeRole: ${ASSUME_ROLE}
-  dependsOn: [${CLUSTER_NAME}]
-  destructionPolicy: onDeletion
+

--- a/bottlerocket/samples/eks/ecs-test.yaml
+++ b/bottlerocket/samples/eks/ecs-test.yaml
@@ -1,21 +1,4 @@
 apiVersion: testsys.system/v1
-kind: Test
-metadata:
-  name: ${CLUSTER_NAME}-test
-  namespace: testsys
-spec:
-  agent:
-    name: ecs-test-agent
-    image: ${ECS_TEST_AGENT_IMAGE_URI}
-    keepRunning: true
-    configuration:
-      clusterName: \${${CLUSTER_NAME}.clusterName}
-      region: \${${CLUSTER_NAME}.region}
-      assumeRole: ${ASSUME_ROLE}
-  dependsOn: []
-  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
----
-apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: ${CLUSTER_NAME}
@@ -54,3 +37,20 @@ spec:
       assumeRole: ${ASSUME_ROLE}
   dependsOn: [${CLUSTER_NAME}]
   destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test
+  namespace: testsys
+spec:
+  agent:
+    name: ecs-test-agent
+    image: ${ECS_TEST_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      region: \${${CLUSTER_NAME}.region}
+      assumeRole: ${ASSUME_ROLE}
+  dependsOn: []
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]

--- a/bottlerocket/samples/eks/ecs-workload-test.yaml
+++ b/bottlerocket/samples/eks/ecs-workload-test.yaml
@@ -1,25 +1,4 @@
 apiVersion: testsys.system/v1
-kind: Test
-metadata:
-  name: ${CLUSTER_NAME}-test
-  namespace: testsys 
-spec:
-  agent:
-    name: ecs-workload-agent
-    image: ${ECS_WORKLOAD_AGENT_IMAGE_URI}
-    keepRunning: true
-    configuration:
-      clusterName: \${${CLUSTER_NAME}.clusterName}
-      region: \${${CLUSTER_NAME}.region}
-      assumeRole: ${ASSUME_ROLE}
-      tests:
-      - name: ${WORKLOAD_TEST_NAME}
-        image: ${WORKLOAD_TEST_IMAGE_URI}
-        gpu: ${GPU}
-  dependsOn: []
-  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]
----
-apiVersion: testsys.system/v1
 kind: Resource
 metadata:
   name: ${CLUSTER_NAME}
@@ -58,3 +37,24 @@ spec:
       assumeRole: ${ASSUME_ROLE}
   dependsOn: [${CLUSTER_NAME}]
   destructionPolicy: onDeletion
+---
+apiVersion: testsys.system/v1
+kind: Test
+metadata:
+  name: ${CLUSTER_NAME}-test
+  namespace: testsys 
+spec:
+  agent:
+    name: ecs-workload-agent
+    image: ${ECS_WORKLOAD_AGENT_IMAGE_URI}
+    keepRunning: true
+    configuration:
+      clusterName: \${${CLUSTER_NAME}.clusterName}
+      region: \${${CLUSTER_NAME}.region}
+      assumeRole: ${ASSUME_ROLE}
+      tests:
+      - name: ${WORKLOAD_TEST_NAME}
+        image: ${WORKLOAD_TEST_IMAGE_URI}
+        gpu: ${GPU}
+  dependsOn: []
+  resources: [${CLUSTER_NAME}-instances, ${CLUSTER_NAME}]

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -636,51 +636,50 @@ mod test {
 
         let docs: Vec<&str> = s.split("---").collect();
         let &yaml = docs.get(0).unwrap();
-        let test_1_initial: Test = serde_yaml::from_str(yaml).unwrap();
-        let _: EcsTestConfig = serde_json::from_value(JsonValue::Object(
-            test_1_initial.spec.agent.configuration.unwrap(),
-        ))
-        .unwrap();
-
-        let &yaml = docs.get(1).unwrap();
-        let test_2_migrate: Test = serde_yaml::from_str(yaml).unwrap();
-        let _: MigrationConfig = serde_json::from_value(JsonValue::Object(
-            test_2_migrate.spec.agent.configuration.unwrap(),
-        ))
-        .unwrap();
-
-        let &yaml = docs.get(2).unwrap();
-        let test_3_migrated: Test = serde_yaml::from_str(yaml).unwrap();
-        let _: EcsTestConfig = serde_json::from_value(JsonValue::Object(
-            test_3_migrated.spec.agent.configuration.unwrap(),
-        ))
-        .unwrap();
-
-        let &yaml = docs.get(3).unwrap();
-        let test_4_migrate: Test = serde_yaml::from_str(yaml).unwrap();
-        let _: MigrationConfig = serde_json::from_value(JsonValue::Object(
-            test_4_migrate.spec.agent.configuration.unwrap(),
-        ))
-        .unwrap();
-
-        let &yaml = docs.get(4).unwrap();
-        let test_5_final: Test = serde_yaml::from_str(yaml).unwrap();
-        let _: EcsTestConfig = serde_json::from_value(JsonValue::Object(
-            test_5_final.spec.agent.configuration.unwrap(),
-        ))
-        .unwrap();
-
-        let &yaml = docs.get(5).unwrap();
         let cluster_resource: Resource = serde_yaml::from_str(yaml).unwrap();
         let _: EcsClusterConfig = serde_json::from_value(JsonValue::Object(
             cluster_resource.spec.agent.configuration.unwrap(),
         ))
         .unwrap();
 
-        let &yaml = docs.get(6).unwrap();
+        let &yaml = docs.get(1).unwrap();
         let ec2_resource: Resource = serde_yaml::from_str(yaml).unwrap();
         let _: Ec2Config = serde_json::from_value(JsonValue::Object(
             ec2_resource.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+        let &yaml = docs.get(2).unwrap();
+        let test_1_initial: Test = serde_yaml::from_str(yaml).unwrap();
+        let _: EcsTestConfig = serde_json::from_value(JsonValue::Object(
+            test_1_initial.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+
+        let &yaml = docs.get(3).unwrap();
+        let test_2_migrate: Test = serde_yaml::from_str(yaml).unwrap();
+        let _: MigrationConfig = serde_json::from_value(JsonValue::Object(
+            test_2_migrate.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+
+        let &yaml = docs.get(4).unwrap();
+        let test_3_migrated: Test = serde_yaml::from_str(yaml).unwrap();
+        let _: EcsTestConfig = serde_json::from_value(JsonValue::Object(
+            test_3_migrated.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+
+        let &yaml = docs.get(5).unwrap();
+        let test_4_migrate: Test = serde_yaml::from_str(yaml).unwrap();
+        let _: MigrationConfig = serde_json::from_value(JsonValue::Object(
+            test_4_migrate.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+
+        let &yaml = docs.get(6).unwrap();
+        let test_5_final: Test = serde_yaml::from_str(yaml).unwrap();
+        let _: EcsTestConfig = serde_json::from_value(JsonValue::Object(
+            test_5_final.spec.agent.configuration.unwrap(),
         ))
         .unwrap();
     }
@@ -695,23 +694,23 @@ mod test {
 
         let docs: Vec<&str> = s.split("---").collect();
         let &yaml = docs.get(0).unwrap();
-        let test_1_initial: Test = serde_yaml::from_str(yaml).unwrap();
-        let _: EcsTestConfig = serde_json::from_value(JsonValue::Object(
-            test_1_initial.spec.agent.configuration.unwrap(),
-        ))
-        .unwrap();
-
-        let &yaml = docs.get(1).unwrap();
         let cluster_resource: Resource = serde_yaml::from_str(yaml).unwrap();
         let _: EcsClusterConfig = serde_json::from_value(JsonValue::Object(
             cluster_resource.spec.agent.configuration.unwrap(),
         ))
         .unwrap();
 
-        let &yaml = docs.get(2).unwrap();
+        let &yaml = docs.get(1).unwrap();
         let ec2_resource: Resource = serde_yaml::from_str(yaml).unwrap();
         let _: Ec2Config = serde_json::from_value(JsonValue::Object(
             ec2_resource.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+
+        let &yaml = docs.get(2).unwrap();
+        let test_1_initial: Test = serde_yaml::from_str(yaml).unwrap();
+        let _: EcsTestConfig = serde_json::from_value(JsonValue::Object(
+            test_1_initial.spec.agent.configuration.unwrap(),
         ))
         .unwrap();
     }
@@ -728,23 +727,23 @@ mod test {
 
         let docs: Vec<&str> = s.split("---").collect();
         let &yaml = docs.get(0).unwrap();
-        let test_1_initial: Test = serde_yaml::from_str(yaml).unwrap();
-        let _: EcsWorkloadTestConfig = serde_json::from_value(JsonValue::Object(
-            test_1_initial.spec.agent.configuration.unwrap(),
-        ))
-        .unwrap();
-
-        let &yaml = docs.get(1).unwrap();
         let cluster_resource: Resource = serde_yaml::from_str(yaml).unwrap();
         let _: EcsClusterConfig = serde_json::from_value(JsonValue::Object(
             cluster_resource.spec.agent.configuration.unwrap(),
         ))
         .unwrap();
 
-        let &yaml = docs.get(2).unwrap();
+        let &yaml = docs.get(1).unwrap();
         let ec2_resource: Resource = serde_yaml::from_str(yaml).unwrap();
         let _: Ec2Config = serde_json::from_value(JsonValue::Object(
             ec2_resource.spec.agent.configuration.unwrap(),
+        ))
+        .unwrap();
+
+        let &yaml = docs.get(2).unwrap();
+        let test_1_initial: Test = serde_yaml::from_str(yaml).unwrap();
+        let _: EcsWorkloadTestConfig = serde_json::from_value(JsonValue::Object(
+            test_1_initial.spec.agent.configuration.unwrap(),
         ))
         .unwrap();
     }


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**



**Description of changes:**

There is a race condition that can cause ecs migration samples to fail since the test crds are created before the resource crds. This commit re-orders the crds as mitigation.


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
