### PR TITLE
ec2-resource: extend ec2 resource destroy timeout time

### DIFF
--- a/bottlerocket/agents/src/bin/ec2-resource-agent/ec2_provider.rs
+++ b/bottlerocket/agents/src/bin/ec2-resource-agent/ec2_provider.rs
@@ -788,7 +788,7 @@ impl Destroy for Ec2Destroyer {
 
         // Ensure the instances reach a terminated state.
         tokio::time::timeout(
-            Duration::from_secs(600),
+            Duration::from_secs(900),
             wait_for_conforming_instances(
                 &ec2_client,
                 &ids,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

**Description of changes:**
ec2-resource: extend ec2 resource destroy timeout time.

P4 instance has been introduced to 1.29-nvidia, and it needs more time to be terminated. 


**Testing done:**
```
NAME                                         TYPE        STATE            PASSED       FAILED       SKIPPED   BUILD ID       LAST UPDATE
 x86-64-aws-k8s-129-nvidia-conformance        Test        passed              392            0          7020   fcf71a47       2024-06-28T11:46:19Z
 x86-64-aws-k8s-129-nvidia-test               Test        passed                2            0             0   fcf71a47       2024-06-28T09:43:19Z
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
