### PR TITLE
Karpenter version update to 1.2.1

### DIFF
--- a/bottlerocket/agents/src/bin/ec2-karpenter-resource-agent/ec2_karpenter_provider.rs
+++ b/bottlerocket/agents/src/bin/ec2-karpenter-resource-agent/ec2_karpenter_provider.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 use testsys_model::{Configuration, SecretName};
 use tokio::fs::read_to_string;
 
-const KARPENTER_VERSION: &str = "1.0.5";
+const KARPENTER_VERSION: &str = "1.2.1";
 const CLUSTER_KUBECONFIG: &str = "/local/cluster.kubeconfig";
 const PROVISIONER_YAML: &str = "/local/provisioner.yaml";
 const TAINTED_NODEGROUP_NAME: &str = "tainted-nodegroup";


### PR DESCRIPTION
**Description of changes:**

Bumped version for karpenter to 1.2.1

**Testing done:**

Manually tested by @qianxjcraig  
```
kubectl get nodes -o wide

deployment.apps/inflate scaled
NAME                                           STATUS   ROLES    AGE    VERSION                INTERNAL-IP      EXTERNAL-IP     OS-IMAGE                                KERNEL-VERSION                  CONTAINER-RUNTIME
ip-192-168-46-192.us-west-2.compute.internal   Ready    <none>   26m    v1.25.16-eks-59bf375   192.168.46.192   35.87.246.130   Amazon Linux 2                          5.10.233-224.894.amzn2.x86_64   containerd://1.7.25
ip-192-168-95-170.us-west-2.compute.internal   Ready    <none>   26m    v1.25.16-eks-59bf375   192.168.95.170   44.244.225.1    Amazon Linux 2                          5.10.233-224.894.amzn2.x86_64   containerd://1.7.25
ip-192-168-96-110.us-west-2.compute.internal   Ready    <none>   5m8s   v1.25.16               192.168.96.110   <none>          Bottlerocket OS 1.32.0 (aws-k8s-1.25)   5.15.176                        containerd://1.7.24+bottlerocket
Manual Karpenter 1.2.1 test passed for 1.25 variant. Tested using bottlerocket-aws-k8s-1.25-x86_64-v1.32.0-cacc4ce9 (ami-0e6b8d3579877732d) 

dev-dsk-qianxj-2a-e1c73b99 % kubectl get nodes -o wide
NAME                                           STATUS   ROLES    AGE   VERSION               INTERNAL-IP      EXTERNAL-IP   OS-IMAGE                                KERNEL-VERSION                  CONTAINER-RUNTIME
ip-192-168-125-96.us-west-2.compute.internal   Ready    <none>   65s   v1.31.4-eks-0f56d01   192.168.125.96   <none>        Bottlerocket OS 1.33.0 (aws-k8s-1.31)   6.1.127                         containerd://1.7.24+bottlerocket
ip-192-168-14-134.us-west-2.compute.internal   Ready    <none>   20m   v1.31.5-eks-5d632ec   192.168.14.134   35.94.95.20   Amazon Linux 2                          5.10.233-224.894.amzn2.x86_64   containerd://1.7.25
ip-192-168-66-113.us-west-2.compute.internal   Ready    <none>   20m   v1.31.5-eks-5d632ec   192.168.66.113   52.27.5.75    Amazon Linux 2                          5.10.233-224.894.amzn2.x86_64   containerd://1.7.25

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
