### PR TITLE
sonobuoy: pass progress report URL

### DIFF
--- a/bottlerocket/agents/src/sonobuoy.rs
+++ b/bottlerocket/agents/src/sonobuoy.rs
@@ -82,7 +82,7 @@ where
         .args(k8s_image_arg)
         .args(e2e_repo_arg)
         .args(sonobuoy_image_arg)
-        .arg("--plugin-env=e2e.E2E_EXTRA_ARGS=--non-blocking-taints=sonobuoy,node-role.kubernetes.io/control-plane,node-role.kubernetes.io/master")
+        .arg("--plugin-env=e2e.E2E_EXTRA_ARGS=--non-blocking-taints=sonobuoy,node-role.kubernetes.io/control-plane,node-role.kubernetes.io/master --progress-report-url=http://localhost:8099/progress")
         .status()
         .context(error::SonobuoyProcessSnafu)?;
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
#890

**Description of changes:**
In https://github.com/bottlerocket-os/bottlerocket-test-system/pull/803 the sonobuoy agent was updated to pass in e2e args. As a result, the default ones were removed causing sonobuoy to not report the status as tests are completing.

The fix can be found here - https://github.com/vmware-tanzu/sonobuoy/issues/1507#issuecomment-1089297318


**Testing done:**

 

- [x] Run full conformance test with updated agent and while watching testsys status, verify that tests results are regularly updated

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
