### PR TITLE
controller: Add cloudwatch logging for pods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-cloudwatchlogs"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4f8dbe7e86cb0c5999cb5911e052ec1e6e3f4abbbcb1333a63538b4aecdaa9b"
+dependencies = [
+ "aws-credential-types",
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "regex",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
 name = "aws-sdk-ec2"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +972,9 @@ name = "controller"
 version = "0.0.10"
 dependencies = [
  "anyhow",
+ "aws-config",
+ "aws-sdk-cloudwatchlogs",
+ "aws-types",
  "env_logger",
  "futures",
  "http",

--- a/cli/src/install.rs
+++ b/cli/src/install.rs
@@ -14,6 +14,9 @@ pub(crate) struct Install {
     // TODO - add default controller_uri after images are published.
     #[clap(long = "controller-uri")]
     controller_uri: String,
+
+    #[clap(long = "archive-logs")]
+    archive_logs: bool,
 }
 
 impl Install {
@@ -22,9 +25,12 @@ impl Install {
             (Some(secret), image) => ImageConfig::WithCreds { secret, image },
             (None, image) => ImageConfig::Image(image),
         };
-        client.install(controller_image).await.context(
-            "Unable to install testsys to the cluster. (Some artifacts may be left behind)",
-        )?;
+        client
+            .install(controller_image, self.archive_logs)
+            .await
+            .context(
+                "Unable to install testsys to the cluster. (Some artifacts may be left behind)",
+            )?;
 
         println!("testsys components were successfully installed.");
 

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -7,6 +7,9 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1"
+aws-config = "0.54"
+aws-types = "0.54"
+aws-sdk-cloudwatchlogs = "0.24"
 env_logger = "0.10"
 futures = "0.3"
 http = "0"

--- a/controller/src/job/error.rs
+++ b/controller/src/job/error.rs
@@ -13,14 +13,42 @@ pub(crate) enum JobError {
     #[snafu(display("Unable to create job: {}", source))]
     Create { source: kube::Error },
 
+    #[snafu(display("Unable to create log event '{}': {:?}", log_event, source))]
+    CreateLogEvent {
+        log_event: String,
+        source: aws_sdk_cloudwatchlogs::types::SdkError<
+            aws_sdk_cloudwatchlogs::error::PutLogEventsError,
+        >,
+    },
+
+    #[snafu(display("Unable to create log group '{}': {}", log_group, message))]
+    CreateLogGroup { log_group: String, message: String },
+
+    #[snafu(display("Unable to create log stream '{}': {:?}", log_stream, source))]
+    CreateLogStream {
+        log_stream: String,
+        source: aws_sdk_cloudwatchlogs::types::SdkError<
+            aws_sdk_cloudwatchlogs::error::CreateLogStreamError,
+        >,
+    },
+
     #[snafu(display("Unable to delete job: {}", source))]
     Delete { source: kube::Error },
 
     #[snafu(display("Unable to get job: {}", source))]
     Get { source: kube::Error },
 
+    #[snafu(display("Unable to read logs for pod '{}': {}", pod, source))]
+    NoLogs { pod: String, source: kube::Error },
+
+    #[snafu(display("No pods found for job '{}'", job))]
+    NoPods { job: String },
+
     #[snafu(display("Job does not exist: {}", source))]
     NotFound { source: kube::Error },
+
+    #[snafu(display("{}", source), context(false))]
+    SystemTime { source: std::time::SystemTimeError },
 
     #[snafu(display(
         "There should be only one container for job '{}' but found {} running, {} succeeded, and {} failed",

--- a/model/src/system/mod.rs
+++ b/model/src/system/mod.rs
@@ -6,6 +6,6 @@ mod namespace;
 pub use agent::{agent_cluster_role, agent_cluster_role_binding, agent_service_account, AgentType};
 pub use controller::{
     controller_cluster_role, controller_cluster_role_binding, controller_deployment,
-    controller_service_account,
+    controller_service_account, TESTSYS_CONTROLLER_ARCHIVE_LOGS,
 };
 pub use namespace::testsys_namespace;

--- a/model/src/test_manager/install.rs
+++ b/model/src/test_manager/install.rs
@@ -119,8 +119,9 @@ impl TestManager {
         &self,
         uri: String,
         secret: Option<String>,
+        enable_logging: bool,
     ) -> Result<()> {
-        let controller_deployment = controller_deployment(uri, secret);
+        let controller_deployment = controller_deployment(uri, secret, enable_logging);
 
         // If the controller deployment already exists, update it with the new one using Patch. If
         // not create a new controller deployment.

--- a/model/src/test_manager/manager.rs
+++ b/model/src/test_manager/manager.rs
@@ -131,7 +131,7 @@ impl TestManager {
     }
 
     /// Install testsys to a cluster.
-    pub async fn install(&self, controller_config: ImageConfig) -> Result<()> {
+    pub async fn install(&self, controller_config: ImageConfig, store_logs: bool) -> Result<()> {
         self.create_namespace().await?;
         self.create_crd().await?;
         self.create_roles(AgentType::Test).await?;
@@ -145,7 +145,7 @@ impl TestManager {
             ImageConfig::WithCreds { secret, image } => (image, Some(secret)),
             ImageConfig::Image(image) => (image, None),
         };
-        self.create_deployment(image, secret).await?;
+        self.create_deployment(image, secret, store_logs).await?;
 
         Ok(())
     }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Add an optional flag to the controller for archiving pod logs with CloudWatch.

**Testing done:**

Verified that logs are archived when the flag is set and not if the flag is not set. Tested archival for completed pods and interrupted pods.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
