### PR TITLE
Added CRD data extraction and output condenser

### DIFF
--- a/bottlerocket/agents/src/sonobuoy.rs
+++ b/bottlerocket/agents/src/sonobuoy.rs
@@ -17,6 +17,7 @@ const SONOBUOY_STATUS_TIMEOUT: u64 = 900;
 
 /// Runs the sonobuoy conformance tests according to the provided configuration and returns a test
 /// result at the end.
+#[allow(clippy::needless_borrows_for_generic_args)]
 pub async fn run_sonobuoy<I>(
     kubeconfig_path: &str,
     e2e_repo_config_path: Option<&str>,

--- a/model/src/test_manager/mod.rs
+++ b/model/src/test_manager/mod.rs
@@ -5,7 +5,7 @@ pub use error::{Error, Result};
 pub use manager::{read_manifest, TestManager};
 use serde::{Deserialize, Serialize};
 use serde_plain::derive_fromstr_from_deserialize;
-pub use status::{StatusColumn, StatusSnapshot};
+pub use status::{crd_results, crd_state, crd_type, ResultType, StatusColumn, StatusSnapshot};
 use std::collections::HashMap;
 
 mod delete;


### PR DESCRIPTION
**Issue number:**

N/A


**Description of changes:**

I added methods to extract the data of one CRD and all CRDs. This data can then be used to condensed further by outputting aggregate data on the 5 migration CRDs per migration test, if all 5 migration stages pass. The aggregate data will be output as a singular unit of data that is accessible and provides output in a less cluttered way.

**Testing done:**

I booted up multiple migration tests that either completely passed or failed at some stages. The migration tests that completely passed only outputted one line of results within 'testsys status.' Migration tests that failed at some point has all lines outputted.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
