### PR TITLE
ec2-resource: add `credential-providers` and `no-proxy` settings

### DIFF
--- a/bottlerocket/agents/src/bin/ec2-resource-agent/ec2_provider.rs
+++ b/bottlerocket/agents/src/bin/ec2-resource-agent/ec2_provider.rs
@@ -469,7 +469,18 @@ ignore-waves = true
 api-server = "{}"
 cluster-name = "{}"
 cluster-certificate = "{}"
-cluster-dns-ip = "{}""#,
+cluster-dns-ip = "{}"
+
+[settings.kubernetes.credential-providers.ecr-credential-provider]
+enabled = true
+cache-duration = "30m"
+image-patterns = [
+  "*.dkr.ecr.us-east-2.amazonaws.com",
+  "*.dkr.ecr.us-west-2.amazonaws.com"
+]
+
+[settings.network]
+no-proxy = ["localhost", "127.0.0.1"]"#,
         endpoint
             .as_ref()
             .context(memo, "Server endpoint is required for eks clusters.")?,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
**Description of changes:**
```
ec2-resource: add `credential-providers` and `no-proxy` settings
```

**Testing done:**

- [x] Create instances with new settings

- [x] Run quick and conformance test

```
x86-64-aws-k8s-130-conformance                                Test                               passed                                                         406                                0                              6797   d54c470e                           2024-10-30T06:51:36Z
 x86-64-aws-k8s-130-ipv6-conformance                           Test                               passed                                                         406                                0                              6797   d54c470e                           2024-10-30T06:52:48Z
 x86-64-aws-k8s-130-ipv6-quick                                 Test                               passed                                                           5                                0                              7198   d54c470e                           2024-10-30T05:04:36Z
 x86-64-aws-k8s-130-quick                                      Test                               passed                                                           5                                0                              7198   d54c470e                           2024-10-30T05:04:41Z
 x86-64-aws-k8s-131-conformance                                Test                               passed                                                         408                                0                              6199   d54c470e                           2024-10-30T06:51:56Z
 x86-64-aws-k8s-131-ipv6-conformance                           Test                               passed                                                         408                                0                              6199   d54c470e                           2024-10-30T06:53:41Z
 x86-64-aws-k8s-131-ipv6-quick                                 Test                               passed                                                           5                                0                              6602   d54c470e                           2024-10-30T05:04:26Z
 x86-64-aws-k8s-131-quick                                      Test                               passed                                                           5                                0                              6602   d54c470e                           2024-10-30T05:04:56Z
 x86-64-aws-k8s-130                                            Resource                           completed                                                                                                                               d54c470e                           2024-10-30T05:02:51Z
 x86-64-aws-k8s-130-ipv6                                       Resource                           completed                                                                                                                               d54c470e                           2024-10-30T05:02:51Z
 x86-64-aws-k8s-131                                            Resource                           completed                                                                                                                               d54c470e                           2024-10-30T05:02:40Z
 x86-64-aws-k8s-131-ipv6                                       Resource                           completed                                                                                                                               d54c470e                           2024-10-30T05:02:41Z
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
