### PR TITLE
sonobuoy: re-set the assume role credentials if it expires

### DIFF
--- a/bottlerocket/agents/src/bin/k8s-workload-agent/main.rs
+++ b/bottlerocket/agents/src/bin/k8s-workload-agent/main.rs
@@ -99,6 +99,7 @@ where
             &self.config,
             &self.results_dir,
             info_client,
+            &self.aws_secret_name.as_ref(),
         )
         .await
     }
@@ -115,7 +116,14 @@ where
             .await?;
         info!("Stored kubeconfig in {}", TEST_CLUSTER_KUBECONFIG_PATH);
 
-        rerun_failed_workload(TEST_CLUSTER_KUBECONFIG_PATH, &self.results_dir, info_client).await
+        rerun_failed_workload(
+            TEST_CLUSTER_KUBECONFIG_PATH,
+            &self.results_dir,
+            info_client,
+            &self.config,
+            &self.aws_secret_name.as_ref(),
+        )
+        .await
     }
 
     async fn terminate(&mut self) -> Result<(), Self::E> {

--- a/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
+++ b/bottlerocket/agents/src/bin/sonobuoy-test-agent/main.rs
@@ -46,8 +46,8 @@ use test_agent::{
 };
 use testsys_model::{SecretName, TestResults};
 
-// Default Sonobuoy agents assume role duration to 4 hours.
-const DEFAULT_ASSUME_ROLE_SESSION_DURATION: i32 = 14400;
+// Default Sonobuoy agents assume role duration to 1 hour.
+const DEFAULT_ASSUME_ROLE_SESSION_DURATION: i32 = 3600;
 
 struct SonobuoyTestRunner {
     config: SonobuoyConfig,
@@ -111,6 +111,7 @@ where
             &self.config,
             &self.results_dir,
             info_client,
+            &self.aws_secret_name.as_ref(),
         )
         .await
     }
@@ -153,6 +154,7 @@ where
             &self.config,
             &self.results_dir,
             info_client,
+            &self.aws_secret_name.as_ref(),
         )
         .await
     }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
We use IAM Role chaining on ephemeral testing infrastructure. Role chaining limits AWS CLI or AWS API role session to a maximum of one hour. When we assume the k8s new account role using role chaining and provide a DurationSeconds parameter value greater than one hour, the operation fails. Testsys sonobuoy agent needs more than one hour, so we need to refresh the credential when the client asks us to provide credentials

**Testing done:**

- [x] Running aws-k8s-1.24 conformance and workload test on [thar-dev+k8s-testing-124@amazon.com](https://isengard.amazon.com/manage-accounts/058264117412) since this will need IAM role chaining. 

```
x86-64-aws-k8s-124-conformance                             Test                       passed                                        354                       0                     6619   34b6993c                  2024-03-18T05:13:55Z
x86-64-aws-k8s-124-ipv6-test                             Test                       passed                                           1                        0                        0   34b6993c                  2024-03-18T06:42:51Z
 x86-64-aws-k8s-124-test                                  Test                       passed                                           1                        0                        0   34b6993c                  2024-03-18T06:42:51Z
``` 
- [x] Running aws-k8s-1.28 conformance and workload test on [thar-dev+k8s-testing-128@amazon.com](https://isengard.amazon.com/manage-accounts/339713044837) since this will need IAM role chaining. 
```
x86-64-aws-k8s-128-conformance                             Test                       passed                                        384                       0                     7009   34b6993c                  2024-03-18T05:26:33Z
x86-64-aws-k8s-128-test                                    Test                       passed                                          1                       0                        0   34b6993c                  2024-03-18T05:29:00Z
x86-64-aws-k8s-128-nvidia-conformance                      Test                       passed                                        384                       0                     7009   34b6993c                  2024-03-18T06:34:18Z
x86-64-aws-k8s-128-nvidia-test                             Test                       passed                                          2                       0                        0   34b6993c                  2024-03-18T06:37:27Z
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
