### PR TITLE
Update Karpenter and bottlerocket-sdk versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SHELL = /bin/bash
 TOP := $(dir $(firstword $(MAKEFILE_LIST)))
 
 # Variables we update as newer versions are released
-BOTTLEROCKET_SDK_VERSION = v0.42.0
+BOTTLEROCKET_SDK_VERSION = v0.45.0
 BOTTLEROCKET_SDK_ARCH = $(TESTSYS_BUILD_HOST_UNAME_ARCH)
 BOTTLEROCKET_TOOLS_VERSION ?= v0.9.0
 

--- a/bottlerocket/agents/src/bin/ec2-karpenter-resource-agent/ec2_karpenter_provider.rs
+++ b/bottlerocket/agents/src/bin/ec2-karpenter-resource-agent/ec2_karpenter_provider.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 use testsys_model::{Configuration, SecretName};
 use tokio::fs::read_to_string;
 
-const KARPENTER_VERSION: &str = "0.37.0";
+const KARPENTER_VERSION: &str = "1.0.5";
 const CLUSTER_KUBECONFIG: &str = "/local/cluster.kubeconfig";
 const PROVISIONER_YAML: &str = "/local/provisioner.yaml";
 const TAINTED_NODEGROUP_NAME: &str = "tainted-nodegroup";
@@ -517,7 +517,7 @@ impl Create for Ec2KarpenterCreator {
         };
 
         let provisioner = format!(
-            r#"apiVersion: karpenter.sh/v1beta1
+            r#"apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
     name: default
@@ -526,6 +526,8 @@ spec:
     spec:
         nodeClassRef:
             name: my-provider
+            group: karpenter.k8s.aws
+            kind: EC2NodeClass
         requirements:
         - key: kubernetes.io/arch
           operator: In
@@ -535,7 +537,7 @@ spec:
           values: ['on-demand']
 {}
 ---
-apiVersion: karpenter.k8s.aws/v1beta1
+apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass
 metadata:
     name: my-provider


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #937

**Description of changes:**

Bump versions of bottlerocket-sdk and karpenter

**Testing done:**

`make`

Conducted testing against 1.31 with karpenter v1.0.5 in EKS cluster and verified scaling of nodes. Additionally tested:

```
 NAME                                            TYPE                  STATE                             PASSED              FAILED              SKIPPED   BUILD ID                    LAST UPDATE
 aarch64-aws-k8s-124-quick                       Test                  passed                                 1                   0                 6972   800458c4-dirty              2024-10-03T21:30:27Z
 aarch64-aws-k8s-129-quick                       Test                  passed                                 5                   0                 7409   800458c4-dirty              2024-10-03T20:58:16Z
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
