### PR TITLE
Add tests for common runtimes

### DIFF
--- a/bottlerocket/tests/workload/hello-go.yaml
+++ b/bottlerocket/tests/workload/hello-go.yaml
@@ -1,0 +1,16 @@
+kind: Test
+metadata:
+  name: workload-agent
+  namespace: testsys
+spec:
+  agent:
+    name: workload-agent
+    image: <WORKLOAD-AGENT-IMAGE>
+    keepRunning: false
+    configuration:
+      kubeconfigBase64: <BASE64-KUBECONFIG>
+      plugins:
+        - name: go-workload
+          image: <GO-WORKLOAD-IMAGE>
+  resources: []
+  dependsOn: []

--- a/bottlerocket/tests/workload/hello-go/Dockerfile
+++ b/bottlerocket/tests/workload/hello-go/Dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+RUN dnf makecache && \
+    dnf install -y \
+      gzip \
+      go \
+      tar \
+    && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+COPY --chmod=755 ./run.sh /
+ENTRYPOINT ["./run.sh"]

--- a/bottlerocket/tests/workload/hello-go/Makefile
+++ b/bottlerocket/tests/workload/hello-go/Makefile
@@ -1,0 +1,59 @@
+.DEFAULT_GOAL:=publish
+
+#### Variables
+PUBLISH_IMAGES_REGISTRY ?=
+TAG ?= latest
+REPOSITORY ?= hello-go
+
+#### Format the registry portion of the image tag, if needed
+REGISTRY ?=
+ifdef PUBLISH_IMAGES_REGISTRY
+REGISTRY = "$(PUBLISH_IMAGES_REGISTRY)/"
+endif
+
+ifndef REGISTRY
+$(error "The PUBLISH_IMAGES_REGISTRY value must be provided (e.g. PUBLISH_IMAGES_REGISTRY=861807767978.dkr.ecr.us-east-2.amazonaws.com make)")
+endif
+
+define build-image
+	docker buildx build . -t $(REPOSITORY)-$1 --platform $2 --load
+endef
+
+define tag-image
+	docker tag $(REPOSITORY)-$1 $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+define push-image
+	docker push $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+#### Actual build targets
+.PHONY: build
+build: x86_64 aarch64
+
+.PHONY: x86_64
+x86_64:
+	$(call build-image,$@,linux/amd64)
+	$(call tag-image,x86_64)
+
+.PHONY: aarch64
+aarch64:
+	$(call build-image,$@,linux/aarch64)
+	$(call tag-image,aarch64)
+
+.PHONY: push-platforms
+push-platforms: build
+	$(call push-image,x86_64)
+	$(call push-image,aarch64)
+
+.PHONY: create-manifest
+create-manifest: push-platforms
+	- docker manifest rm $(REGISTRY)$(REPOSITORY):$(TAG)
+	docker manifest create \
+		$(REGISTRY)$(REPOSITORY):$(TAG) \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-x86_64 \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-aarch64 \
+
+.PHONY: publish
+publish: create-manifest
+	docker manifest push $(REGISTRY)$(REPOSITORY):$(TAG)

--- a/bottlerocket/tests/workload/hello-go/README.md
+++ b/bottlerocket/tests/workload/hello-go/README.md
@@ -1,0 +1,67 @@
+# Hello Go test
+
+This container image can be used as a TestSys workload test to validate the Bottlerocket variants.
+
+## Build requirements
+
+Due to missing packages needed for cross-compiling, and unexpected handling in the sample Makefile logic when compiling for one platform for another, the build for this image requires two Buildx hosts - one for each architecture.
+
+In order to build the image for both architectures, you need to set up the `buildx` docker plugin.
+[This guide describes](https://github.com/docker/buildx#installing) the installation process.
+
+By default, the install of `docker buildx` uses the `docker` driver type.
+This driver is not able to build for all platform targets we need.
+You will need to run the following to create a new builder using the `docker-container` driver:
+
+```bash
+docker buildx create --use --bootstrap
+docker buildx ls
+```
+
+You should see a `*` next to your newly created builder denoting it as the currently active builder to use.
+If it is not, you can switch builder contexts by running:
+
+```sh
+docker buildx use $BUILDER_NAME
+```
+
+You then need to add another "context" to the builder for a second host that can build the other platform architecture.
+If you are running these steps on an `amd64` host, you will need to add an `arm64` host to the builder, or vice versa.
+
+First, verify you are able to access the remote host via SSH:
+
+```sh
+docker -H ssh://user@hostname info
+```
+
+The output from that command should show information about the Docker instance running on the remote host.
+You can then add that host to your Buildx builder by running:
+
+```sh
+docker buildx create --name $BUILDER_NAME --append ssh://user@hostname
+```
+
+Supported platforms can be verified by running:
+
+```bash
+docker buildx inspect | grep Platforms
+```
+
+The output from this command should show both `linux/amd64` and `linux/arm64` platforms.
+
+By default, the image will be tagged `<PUBLISH_IMAGES_REGISTRY>/hello-testsys:<TAG>`, so make sure you already have a `hello-testsys` repository in your registry.
+You can change the name of the repo by overriding the `PUBLISH_IMAGES_REGISTRY` env variable while building the image.
+
+**NOTE:** This assumes that you have already configured your credentials to be able to perform a `docker push` to your registry.
+
+## Building the image
+
+To build the image for both `x86_64` and `aarch64`, run the following:
+
+```sh
+PUBLISH_IMAGES_REGISTRY=<YOUR_REGISTRY> make
+```
+
+The command will build, tag, and push the images to your `PUBLISH_IMAGES_REGISTRY` using the name `hello-testsys:<TAG>`.
+
+Since this is a multi-arch image, you can use it in both `x86_64` and `aarch64` clusters.

--- a/bottlerocket/tests/workload/hello-go/run.sh
+++ b/bottlerocket/tests/workload/hello-go/run.sh
@@ -1,0 +1,35 @@
+#! /usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# Collect the test output where sonobuoy expects plugins to place them
+results_dir="${RESULTS_DIR:-/tmp/results}"
+results_tar="results.tar.gz"
+mkdir -p "${results_dir}"
+
+testDone() {
+    echo "${results_dir}/${results_tar}" >"${results_dir}/done"
+}
+
+# Make sure to always output done file in expected place and format
+trap testDone EXIT
+
+hello_script="$(mktemp --suffix='.go')"
+
+cat >"${hello_script}" <<EOF
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello, go")
+}
+EOF
+
+go run "${hello_script}" |
+    tee "${results_dir}/hello.log"
+
+# Collect the results
+tar czf "${results_tar}" -C "${results_dir}" .
+mv "${results_tar}" "${results_dir}/"

--- a/bottlerocket/tests/workload/hello-java.yaml
+++ b/bottlerocket/tests/workload/hello-java.yaml
@@ -1,0 +1,16 @@
+kind: Test
+metadata:
+  name: workload-agent
+  namespace: testsys
+spec:
+  agent:
+    name: workload-agent
+    image: <WORKLOAD-AGENT-IMAGE>
+    keepRunning: false
+    configuration:
+      kubeconfigBase64: <BASE64-KUBECONFIG>
+      plugins:
+        - name: java-workload
+          image: <JAVA-WORKLOAD-IMAGE>
+  resources: []
+  dependsOn: []

--- a/bottlerocket/tests/workload/hello-java/Dockerfile
+++ b/bottlerocket/tests/workload/hello-java/Dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+RUN dnf makecache && \
+    dnf install -y \
+      gzip \
+      java \
+      tar \
+    && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+COPY --chmod=755 ./run.sh /
+ENTRYPOINT ["./run.sh"]

--- a/bottlerocket/tests/workload/hello-java/Makefile
+++ b/bottlerocket/tests/workload/hello-java/Makefile
@@ -1,0 +1,59 @@
+.DEFAULT_GOAL:=publish
+
+#### Variables
+PUBLISH_IMAGES_REGISTRY ?=
+TAG ?= latest
+REPOSITORY ?= hello-java
+
+#### Format the registry portion of the image tag, if needed
+REGISTRY ?=
+ifdef PUBLISH_IMAGES_REGISTRY
+REGISTRY = "$(PUBLISH_IMAGES_REGISTRY)/"
+endif
+
+ifndef REGISTRY
+$(error "The PUBLISH_IMAGES_REGISTRY value must be provided (e.g. PUBLISH_IMAGES_REGISTRY=861807767978.dkr.ecr.us-east-2.amazonaws.com make)")
+endif
+
+define build-image
+	docker buildx build . -t $(REPOSITORY)-$1 --platform $2 --load
+endef
+
+define tag-image
+	docker tag $(REPOSITORY)-$1 $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+define push-image
+	docker push $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+#### Actual build targets
+.PHONY: build
+build: x86_64 aarch64
+
+.PHONY: x86_64
+x86_64:
+	$(call build-image,$@,linux/amd64)
+	$(call tag-image,x86_64)
+
+.PHONY: aarch64
+aarch64:
+	$(call build-image,$@,linux/aarch64)
+	$(call tag-image,aarch64)
+
+.PHONY: push-platforms
+push-platforms: build
+	$(call push-image,x86_64)
+	$(call push-image,aarch64)
+
+.PHONY: create-manifest
+create-manifest: push-platforms
+	- docker manifest rm $(REGISTRY)$(REPOSITORY):$(TAG)
+	docker manifest create \
+		$(REGISTRY)$(REPOSITORY):$(TAG) \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-x86_64 \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-aarch64 \
+
+.PHONY: publish
+publish: create-manifest
+	docker manifest push $(REGISTRY)$(REPOSITORY):$(TAG)

--- a/bottlerocket/tests/workload/hello-java/README.md
+++ b/bottlerocket/tests/workload/hello-java/README.md
@@ -1,0 +1,67 @@
+# Hello Java test
+
+This container image can be used as a TestSys workload test to validate the Bottlerocket variants.
+
+## Build requirements
+
+Due to missing packages needed for cross-compiling, and unexpected handling in the sample Makefile logic when compiling for one platform for another, the build for this image requires two Buildx hosts - one for each architecture.
+
+In order to build the image for both architectures, you need to set up the `buildx` docker plugin.
+[This guide describes](https://github.com/docker/buildx#installing) the installation process.
+
+By default, the install of `docker buildx` uses the `docker` driver type.
+This driver is not able to build for all platform targets we need.
+You will need to run the following to create a new builder using the `docker-container` driver:
+
+```bash
+docker buildx create --use --bootstrap
+docker buildx ls
+```
+
+You should see a `*` next to your newly created builder denoting it as the currently active builder to use.
+If it is not, you can switch builder contexts by running:
+
+```sh
+docker buildx use $BUILDER_NAME
+```
+
+You then need to add another "context" to the builder for a second host that can build the other platform architecture.
+If you are running these steps on an `amd64` host, you will need to add an `arm64` host to the builder, or vice versa.
+
+First, verify you are able to access the remote host via SSH:
+
+```sh
+docker -H ssh://user@hostname info
+```
+
+The output from that command should show information about the Docker instance running on the remote host.
+You can then add that host to your Buildx builder by running:
+
+```sh
+docker buildx create --name $BUILDER_NAME --append ssh://user@hostname
+```
+
+Supported platforms can be verified by running:
+
+```bash
+docker buildx inspect | grep Platforms
+```
+
+The output from this command should show both `linux/amd64` and `linux/arm64` platforms.
+
+By default, the image will be tagged `<PUBLISH_IMAGES_REGISTRY>/hello-testsys:<TAG>`, so make sure you already have a `hello-testsys` repository in your registry.
+You can change the name of the repo by overriding the `PUBLISH_IMAGES_REGISTRY` env variable while building the image.
+
+**NOTE:** This assumes that you have already configured your credentials to be able to perform a `docker push` to your registry.
+
+## Building the image
+
+To build the image for both `x86_64` and `aarch64`, run the following:
+
+```sh
+PUBLISH_IMAGES_REGISTRY=<YOUR_REGISTRY> make
+```
+
+The command will build, tag, and push the images to your `PUBLISH_IMAGES_REGISTRY` using the name `hello-testsys:<TAG>`.
+
+Since this is a multi-arch image, you can use it in both `x86_64` and `aarch64` clusters.

--- a/bottlerocket/tests/workload/hello-java/run.sh
+++ b/bottlerocket/tests/workload/hello-java/run.sh
@@ -1,0 +1,33 @@
+#! /usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# Collect the test output where sonobuoy expects plugins to place them
+results_dir="${RESULTS_DIR:-/tmp/results}"
+results_tar="results.tar.gz"
+mkdir -p "${results_dir}"
+
+testDone() {
+    echo "${results_dir}/${results_tar}" >"${results_dir}/done"
+}
+
+# Make sure to always output done file in expected place and format
+trap testDone EXIT
+
+hello_script="$(mktemp --suffix='.java')"
+
+cat >"${hello_script}" <<EOF
+public class Main {
+  public static void main(String[] args) {
+    System.out.println("hello, java");
+  }
+}
+EOF
+
+java "${hello_script}" |
+    tee "${results_dir}/hello.log"
+
+# Collect the results
+tar czf "${results_tar}" -C "${results_dir}" .
+mv "${results_tar}" "${results_dir}/"

--- a/bottlerocket/tests/workload/hello-nodejs.yaml
+++ b/bottlerocket/tests/workload/hello-nodejs.yaml
@@ -1,0 +1,16 @@
+kind: Test
+metadata:
+  name: workload-agent
+  namespace: testsys
+spec:
+  agent:
+    name: workload-agent
+    image: <WORKLOAD-AGENT-IMAGE>
+    keepRunning: false
+    configuration:
+      kubeconfigBase64: <BASE64-KUBECONFIG>
+      plugins:
+        - name: nodejs-workload
+          image: <NODEJS-WORKLOAD-IMAGE>
+  resources: []
+  dependsOn: []

--- a/bottlerocket/tests/workload/hello-nodejs/Dockerfile
+++ b/bottlerocket/tests/workload/hello-nodejs/Dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+RUN dnf makecache && \
+    dnf install -y \
+      gzip \
+      nodejs \
+      tar \
+    && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+COPY --chmod=755 ./run.sh /
+ENTRYPOINT ["./run.sh"]

--- a/bottlerocket/tests/workload/hello-nodejs/Makefile
+++ b/bottlerocket/tests/workload/hello-nodejs/Makefile
@@ -1,0 +1,59 @@
+.DEFAULT_GOAL:=publish
+
+#### Variables
+PUBLISH_IMAGES_REGISTRY ?=
+TAG ?= latest
+REPOSITORY ?= hello-nodejs
+
+#### Format the registry portion of the image tag, if needed
+REGISTRY ?=
+ifdef PUBLISH_IMAGES_REGISTRY
+REGISTRY = "$(PUBLISH_IMAGES_REGISTRY)/"
+endif
+
+ifndef REGISTRY
+$(error "The PUBLISH_IMAGES_REGISTRY value must be provided (e.g. PUBLISH_IMAGES_REGISTRY=861807767978.dkr.ecr.us-east-2.amazonaws.com make)")
+endif
+
+define build-image
+	docker buildx build . -t $(REPOSITORY)-$1 --platform $2 --load
+endef
+
+define tag-image
+	docker tag $(REPOSITORY)-$1 $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+define push-image
+	docker push $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+#### Actual build targets
+.PHONY: build
+build: x86_64 aarch64
+
+.PHONY: x86_64
+x86_64:
+	$(call build-image,$@,linux/amd64)
+	$(call tag-image,x86_64)
+
+.PHONY: aarch64
+aarch64:
+	$(call build-image,$@,linux/aarch64)
+	$(call tag-image,aarch64)
+
+.PHONY: push-platforms
+push-platforms: build
+	$(call push-image,x86_64)
+	$(call push-image,aarch64)
+
+.PHONY: create-manifest
+create-manifest: push-platforms
+	- docker manifest rm $(REGISTRY)$(REPOSITORY):$(TAG)
+	docker manifest create \
+		$(REGISTRY)$(REPOSITORY):$(TAG) \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-x86_64 \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-aarch64 \
+
+.PHONY: publish
+publish: create-manifest
+	docker manifest push $(REGISTRY)$(REPOSITORY):$(TAG)

--- a/bottlerocket/tests/workload/hello-nodejs/README.md
+++ b/bottlerocket/tests/workload/hello-nodejs/README.md
@@ -1,0 +1,67 @@
+# Hello Node.js test
+
+This container image can be used as a TestSys workload test to validate the Bottlerocket variants.
+
+## Build requirements
+
+Due to missing packages needed for cross-compiling, and unexpected handling in the sample Makefile logic when compiling for one platform for another, the build for this image requires two Buildx hosts - one for each architecture.
+
+In order to build the image for both architectures, you need to set up the `buildx` docker plugin.
+[This guide describes](https://github.com/docker/buildx#installing) the installation process.
+
+By default, the install of `docker buildx` uses the `docker` driver type.
+This driver is not able to build for all platform targets we need.
+You will need to run the following to create a new builder using the `docker-container` driver:
+
+```bash
+docker buildx create --use --bootstrap
+docker buildx ls
+```
+
+You should see a `*` next to your newly created builder denoting it as the currently active builder to use.
+If it is not, you can switch builder contexts by running:
+
+```sh
+docker buildx use $BUILDER_NAME
+```
+
+You then need to add another "context" to the builder for a second host that can build the other platform architecture.
+If you are running these steps on an `amd64` host, you will need to add an `arm64` host to the builder, or vice versa.
+
+First, verify you are able to access the remote host via SSH:
+
+```sh
+docker -H ssh://user@hostname info
+```
+
+The output from that command should show information about the Docker instance running on the remote host.
+You can then add that host to your Buildx builder by running:
+
+```sh
+docker buildx create --name $BUILDER_NAME --append ssh://user@hostname
+```
+
+Supported platforms can be verified by running:
+
+```bash
+docker buildx inspect | grep Platforms
+```
+
+The output from this command should show both `linux/amd64` and `linux/arm64` platforms.
+
+By default, the image will be tagged `<PUBLISH_IMAGES_REGISTRY>/hello-testsys:<TAG>`, so make sure you already have a `hello-testsys` repository in your registry.
+You can change the name of the repo by overriding the `PUBLISH_IMAGES_REGISTRY` env variable while building the image.
+
+**NOTE:** This assumes that you have already configured your credentials to be able to perform a `docker push` to your registry.
+
+## Building the image
+
+To build the image for both `x86_64` and `aarch64`, run the following:
+
+```sh
+PUBLISH_IMAGES_REGISTRY=<YOUR_REGISTRY> make
+```
+
+The command will build, tag, and push the images to your `PUBLISH_IMAGES_REGISTRY` using the name `hello-testsys:<TAG>`.
+
+Since this is a multi-arch image, you can use it in both `x86_64` and `aarch64` clusters.

--- a/bottlerocket/tests/workload/hello-nodejs/run.sh
+++ b/bottlerocket/tests/workload/hello-nodejs/run.sh
@@ -1,0 +1,29 @@
+#! /usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# Collect the test output where sonobuoy expects plugins to place them
+results_dir="${RESULTS_DIR:-/tmp/results}"
+results_tar="results.tar.gz"
+mkdir -p "${results_dir}"
+
+testDone() {
+    echo "${results_dir}/${results_tar}" >"${results_dir}/done"
+}
+
+# Make sure to always output done file in expected place and format
+trap testDone EXIT
+
+hello_script="$(mktemp --suffix='.js')"
+
+cat >"${hello_script}" <<EOF
+console.log('hello, nodejs');
+EOF
+
+node "${hello_script}" |
+    tee "${results_dir}/hello.log"
+
+# Collect the results
+tar czf "${results_tar}" -C "${results_dir}" .
+mv "${results_tar}" "${results_dir}/"

--- a/bottlerocket/tests/workload/hello-python.yaml
+++ b/bottlerocket/tests/workload/hello-python.yaml
@@ -1,0 +1,16 @@
+kind: Test
+metadata:
+  name: workload-agent
+  namespace: testsys
+spec:
+  agent:
+    name: workload-agent
+    image: <WORKLOAD-AGENT-IMAGE>
+    keepRunning: false
+    configuration:
+      kubeconfigBase64: <BASE64-KUBECONFIG>
+      plugins:
+        - name: python-workload
+          image: <PYTHON-WORKLOAD-IMAGE>
+  resources: []
+  dependsOn: []

--- a/bottlerocket/tests/workload/hello-python/Dockerfile
+++ b/bottlerocket/tests/workload/hello-python/Dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+RUN dnf makecache && \
+    dnf install -y \
+      gzip \
+      python \
+      tar \
+    && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+COPY --chmod=755 ./run.sh /
+ENTRYPOINT ["./run.sh"]

--- a/bottlerocket/tests/workload/hello-python/Makefile
+++ b/bottlerocket/tests/workload/hello-python/Makefile
@@ -1,0 +1,59 @@
+.DEFAULT_GOAL:=publish
+
+#### Variables
+PUBLISH_IMAGES_REGISTRY ?=
+TAG ?= latest
+REPOSITORY ?= hello-python
+
+#### Format the registry portion of the image tag, if needed
+REGISTRY ?=
+ifdef PUBLISH_IMAGES_REGISTRY
+REGISTRY = "$(PUBLISH_IMAGES_REGISTRY)/"
+endif
+
+ifndef REGISTRY
+$(error "The PUBLISH_IMAGES_REGISTRY value must be provided (e.g. PUBLISH_IMAGES_REGISTRY=861807767978.dkr.ecr.us-east-2.amazonaws.com make)")
+endif
+
+define build-image
+	docker buildx build . -t $(REPOSITORY)-$1 --platform $2 --load
+endef
+
+define tag-image
+	docker tag $(REPOSITORY)-$1 $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+define push-image
+	docker push $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+#### Actual build targets
+.PHONY: build
+build: x86_64 aarch64
+
+.PHONY: x86_64
+x86_64:
+	$(call build-image,$@,linux/amd64)
+	$(call tag-image,x86_64)
+
+.PHONY: aarch64
+aarch64:
+	$(call build-image,$@,linux/aarch64)
+	$(call tag-image,aarch64)
+
+.PHONY: push-platforms
+push-platforms: build
+	$(call push-image,x86_64)
+	$(call push-image,aarch64)
+
+.PHONY: create-manifest
+create-manifest: push-platforms
+	- docker manifest rm $(REGISTRY)$(REPOSITORY):$(TAG)
+	docker manifest create \
+		$(REGISTRY)$(REPOSITORY):$(TAG) \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-x86_64 \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-aarch64 \
+
+.PHONY: publish
+publish: create-manifest
+	docker manifest push $(REGISTRY)$(REPOSITORY):$(TAG)

--- a/bottlerocket/tests/workload/hello-python/README.md
+++ b/bottlerocket/tests/workload/hello-python/README.md
@@ -1,0 +1,67 @@
+# Hello Python test
+
+This container image can be used as a TestSys workload test to validate the Bottlerocket variants.
+
+## Build requirements
+
+Due to missing packages needed for cross-compiling, and unexpected handling in the sample Makefile logic when compiling for one platform for another, the build for this image requires two Buildx hosts - one for each architecture.
+
+In order to build the image for both architectures, you need to set up the `buildx` docker plugin.
+[This guide describes](https://github.com/docker/buildx#installing) the installation process.
+
+By default, the install of `docker buildx` uses the `docker` driver type.
+This driver is not able to build for all platform targets we need.
+You will need to run the following to create a new builder using the `docker-container` driver:
+
+```bash
+docker buildx create --use --bootstrap
+docker buildx ls
+```
+
+You should see a `*` next to your newly created builder denoting it as the currently active builder to use.
+If it is not, you can switch builder contexts by running:
+
+```sh
+docker buildx use $BUILDER_NAME
+```
+
+You then need to add another "context" to the builder for a second host that can build the other platform architecture.
+If you are running these steps on an `amd64` host, you will need to add an `arm64` host to the builder, or vice versa.
+
+First, verify you are able to access the remote host via SSH:
+
+```sh
+docker -H ssh://user@hostname info
+```
+
+The output from that command should show information about the Docker instance running on the remote host.
+You can then add that host to your Buildx builder by running:
+
+```sh
+docker buildx create --name $BUILDER_NAME --append ssh://user@hostname
+```
+
+Supported platforms can be verified by running:
+
+```bash
+docker buildx inspect | grep Platforms
+```
+
+The output from this command should show both `linux/amd64` and `linux/arm64` platforms.
+
+By default, the image will be tagged `<PUBLISH_IMAGES_REGISTRY>/hello-testsys:<TAG>`, so make sure you already have a `hello-testsys` repository in your registry.
+You can change the name of the repo by overriding the `PUBLISH_IMAGES_REGISTRY` env variable while building the image.
+
+**NOTE:** This assumes that you have already configured your credentials to be able to perform a `docker push` to your registry.
+
+## Building the image
+
+To build the image for both `x86_64` and `aarch64`, run the following:
+
+```sh
+PUBLISH_IMAGES_REGISTRY=<YOUR_REGISTRY> make
+```
+
+The command will build, tag, and push the images to your `PUBLISH_IMAGES_REGISTRY` using the name `hello-testsys:<TAG>`.
+
+Since this is a multi-arch image, you can use it in both `x86_64` and `aarch64` clusters.

--- a/bottlerocket/tests/workload/hello-python/run.sh
+++ b/bottlerocket/tests/workload/hello-python/run.sh
@@ -1,0 +1,29 @@
+#! /usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# Collect the test output where sonobuoy expects plugins to place them
+results_dir="${RESULTS_DIR:-/tmp/results}"
+results_tar="results.tar.gz"
+mkdir -p "${results_dir}"
+
+testDone() {
+    echo "${results_dir}/${results_tar}" >"${results_dir}/done"
+}
+
+# Make sure to always output done file in expected place and format
+trap testDone EXIT
+
+hello_script="$(mktemp --suffix='.py')"
+
+cat >"${hello_script}" <<EOF
+print("hello, python")
+EOF
+
+python "${hello_script}" |
+    tee "${results_dir}/hello.log"
+
+# Collect the results
+tar czf "${results_tar}" -C "${results_dir}" .
+mv "${results_tar}" "${results_dir}/"


### PR DESCRIPTION
**Description of changes:**

Add simple workloads for Go, Java, Node.js, and Python.

**Testing done:**

**Bottlerocket 1.26.0 w/ process restriction**
```shell
[cargo-make][1] INFO - Running Task: testsys
 NAME                            TYPE         STATE           PASSED     FAILED    SKIPPED   BUILD ID    LAST UPDATE
 bottlerocket-test               Test         error                2          2          0   85f0d68c    2025-01-28T20:15:59Z
                                                                   0          0          0
```

**Bottlerocket 1.31.0**
```shell
[cargo-make][1] INFO - Running Task: testsys
 NAME                    TYPE          STATE       	 PASSED      FAILED      SKIPPED   BUILD ID      LAST UPDATE
 bottlerocket-test       Test          passed                 4     	  0            0   24c0647f      2025-01-28T21:05:26Z
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
