### PR TITLE
sonobuoy agent: increase assume role duration time to 4 hours

### DIFF
--- a/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
@@ -46,6 +46,9 @@ use test_agent::{
 };
 use testsys_model::{SecretName, TestResults};
 
+// Default Sonobuoy agents assume role duration to 4 hours.
+const DEFAULT_ASSUME_ROLE_SESSION_DURATION: i32 = 14400;
+
 struct SonobuoyTestRunner {
     config: SonobuoyConfig,
     aws_secret_name: Option<SecretName>,
@@ -73,7 +76,7 @@ where
         aws_config(
             &self.aws_secret_name.as_ref(),
             &self.config.assume_role,
-            &None,
+            &Some(DEFAULT_ASSUME_ROLE_SESSION_DURATION),
             &None,
             &None,
             true,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
sonobuoy agent: increase assume role duration time to 4 hours

**Testing done:**
Launch conformance test by using the sonobuoy agent with the change.
```
  Normal  Pulled     2m50s  kubelet            Successfully pulled image "359404537045.dkr.ecr.us-west-2.amazonaws.com/tianhg-sonobuoy:latest" in 7.413848778s (7.413873208s including waiting)
```

```
[2024-03-15T00:07:56Z WARN  twoliter::project] A Release.toml file was found. Release.toml is deprecated. Please remove it from your project.
[cargo-make][1] INFO - Build File: /home/tianhg/workspaces/bottlerocket/build/tools/Makefile.toml
[cargo-make][1] INFO - Task: testsys
[cargo-make][1] INFO - Profile: development
[cargo-make][1] INFO - Running Task: testsys
 NAME                                                     TYPE                       STATE                                       PASSED                   FAILED                  SKIPPED   BUILD ID                  LAST UPDATE
 x86-64-aws-k8s-128-conformance                           Test                       running                                          0                        0                        0   d533ff69                  2024-03-15T00:07:51Z
 x86-64-aws-k8s-128-ipv6-conformance                      Test                       running                                          0                        0                        0   d533ff69                  2024-03-15T00:07:51Z
 x86-64-aws-k8s-128                                       Resource                   completed                                                                                              d533ff69                  2024-03-15T00:04:18Z
 x86-64-aws-k8s-128-instances-eleh                        Resource                   completed                                                                                              d533ff69                  2024-03-15T00:04:28Z
 x86-64-aws-k8s-128-ipv6                                  Resource                   completed                                                                                              d533ff69                  2024-03-15T00:04:18Z
 x86-64-aws-k8s-128-ipv6-instances-jfmq                   Resource                   completed                                                                                              d533ff69                  2024-03-15T00:04:26Z
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
