### PR TITLE
Add step to setup for building cross arch containers

### DIFF
--- a/bottlerocket/tests/workload/nvidia-smoke/README.md
+++ b/bottlerocket/tests/workload/nvidia-smoke/README.md
@@ -42,6 +42,12 @@ You can then add that host to your Buildx builder by running:
 docker buildx create --name $BUILDER_NAME --append ssh://user@hostname
 ```
 
+You must bootstrap the new builder.
+
+```sh
+docker buildx inspect --bootstrap --builder $BUILDER_NAME
+```
+
 Supported platforms can be verified by running:
 
 ```bash


### PR DESCRIPTION
The nvidia-smoke tests need multi-arch builds if using the README which is missing a command to fully configure the remote builder. This should enable the builds to succeed.

**Testing done:**

The buildx command failed to find arm platforms until this command was run, now it shows all the required platforms:
```
$ docker buildx ls
NAME/NODE           DRIVER/ENDPOINT                                               STATUS  BUILDKIT             PLATFORMS
gracious_shirley *  docker-container
  gracious_shirley0 unix:///var/run/docker.sock                                   running v0.12.3              linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/amd64/v4, linux/386
  gracious_shirley1 ssh://fedora@HOSTNAME running v0.12.3              linux/arm64, linux/arm/v7, linux/arm/v6
default             docker
  default           default                                                       running v0.11.6+616c3f613b54 linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/amd64/v4, linux/386
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
