### PR TITLE
fix bug from updating tabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/bottlerocket-os/bottlerocket-test-system/compare/v0.0.13...develop
+[Unreleased]: https://github.com/bottlerocket-os/bottlerocket-test-system/compare/v0.0.14...develop
+
+## [0.0.14] - 2024-07-31
+
+### Fixed
+
+- fixed a bug preventing test names from being printed by `cli status` ([#932])
+
+[#932]: https://github.com/bottlerocket-os/bottlerocket-test-system/pull/932
+
+[0.0.14]: https://github.com/bottlerocket-os/bottlerocket-test-system/tree/v0.0.14
 
 ## [0.0.13] - 2024-07-31
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "agent-common"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "snafu",
  "tempfile",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agent-utils"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "agent-common",
  "aws-config",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-agents"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "agent-common",
  "agent-utils",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-types"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "builder-derive",
  "configuration-derive",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "builder-derive"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "configuration-derive",
  "proc-macro2",
@@ -926,7 +926,7 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "cli"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -949,7 +949,7 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "configuration-derive"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "quote",
  "syn 2.0.71",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "resource-agent"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "agent-common",
  "async-trait",
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "selftest"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "anyhow",
  "envy",
@@ -2885,7 +2885,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-agent"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "agent-common",
  "async-trait",
@@ -2901,7 +2901,7 @@ dependencies = [
 
 [[package]]
 name = "test-agent-cli"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "agent-common",
  "argh",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "testsys-model"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/agent/agent-common/Cargo.toml
+++ b/agent/agent-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "agent-common"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-testsys-model = { version = "0.0.13", path = "../../model" }
+testsys-model = { version = "0.0.14", path = "../../model" }
 snafu = "0.8"
 
 [dev-dependencies]

--- a/agent/builder-derive/Cargo.toml
+++ b/agent/builder-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "builder-derive"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2018"
 publish = false
 license = "MIT OR Apache-2.0"
@@ -17,5 +17,5 @@ proc-macro = true
 [dev-dependencies]
 serde = "1"
 serde_json= "1"
-testsys-model = { version = "0.0.13", path = "../../model" }
-configuration-derive = { version = "0.0.13", path = "../configuration-derive" }
+testsys-model = { version = "0.0.14", path = "../../model" }
+configuration-derive = { version = "0.0.14", path = "../configuration-derive" }

--- a/agent/configuration-derive/Cargo.toml
+++ b/agent/configuration-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "configuration-derive"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2018"
 publish = false
 license = "MIT OR Apache-2.0"

--- a/agent/resource-agent/Cargo.toml
+++ b/agent/resource-agent/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "resource-agent"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-agent-common = { version = "0.0.13", path = "../agent-common" }
+agent-common = { version = "0.0.14", path = "../agent-common" }
 async-trait = "0.1"
 log = "0.4"
-testsys-model = { version = "0.0.13", path = "../../model" }
+testsys-model = { version = "0.0.14", path = "../../model" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu = "0.8"

--- a/agent/test-agent-cli/Cargo.toml
+++ b/agent/test-agent-cli/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "test-agent-cli"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 argh = "0.1"
-agent-common = { version = "0.0.13", path = "../agent-common" }
+agent-common = { version = "0.0.14", path = "../agent-common" }
 copy_dir = "0.1"
-test-agent = { version = "0.0.13", path = "../test-agent" }
+test-agent = { version = "0.0.14", path = "../test-agent" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
 log = "0.4"
-testsys-model = { version = "0.0.13", path = "../../model" }
+testsys-model = { version = "0.0.14", path = "../../model" }
 snafu = "0.8"
 serde_json = "1"
 env_logger = "0.10"
@@ -22,4 +22,4 @@ tar = "0.4"
 
 [dev-dependencies]
 assert_cmd = "2"
-selftest = { version = "0.0.13", path = "../../selftest" }
+selftest = { version = "0.0.14", path = "../../selftest" }

--- a/agent/test-agent/Cargo.toml
+++ b/agent/test-agent/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "test-agent"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-agent-common = { version = "0.0.13", path = "../agent-common" }
+agent-common = { version = "0.0.14", path = "../agent-common" }
 async-trait = "0.1"
 log = "0.4"
-testsys-model = { version = "0.0.13", path = "../../model" }
+testsys-model = { version = "0.0.14", path = "../../model" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu = "0.8"

--- a/agent/test-agent/src/k8s_client.rs
+++ b/agent/test-agent/src/k8s_client.rs
@@ -72,10 +72,7 @@ impl Client for DefaultClient {
     {
         let test_data = self.client.get(&self.name).await.context(K8sSnafu)?;
 
-        let raw_config = match test_data.spec.agent.configuration {
-            Some(serde_map) => serde_map,
-            None => Default::default(),
-        };
+        let raw_config = test_data.spec.agent.configuration.unwrap_or_default();
 
         let resource_client = ResourceClient::new()
             .await

--- a/agent/utils/Cargo.toml
+++ b/agent/utils/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "agent-utils"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2018"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-agent-common = { version = "0.0.13", path = "../../agent/agent-common" }
+agent-common = { version = "0.0.14", path = "../../agent/agent-common" }
 aws-config = "1"
 aws-credential-types = "1"
 aws-types = "1"
@@ -17,10 +17,10 @@ aws-smithy-types = "1"
 base64 = "0.21"
 env_logger = "0.10"
 log = "0.4"
-testsys-model = { version = "0.0.13", path = "../../model" }
-resource-agent = { version = "0.0.13", path = "../../agent/resource-agent" }
+testsys-model = { version = "0.0.14", path = "../../model" }
+resource-agent = { version = "0.0.14", path = "../../agent/resource-agent" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu = "0.8"
-test-agent = { version = "0.0.13", path = "../../agent/test-agent" }
+test-agent = { version = "0.0.14", path = "../../agent/test-agent" }
 tokio = { version = "1", default-features = false, features = ["time"] }

--- a/bottlerocket/agents/Cargo.toml
+++ b/bottlerocket/agents/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "bottlerocket-agents"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2018"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-agent-common = { version = "0.0.13", path = "../../agent/agent-common" }
-agent-utils = { version = "0.0.13", path = "../../agent/utils" }
-bottlerocket-types = { version = "0.0.13", path = "../types" }
+agent-common = { version = "0.0.14", path = "../../agent/agent-common" }
+agent-utils = { version = "0.0.14", path = "../../agent/utils" }
+bottlerocket-types = { version = "0.0.14", path = "../types" }
 async-trait = "0.1"
 aws-types = "1"
 aws-sdk-ec2 = "1"
@@ -26,16 +26,16 @@ kube = { version = "0.88", default-features = false, features = ["config", "deri
 log = "0.4"
 maplit = "1"
 openssh = { version = "0.10", features = ["native-mux"] }
-testsys-model = { version = "0.0.13", path = "../../model" }
+testsys-model = { version = "0.0.14", path = "../../model" }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "blocking"] }
-resource-agent = { version = "0.0.13", path = "../../agent/resource-agent" }
+resource-agent = { version = "0.0.14", path = "../../agent/resource-agent" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
 snafu = "0.8"
 tar = "0.4"
-test-agent = { version = "0.0.13", path = "../../agent/test-agent" }
+test-agent = { version = "0.0.14", path = "../../agent/test-agent" }
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
 toml = "0.5"
 tough = { version = "0.17", features = ["http"] }

--- a/bottlerocket/types/Cargo.toml
+++ b/bottlerocket/types/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "bottlerocket-types"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2018"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-configuration-derive = { version = "0.0.13", path = "../../agent/configuration-derive" }
-builder-derive = { version = "0.0.13", path = "../../agent/builder-derive" }
-testsys-model = { version = "0.0.13", path = "../../model" }
+configuration-derive = { version = "0.0.14", path = "../../agent/configuration-derive" }
+builder-derive = { version = "0.0.14", path = "../../agent/builder-derive" }
+testsys-model = { version = "0.0.14", path = "../../model" }
 serde = "1"
 serde_plain = "1"
 serde_yaml = "0.9"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "controller"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
@@ -18,6 +18,6 @@ kube = { version = "0.88", default-features = false, features = ["derive", "clie
 kube-runtime = "0.88"
 lazy_static = "1"
 log = "0.4"
-testsys-model = { version = "0.0.13", path = "../model" }
+testsys-model = { version = "0.0.14", path = "../model" }
 snafu = "0.8"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testsys-model"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
@@ -32,7 +32,7 @@ tokio-util = "0.7"
 topological-sort = "0.2"
 
 [dev-dependencies]
-selftest = { version = "0.0.13", path = "../selftest" }
+selftest = { version = "0.0.14", path = "../selftest" }
 tokio = { version = "1", features = ["macros"] }
 
 [features]

--- a/model/src/test_manager/manager_impl.rs
+++ b/model/src/test_manager/manager_impl.rs
@@ -200,7 +200,7 @@ impl TestManager {
     where
         S: Into<String>,
     {
-        let resource_crd = self.resource_client().get(&resource.into()).await;
+        let resource_crd = self.resource_client().get(resource.into()).await;
         match resource_crd {
             // if the resource exists, retrieve the pod based on the truncated resource name + UID + resource state
             Ok(resource_object) => {

--- a/selftest/Cargo.toml
+++ b/selftest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "selftest"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2021"
 publish = false
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ envy = "0"
 k8s-openapi = { version = "0.21", default-features = false, features = ["v1_24"] }
 kube = { version = "0.88", default-features = false, features = ["client", "rustls-tls"] }
 lazy_static = "1"
-testsys-model = { version = "0.0.13", path = "../model"}
+testsys-model = { version = "0.0.14", path = "../model"}
 serde = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["time"] }


### PR DESCRIPTION
**Description of changes:**
We noticed that `cli status` no longer printed test names in its log output. This was because Tabled changed its logic around table indices, using our own data for the index when transposing the data.


**Testing done:**
* `cli status` now prints test names:
```
 NAME                                            TYPE             STATE                  PASSED        FAILED        SKIPPED
 aarch64-aws-k8s-128-1-initial                   Test             waiting
 aarch64-aws-k8s-128-2-migrate                   Test             error
 aarch64-aws-k8s-128-3-migrated                  Test             waiting
 aarch64-aws-k8s-128-4-migrate                   Test             error
 aarch64-aws-k8s-128-5-final                     Test             waiting
 aarch64-aws-k8s-128-conformance                 Test             waiting
```
* added test passes


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
