### PR TITLE
update karpenter agent version to 0.36.1

### DIFF
--- a/bottlerocket/agents/src/bin/ec2-karpenter-resource-agent/ec2_karpenter_provider.rs
+++ b/bottlerocket/agents/src/bin/ec2-karpenter-resource-agent/ec2_karpenter_provider.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 use testsys_model::{Configuration, SecretName};
 use tokio::fs::read_to_string;
 
-const KARPENTER_VERSION: &str = "v0.33.1";
+const KARPENTER_VERSION: &str = "0.36.1";
 const CLUSTER_KUBECONFIG: &str = "/local/cluster.kubeconfig";
 const PROVISIONER_YAML: &str = "/local/provisioner.yaml";
 const TAINTED_NODEGROUP_NAME: &str = "tainted-nodegroup";


### PR DESCRIPTION
**Issue number:**
n/a


**Description of changes:**

Update the Karpenter Agent version to 0.36.1. Karpenter switched the naming convention for its agent image tages to drop 'v': https://gallery.ecr.aws/karpenter/karpenter


**Testing done:**

This image was used in the Karpenter testing of the Bottlerocket 1.20.0 release.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
