### PR TITLE
sonobuoy: Delete namespace before attempting test

### DIFF
--- a/bottlerocket/agents/src/bin/k8s-workload-agent/main.rs
+++ b/bottlerocket/agents/src/bin/k8s-workload-agent/main.rs
@@ -86,6 +86,14 @@ where
             .await?;
         info!("Stored kubeconfig in {}", TEST_CLUSTER_KUBECONFIG_PATH);
 
+        match delete_workload(TEST_CLUSTER_KUBECONFIG_PATH).await {
+            Ok(_) => {}
+            Err(e) => info!(
+                "Unable to delete workload testing namespace. It is possible it was already deleted. {}",
+                e
+            ),
+        };
+
         run_workload(
             TEST_CLUSTER_KUBECONFIG_PATH,
             &self.config,

--- a/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
@@ -94,6 +94,14 @@ where
             None => None,
         };
 
+        match delete_sonobuoy(TEST_CLUSTER_KUBECONFIG_PATH).await {
+            Ok(_) => {}
+            Err(e) => info!(
+                "Unable to delete sonobuoy namespace. It is possible it was already deleted. {}",
+                e
+            ),
+        };
+
         run_sonobuoy(
             TEST_CLUSTER_KUBECONFIG_PATH,
             e2e_repo_config,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**



**Description of changes:**

Automatically delete the sonobuoy namespace to prevent it from causing test errors.

**Testing done:**

Built the sonobuoy agent and verified that it worked with both an existing namespace and without a namespace.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
