### PR TITLE
chore: Update NVIDIA smoke test CUDA version to 11.8 to support Ada Lovelace (L4/L40S for g6/g6e) and Hopper (H100 for p5) architectures

### DIFF
--- a/bottlerocket/tests/workload/nvidia-smoke/Dockerfile
+++ b/bottlerocket/tests/workload/nvidia-smoke/Dockerfile
@@ -1,7 +1,7 @@
 # Builder for the CUDA Sample binaries. The image we run to perform the tests
 # doesn't need everything that is included in the "devel" image. So we build with
 # the larger image, then copy them to the lightweight image we use to run.
-FROM nvidia/cuda:11.4.3-devel-ubi8 as builder
+FROM nvidia/cuda:11.8.0-devel-ubi8 as builder
 
 # Make sure we have git to clone the sample repo
 RUN dnf makecache \
@@ -10,7 +10,7 @@ RUN dnf makecache \
   && rm -fr /var/cache/dnf
 
 # Clone the samples, pinned to a version we know should work
-RUN git clone --branch v11.6 --depth 1 https://github.com/NVIDIA/cuda-samples.git
+RUN git clone --branch v11.8 --depth 1 https://github.com/NVIDIA/cuda-samples.git
 RUN mkdir -p /samples
 
 # There is a Makefile in the 'cuda-samples' project, but it will
@@ -31,8 +31,8 @@ RUN cd /cuda-samples/Samples/3_CUDA_Features/globalToShmemAsyncCopy/ && make && 
 RUN cd /cuda-samples/Samples/6_Performance/UnifiedMemoryPerf/ && make && cp $(basename $(pwd)) /samples/
 
 # We only need the base image to run the tests. It contains the necessary
-# drivers and runtime environment we need.
-FROM nvidia/cuda:11.4.3-base-ubi8
+# runtime and libraries we need.
+FROM nvidia/cuda:11.8.0-base-ubi8
 COPY ./run.sh /
 COPY --from=builder /samples/* /samples/
 RUN chmod +x ./run.sh


### PR DESCRIPTION
**Issue number:**



**Description of changes:**

- Update NVIDIA smoke test CUDA version to 11.8 to support Ada Lovelace (L4/L40S for g6/g6e) and Hopper (H100 for p5) architectures

Ref https://docs.nvidia.com/cuda/archive/11.8.0/cuda-toolkit-release-notes/index.html#cuda-general-new-features
> This release introduces support for both the Hopper and Ada Lovelace GPU families.

**Testing done:**
Image built successfully 

```
[+] Building 313.9s (25/25) FINISHED                                                                                                                                                                                                                                                                   docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                             0.0s
 => => transferring dockerfile: 2.39kB                                                                                                                                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:11.8.0-base-ubi8                                                                                                                                                                                                                                          1.0s
 => [internal] load metadata for docker.io/nvidia/cuda:11.8.0-devel-ubi8                                                                                                                                                                                                                                         0.9s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                  0.0s
 => [builder  1/15] FROM docker.io/nvidia/cuda:11.8.0-devel-ubi8@sha256:07f78c377ad928da58a9da192a4ca978c4050b53c66f6df9461d20cba80db990                                                                                                                                                                       249.5s
 => => resolve docker.io/nvidia/cuda:11.8.0-devel-ubi8@sha256:07f78c377ad928da58a9da192a4ca978c4050b53c66f6df9461d20cba80db990                                                                                                                                                                                   0.0s
 => => sha256:07f78c377ad928da58a9da192a4ca978c4050b53c66f6df9461d20cba80db990 1.05kB / 1.05kB                                                                                                                                                                                                                   0.0s
 => => sha256:6d4df348e537146fba32fc8de652055498c9a444525d680bc625a28a6a8364cd 19.49kB / 19.49kB                                                                                                                                                                                                                 0.0s
 => => sha256:94343313ec1512ab02267e4bc3ce09eecb01fda5bf26c56e2f028ecc72e80b18 79.30MB / 79.30MB                                                                                                                                                                                                                10.7s
 => => sha256:9fb272588c1dde2c505ff679122bc12a648783eccf4af786d077a5bbecff0333 309B / 309B                                                                                                                                                                                                                       0.1s
 => => sha256:b9797304348b224ef9f1016f644c4c19ea859e1eea867acb4bb1c223de80822d 1.45kB / 1.45kB                                                                                                                                                                                                                   0.1s
 => => sha256:e115f90467d03459aeaad23ef824737cd2dbf6a8e435f38b13189ae709591957 2.42kB / 2.42kB                                                                                                                                                                                                                   0.0s
 => => sha256:5e33c7d9d94150e8ef7fb2fe64121c306fda4490fded88576f2a684fff3fba55 60.41MB / 60.41MB                                                                                                                                                                                                                16.8s
 => => sha256:2e545d869d81a7c725922ae796715665429992c545b656abcdccbdf4fe73066d 187B / 187B                                                                                                                                                                                                                       0.5s
 => => sha256:3b6f4fdd4835dbe7336394df11df5c83244f4915a39a70725d221f8058ee4228 6.88kB / 6.88kB                                                                                                                                                                                                                   0.7s
 => => sha256:186b2cf099befa591c3bd476ee0d92661b888ea2474d5c39767f8b820d160119 1.38GB / 1.38GB                                                                                                                                                                                                                 145.8s
 => => sha256:bb9948097bcc7d053bfee72466049d0f70004410321ef0f5e3ff0977fd6b85ad 1.69kB / 1.69kB                                                                                                                                                                                                                  11.0s
 => => extracting sha256:94343313ec1512ab02267e4bc3ce09eecb01fda5bf26c56e2f028ecc72e80b18                                                                                                                                                                                                                        3.2s
 => => sha256:665cacaea78b28f62b3624730d78cd228c1f61e0e5d64d4496f88e4a7012d076 1.52kB / 1.52kB                                                                                                                                                                                                                  11.2s
 => => sha256:a8b41fa5efb1bb0d16dedae97ecba3578c4afdc1f0e738025f72b98702cbf5ae 2.24GB / 2.24GB                                                                                                                                                                                                                 228.8s
 => => extracting sha256:9fb272588c1dde2c505ff679122bc12a648783eccf4af786d077a5bbecff0333                                                                                                                                                                                                                        0.0s
 => => extracting sha256:b9797304348b224ef9f1016f644c4c19ea859e1eea867acb4bb1c223de80822d                                                                                                                                                                                                                        0.0s
 => => extracting sha256:5e33c7d9d94150e8ef7fb2fe64121c306fda4490fded88576f2a684fff3fba55                                                                                                                                                                                                                        0.7s
 => => extracting sha256:2e545d869d81a7c725922ae796715665429992c545b656abcdccbdf4fe73066d                                                                                                                                                                                                                        0.0s
 => => extracting sha256:3b6f4fdd4835dbe7336394df11df5c83244f4915a39a70725d221f8058ee4228                                                                                                                                                                                                                        0.0s
 => => extracting sha256:186b2cf099befa591c3bd476ee0d92661b888ea2474d5c39767f8b820d160119                                                                                                                                                                                                                       11.3s
 => => extracting sha256:bb9948097bcc7d053bfee72466049d0f70004410321ef0f5e3ff0977fd6b85ad                                                                                                                                                                                                                        0.0s
 => => extracting sha256:665cacaea78b28f62b3624730d78cd228c1f61e0e5d64d4496f88e4a7012d076                                                                                                                                                                                                                        0.0s
 => => extracting sha256:a8b41fa5efb1bb0d16dedae97ecba3578c4afdc1f0e738025f72b98702cbf5ae                                                                                                                                                                                                                       20.4s
 => [stage-1 1/4] FROM docker.io/nvidia/cuda:11.8.0-base-ubi8@sha256:39847c2891e91a99098308a263a00fe5724e9cf14c0edaf1528ca484368d95f4                                                                                                                                                                           17.8s
 => => resolve docker.io/nvidia/cuda:11.8.0-base-ubi8@sha256:39847c2891e91a99098308a263a00fe5724e9cf14c0edaf1528ca484368d95f4                                                                                                                                                                                    0.0s
 => => sha256:932176c10be850176415fb267656c1b64aa87c188909ea8593b6a4575c97588d 1.57kB / 1.57kB                                                                                                                                                                                                                   0.0s
 => => sha256:3184a21bb7af916380ad4993150d09213834d20c33fe2418e289def41617a003 13.12kB / 13.12kB                                                                                                                                                                                                                 0.0s
 => => sha256:94343313ec1512ab02267e4bc3ce09eecb01fda5bf26c56e2f028ecc72e80b18 79.30MB / 79.30MB                                                                                                                                                                                                                10.7s
 => => sha256:9fb272588c1dde2c505ff679122bc12a648783eccf4af786d077a5bbecff0333 309B / 309B                                                                                                                                                                                                                       0.1s
 => => sha256:39847c2891e91a99098308a263a00fe5724e9cf14c0edaf1528ca484368d95f4 1.05kB / 1.05kB                                                                                                                                                                                                                   0.0s
 => => sha256:b9797304348b224ef9f1016f644c4c19ea859e1eea867acb4bb1c223de80822d 1.45kB / 1.45kB                                                                                                                                                                                                                   0.1s
 => => sha256:2e545d869d81a7c725922ae796715665429992c545b656abcdccbdf4fe73066d 187B / 187B                                                                                                                                                                                                                       0.4s
 => => sha256:5e33c7d9d94150e8ef7fb2fe64121c306fda4490fded88576f2a684fff3fba55 60.41MB / 60.41MB                                                                                                                                                                                                                16.7s
 => => sha256:3b6f4fdd4835dbe7336394df11df5c83244f4915a39a70725d221f8058ee4228 6.88kB / 6.88kB                                                                                                                                                                                                                   0.6s
 => => extracting sha256:94343313ec1512ab02267e4bc3ce09eecb01fda5bf26c56e2f028ecc72e80b18                                                                                                                                                                                                                      301.9s
 => => extracting sha256:9fb272588c1dde2c505ff679122bc12a648783eccf4af786d077a5bbecff0333                                                                                                                                                                                                                        0.0s
 => => extracting sha256:b9797304348b224ef9f1016f644c4c19ea859e1eea867acb4bb1c223de80822d                                                                                                                                                                                                                        0.0s
 => => extracting sha256:5e33c7d9d94150e8ef7fb2fe64121c306fda4490fded88576f2a684fff3fba55                                                                                                                                                                                                                      295.9s
 => => extracting sha256:3b6f4fdd4835dbe7336394df11df5c83244f4915a39a70725d221f8058ee4228                                                                                                                                                                                                                        0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                0.0s
 => => transferring context: 778B                                                                                                                                                                                                                                                                                0.0s
 => [stage-1 2/4] COPY ./run.sh /                                                                                                                                                                                                                                                                                0.4s
 => [builder  2/15] RUN dnf makecache   && dnf -y install git-core   && dnf clean all   && rm -fr /var/cache/dnf                                                                                                                                                                                                 9.4s
 => [builder  3/15] RUN git clone --branch v11.8 --depth 1 https://github.com/NVIDIA/cuda-samples.git                                                                                                                                                                                                            8.4s
 => [builder  4/15] RUN mkdir -p /samples                                                                                                                                                                                                                                                                        0.3s
 => [builder  5/15] RUN cd /cuda-samples/Samples/0_Introduction/vectorAdd/ && make && cp $(basename $(pwd)) /samples/                                                                                                                                                                                            2.3s
 => [builder  6/15] RUN cd /cuda-samples/Samples/0_Introduction/simpleVoteIntrinsics/ && make && cp $(basename $(pwd)) /samples/                                                                                                                                                                                 2.6s
 => [builder  7/15] RUN cd /cuda-samples/Samples/0_Introduction/simpleAtomicIntrinsics/ && make && cp $(basename $(pwd)) /samples/                                                                                                                                                                               2.7s
 => [builder  8/15] RUN cd /cuda-samples/Samples/0_Introduction/simpleAWBarrier/ && make && cp $(basename $(pwd)) /samples/                                                                                                                                                                                      3.7s
 => [builder  9/15] RUN cd /cuda-samples/Samples/1_Utilities/deviceQuery/ && make && cp $(basename $(pwd)) /samples/                                                                                                                                                                                             0.9s
 => [builder 10/15] RUN cd /cuda-samples/Samples/2_Concepts_and_Techniques/reductionMultiBlockCG/ && make && cp $(basename $(pwd)) /samples/                                                                                                                                                                     3.9s
 => [builder 11/15] RUN cd /cuda-samples/Samples/2_Concepts_and_Techniques/shfl_scan/ && make && cp $(basename $(pwd)) /samples/                                                                                                                                                                                 4.3s
 => [builder 12/15] RUN cd /cuda-samples/Samples/3_CUDA_Features/immaTensorCoreGemm/ && make && cp $(basename $(pwd)) /samples/                                                                                                                                                                                 11.4s
 => [builder 13/15] RUN cd /cuda-samples/Samples/3_CUDA_Features/warpAggregatedAtomicsCG/ && make && cp $(basename $(pwd)) /samples/                                                                                                                                                                             4.2s
 => [builder 14/15] RUN cd /cuda-samples/Samples/3_CUDA_Features/globalToShmemAsyncCopy/ && make && cp $(basename $(pwd)) /samples/                                                                                                                                                                              4.2s
 => [builder 15/15] RUN cd /cuda-samples/Samples/6_Performance/UnifiedMemoryPerf/ && make && cp $(basename $(pwd)) /samples/                                                                                                                                                                                     3.9s
 => [stage-1 3/4] COPY --from=builder /samples/* /samples/                                                                                                                                                                                                                                                       0.1s
 => [stage-1 4/4] RUN chmod +x ./run.sh                                                                                                                                                                                                                                                                          0.3s
 => exporting to image                                                                                                                                                                                                                                                                                           0.1s
 => => exporting layers                                                                                                                                                                                                                                                                                          0.1s
 => => writing image sha256:bd243621b029db71964f980885091c94f9cdeb1d5be77da00b129f6e724752fb                                                                                                                                                                                                                     0.0s
 => => naming to docker.io/library/test 
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
