### PR TITLE
karpenter-ec2: take cluster sg as a single string instead of sequence

### DIFF
--- a/bottlerocket/agents/src/bin/ec2-karpenter-resource-agent/ec2_karpenter_provider.rs
+++ b/bottlerocket/agents/src/bin/ec2-karpenter-resource-agent/ec2_karpenter_provider.rs
@@ -261,7 +261,7 @@ impl Create for Ec2KarpenterCreator {
                     .value(&spec.configuration.cluster_name)
                     .build(),
             )
-            .set_resources(Some(spec.configuration.cluster_sg.clone()))
+            .set_resources(Some(vec![spec.configuration.cluster_sg.clone()]))
             .send()
             .await
             .context(resources, "Unable to tag cluster's security groups")?;

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -325,7 +325,7 @@ pub struct Ec2KarpenterConfig {
     pub endpoint: String,
 
     /// The cluster security group
-    pub cluster_sg: Vec<String>,
+    pub cluster_sg: String,
 
     /// The device mappings used for karpenter provisioning
     #[serde(default)]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A


**Description of changes:**
The cluster security group is a singular value we pass from the EKS resource agent to the EC2 karpenter agent config.


**Testing done:**
```bash
[cargo-make] INFO - Execute Command: "/home/fedora/bottlerocket/tools/twoliter/twoliter" "--log-level=info" "make" "test" "--project-path=/home/fedora/bottlerocket/Twoliter.toml" "--cargo-home=/home/fedora/bottlerocket/.cargo" "--"
[cargo-make][1] INFO - Build File: /tmp/.tmpSRwG0d/Makefile.toml
[cargo-make][1] INFO - Task: test
[cargo-make][1] INFO - Profile: development
[cargo-make][1] INFO - Running Task: test
[2023-09-19T20:33:58Z INFO  testsys::run] Successfully added 'bottlerocket'
[2023-09-19T20:33:58Z INFO  testsys::run] Successfully added 'bottlerocket-karpenter-vugp'
[2023-09-19T20:33:58Z INFO  testsys::run] Successfully added 'bottlerocket-karpenter'
[cargo-make][1] INFO - Build Done in 1.67 seconds.
[cargo-make] INFO - Build Done in 905.67 seconds.

...
$ cli  --kubeconfig testsys.kubeconfig status 
 NAME                    TYPE      STATE       PASSED   FAILED   SKIPPED 
 bottlerocket-karpente   Test      passed           5        0      7206 
 bottlerocket            Resourc   completed                             
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
