### PR TITLE
workload: support sonobuoy-image on workload test.

### DIFF
--- a/bottlerocket/agents/src/workload.rs
+++ b/bottlerocket/agents/src/workload.rs
@@ -64,6 +64,14 @@ where
             plugin_yaml.display().to_string(),
         ]);
     }
+    let sonobuoy_image_arg = match &workload_config.sonobuoy_image {
+        Some(sonobuoy_image_arg) => {
+            vec!["--sonobuoy-image", sonobuoy_image_arg]
+        }
+        None => {
+            vec![]
+        }
+    };
 
     info!("Running workload");
     let kubeconfig_arg = vec!["--kubeconfig", kubeconfig_path];
@@ -73,6 +81,7 @@ where
         .arg("--namespace")
         .arg("testsys-workload")
         .args(plugin_test_args)
+        .args(sonobuoy_image_arg)
         .output()
         .context(error::WorkloadProcessSnafu)?;
 
@@ -120,12 +129,22 @@ where
     let kubeconfig_arg = vec!["--kubeconfig", kubeconfig_path];
     let results_filepath = results_dir.join(SONOBUOY_RESULTS_FILENAME);
 
+    let sonobuoy_image_arg = match &workload_config.sonobuoy_image {
+        Some(sonobuoy_image_arg) => {
+            vec!["--sonobuoy-image", sonobuoy_image_arg]
+        }
+        None => {
+            vec![]
+        }
+    };
+
     info!("Rerunning workload");
     let output = Command::new(SONOBUOY_BIN_PATH)
         .args(kubeconfig_arg.to_owned())
         .arg("run")
         .arg("--namespace")
         .arg("testsys-workload")
+        .args(sonobuoy_image_arg)
         .arg("--rerun-failed")
         .arg(results_filepath.as_os_str())
         .output()

--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -591,6 +591,7 @@ pub struct WorkloadConfig {
     pub kubeconfig_base64: String,
     pub tests: Vec<WorkloadTest>,
     pub assume_role: Option<String>,
+    pub sonobuoy_image: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Configuration, Builder)]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

**Description of changes:**
workload: support sonobuoy-image on workload test.


**Testing done:**

- [x] Test workload on China partition
Test.cn.toml
```

[aws]
conformance-registry = "553617369496.dkr.ecr.cn-north-1.amazonaws.com.cn"
sonobuoy-image = "553617369496.dkr.ecr.cn-north-1.amazonaws.com.cn/sonobuoy:v0.56.12"
```

```
[cargo-make][1] INFO - Running Task: testsys
 NAME                                                TYPE                       STATE                                       PASSED                   FAILED                   SKIPPED   BUILD ID                         LAST UPDATE
 x86-64-aws-k8s-129-test                             Test                       pass                                            1                        0                         0   74114b49-dirty                   2024-06-17T14:52:19Z
 x86-64-aws-k8s-129                                  Resource                   completed                                                                                               74114b49-dirty                   2024-06-17T14:50:50Z
 x86-64-aws-k8s-129-instances-eyca                   Resource                   completed                                                                                               74114b49-dirty                   2024-06-17T14:50:59Z
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
