### PR TITLE
trivial: Fix minor typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,5 +236,5 @@ $(CREATE_REPOS):
 		fi; \
 		echo "Created repository $(REPO)"; \
 	else \
-		echo "Repository already $(REPO) exists"; \
+		echo "Repository $(REPO) already exists"; \
 	fi


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Just fixes some scrambled wording in the output when running the create-repos task.

**Testing done:**

N/A

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
