### PR TITLE
workload: add tests for ruby and dotnet

### DIFF
--- a/bottlerocket/tests/workload/hello-dotnet.yaml
+++ b/bottlerocket/tests/workload/hello-dotnet.yaml
@@ -1,0 +1,16 @@
+kind: Test
+metadata:
+  name: workload-agent
+  namespace: testsys
+spec:
+  agent:
+    name: workload-agent
+    image: <WORKLOAD-AGENT-IMAGE>
+    keepRunning: false
+    configuration:
+      kubeconfigBase64: <BASE64-KUBECONFIG>
+      plugins:
+        - name: dotnet-workload
+          image: <DOTNET-WORKLOAD-IMAGE>
+  resources: []
+  dependsOn: []

--- a/bottlerocket/tests/workload/hello-dotnet/Dockerfile
+++ b/bottlerocket/tests/workload/hello-dotnet/Dockerfile
@@ -1,0 +1,16 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+# Install necessary utilities
+RUN dnf makecache && \
+    dnf install -y \
+      gzip \
+      tar \
+      dotnet \
+    && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+# Copy the script that will run the application
+COPY --chmod=755 ./run.sh /
+ENTRYPOINT ["./run.sh"]
+

--- a/bottlerocket/tests/workload/hello-dotnet/Makefile
+++ b/bottlerocket/tests/workload/hello-dotnet/Makefile
@@ -1,0 +1,59 @@
+.DEFAULT_GOAL:=publish
+
+#### Variables
+PUBLISH_IMAGES_REGISTRY ?=
+TAG ?= latest
+REPOSITORY ?= hello-dotnet
+
+#### Format the registry portion of the image tag, if needed
+REGISTRY ?=
+ifdef PUBLISH_IMAGES_REGISTRY
+REGISTRY = "$(PUBLISH_IMAGES_REGISTRY)/"
+endif
+
+ifndef REGISTRY
+$(error "The PUBLISH_IMAGES_REGISTRY value must be provided (e.g. PUBLISH_IMAGES_REGISTRY=861807767978.dkr.ecr.us-east-2.amazonaws.com make)")
+endif
+
+define build-image
+	docker buildx build . -t $(REPOSITORY)-$1 --platform $2 --load
+endef
+
+define tag-image
+	docker tag $(REPOSITORY)-$1 $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+define push-image
+	docker push $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+#### Actual build targets
+.PHONY: build
+build: x86_64 aarch64
+
+.PHONY: x86_64
+x86_64:
+	$(call build-image,$@,linux/amd64)
+	$(call tag-image,x86_64)
+
+.PHONY: aarch64
+aarch64:
+	$(call build-image,$@,linux/aarch64)
+	$(call tag-image,aarch64)
+
+.PHONY: push-platforms
+push-platforms: build
+	$(call push-image,x86_64)
+	$(call push-image,aarch64)
+
+.PHONY: create-manifest
+create-manifest: push-platforms
+	- docker manifest rm $(REGISTRY)$(REPOSITORY):$(TAG)
+	docker manifest create \
+		$(REGISTRY)$(REPOSITORY):$(TAG) \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-x86_64 \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-aarch64 \
+
+.PHONY: publish
+publish: create-manifest
+	docker manifest push $(REGISTRY)$(REPOSITORY):$(TAG)

--- a/bottlerocket/tests/workload/hello-dotnet/README.md
+++ b/bottlerocket/tests/workload/hello-dotnet/README.md
@@ -1,0 +1,67 @@
+# Hello dotnet test
+
+This container image can be used as a TestSys workload test to validate the Bottlerocket variants.
+
+## Build requirements
+
+Due to missing packages needed for cross-compiling, and unexpected handling in the sample Makefile logic when compiling for one platform for another, the build for this image requires two Buildx hosts - one for each architecture.
+
+In order to build the image for both architectures, you need to set up the `buildx` docker plugin.
+[This guide describes](https://github.com/docker/buildx#installing) the installation process.
+
+By default, the install of `docker buildx` uses the `docker` driver type.
+This driver is not able to build for all platform targets we need.
+You will need to run the following to create a new builder using the `docker-container` driver:
+
+```bash
+docker buildx create --use --bootstrap
+docker buildx ls
+```
+
+You should see a `*` next to your newly created builder denoting it as the currently active builder to use.
+If it is not, you can switch builder contexts by running:
+
+```sh
+docker buildx use $BUILDER_NAME
+```
+
+You then need to add another "context" to the builder for a second host that can build the other platform architecture.
+If you are running these steps on an `amd64` host, you will need to add an `arm64` host to the builder, or vice versa.
+
+First, verify you are able to access the remote host via SSH:
+
+```sh
+docker -H ssh://user@hostname info
+```
+
+The output from that command should show information about the Docker instance running on the remote host.
+You can then add that host to your Buildx builder by running:
+
+```sh
+docker buildx create --name $BUILDER_NAME --append ssh://user@hostname
+```
+
+Supported platforms can be verified by running:
+
+```bash
+docker buildx inspect | grep Platforms
+```
+
+The output from this command should show both `linux/amd64` and `linux/arm64` platforms.
+
+By default, the image will be tagged `<PUBLISH_IMAGES_REGISTRY>/hello-testsys:<TAG>`, so make sure you already have a `hello-testsys` repository in your registry.
+You can change the name of the repo by overriding the `PUBLISH_IMAGES_REGISTRY` env variable while building the image.
+
+**NOTE:** This assumes that you have already configured your credentials to be able to perform a `docker push` to your registry.
+
+## Building the image
+
+To build the image for both `x86_64` and `aarch64`, run the following:
+
+```sh
+PUBLISH_IMAGES_REGISTRY=<YOUR_REGISTRY> make
+```
+
+The command will build, tag, and push the images to your `PUBLISH_IMAGES_REGISTRY` using the name `hello-testsys:<TAG>`.
+
+Since this is a multi-arch image, you can use it in both `x86_64` and `aarch64` clusters.

--- a/bottlerocket/tests/workload/hello-dotnet/run.sh
+++ b/bottlerocket/tests/workload/hello-dotnet/run.sh
@@ -1,0 +1,41 @@
+#! /usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# Collect the test output where sonobuoy expects plugins to place them
+results_dir="${RESULTS_DIR:-/tmp/results}"
+results_tar="results.tar.gz"
+mkdir -p "${results_dir}"
+
+testDone() {
+    echo "${results_dir}/${results_tar}" >"${results_dir}/done"
+}
+
+# Make sure to always output done file in expected place and format
+trap testDone EXIT
+
+hello_script="$(mktemp --suffix='.cs')"
+
+cat >"${hello_script}" <<EOF
+using System;
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine("hello, dotnet");
+    }
+}
+EOF
+
+dotnet new console -o Hello
+mv "${hello_script}" Hello/Program.cs
+cd Hello
+dotnet run |
+   tee "../${results_dir}/hello.log"
+cd ..
+rm -rf Hello
+
+# Collect the results
+tar czf "${results_tar}" -C "${results_dir}" .
+mv "${results_tar}" "${results_dir}/"

--- a/bottlerocket/tests/workload/hello-ruby.yaml
+++ b/bottlerocket/tests/workload/hello-ruby.yaml
@@ -1,0 +1,16 @@
+kind: Test
+metadata:
+  name: workload-agent
+  namespace: testsys
+spec:
+  agent:
+    name: workload-agent
+    image: <WORKLOAD-AGENT-IMAGE>
+    keepRunning: false
+    configuration:
+      kubeconfigBase64: <BASE64-KUBECONFIG>
+      plugins:
+        - name: ruby-workload
+          image: <RUBY-WORKLOAD-IMAGE>
+  resources: []
+  dependsOn: []

--- a/bottlerocket/tests/workload/hello-ruby/Dockerfile
+++ b/bottlerocket/tests/workload/hello-ruby/Dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+RUN dnf makecache && \
+    dnf install -y \
+      gzip \
+      ruby \
+      tar \
+    && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+COPY --chmod=755 ./run.sh /
+ENTRYPOINT ["./run.sh"]

--- a/bottlerocket/tests/workload/hello-ruby/Makefile
+++ b/bottlerocket/tests/workload/hello-ruby/Makefile
@@ -1,0 +1,59 @@
+.DEFAULT_GOAL:=publish
+
+#### Variables
+PUBLISH_IMAGES_REGISTRY ?=
+TAG ?= latest
+REPOSITORY ?= hello-ruby
+
+#### Format the registry portion of the image tag, if needed
+REGISTRY ?=
+ifdef PUBLISH_IMAGES_REGISTRY
+REGISTRY = "$(PUBLISH_IMAGES_REGISTRY)/"
+endif
+
+ifndef REGISTRY
+$(error "The PUBLISH_IMAGES_REGISTRY value must be provided (e.g. PUBLISH_IMAGES_REGISTRY=861807767978.dkr.ecr.us-east-2.amazonaws.com make)")
+endif
+
+define build-image
+	docker buildx build . -t $(REPOSITORY)-$1 --platform $2 --load
+endef
+
+define tag-image
+	docker tag $(REPOSITORY)-$1 $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+define push-image
+	docker push $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+#### Actual build targets
+.PHONY: build
+build: x86_64 aarch64
+
+.PHONY: x86_64
+x86_64:
+	$(call build-image,$@,linux/amd64)
+	$(call tag-image,x86_64)
+
+.PHONY: aarch64
+aarch64:
+	$(call build-image,$@,linux/aarch64)
+	$(call tag-image,aarch64)
+
+.PHONY: push-platforms
+push-platforms: build
+	$(call push-image,x86_64)
+	$(call push-image,aarch64)
+
+.PHONY: create-manifest
+create-manifest: push-platforms
+	- docker manifest rm $(REGISTRY)$(REPOSITORY):$(TAG)
+	docker manifest create \
+		$(REGISTRY)$(REPOSITORY):$(TAG) \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-x86_64 \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-aarch64 \
+
+.PHONY: publish
+publish: create-manifest
+	docker manifest push $(REGISTRY)$(REPOSITORY):$(TAG)

--- a/bottlerocket/tests/workload/hello-ruby/README.md
+++ b/bottlerocket/tests/workload/hello-ruby/README.md
@@ -1,0 +1,67 @@
+# Hello Ruby test
+
+This container image can be used as a TestSys workload test to validate the Bottlerocket variants.
+
+## Build requirements
+
+Due to missing packages needed for cross-compiling, and unexpected handling in the sample Makefile logic when compiling for one platform for another, the build for this image requires two Buildx hosts - one for each architecture.
+
+In order to build the image for both architectures, you need to set up the `buildx` docker plugin.
+[This guide describes](https://github.com/docker/buildx#installing) the installation process.
+
+By default, the install of `docker buildx` uses the `docker` driver type.
+This driver is not able to build for all platform targets we need.
+You will need to run the following to create a new builder using the `docker-container` driver:
+
+```bash
+docker buildx create --use --bootstrap
+docker buildx ls
+```
+
+You should see a `*` next to your newly created builder denoting it as the currently active builder to use.
+If it is not, you can switch builder contexts by running:
+
+```sh
+docker buildx use $BUILDER_NAME
+```
+
+You then need to add another "context" to the builder for a second host that can build the other platform architecture.
+If you are running these steps on an `amd64` host, you will need to add an `arm64` host to the builder, or vice versa.
+
+First, verify you are able to access the remote host via SSH:
+
+```sh
+docker -H ssh://user@hostname info
+```
+
+The output from that command should show information about the Docker instance running on the remote host.
+You can then add that host to your Buildx builder by running:
+
+```sh
+docker buildx create --name $BUILDER_NAME --append ssh://user@hostname
+```
+
+Supported platforms can be verified by running:
+
+```bash
+docker buildx inspect | grep Platforms
+```
+
+The output from this command should show both `linux/amd64` and `linux/arm64` platforms.
+
+By default, the image will be tagged `<PUBLISH_IMAGES_REGISTRY>/hello-testsys:<TAG>`, so make sure you already have a `hello-testsys` repository in your registry.
+You can change the name of the repo by overriding the `PUBLISH_IMAGES_REGISTRY` env variable while building the image.
+
+**NOTE:** This assumes that you have already configured your credentials to be able to perform a `docker push` to your registry.
+
+## Building the image
+
+To build the image for both `x86_64` and `aarch64`, run the following:
+
+```sh
+PUBLISH_IMAGES_REGISTRY=<YOUR_REGISTRY> make
+```
+
+The command will build, tag, and push the images to your `PUBLISH_IMAGES_REGISTRY` using the name `hello-testsys:<TAG>`.
+
+Since this is a multi-arch image, you can use it in both `x86_64` and `aarch64` clusters.

--- a/bottlerocket/tests/workload/hello-ruby/run.sh
+++ b/bottlerocket/tests/workload/hello-ruby/run.sh
@@ -1,0 +1,29 @@
+#! /usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# Collect the test output where sonobuoy expects plugins to place them
+results_dir="${RESULTS_DIR:-/tmp/results}"
+results_tar="results.tar.gz"
+mkdir -p "${results_dir}"
+
+testDone() {
+    echo "${results_dir}/${results_tar}" >"${results_dir}/done"
+}
+
+# Make sure to always output done file in expected place and format
+trap testDone EXIT
+
+hello_script="$(mktemp --suffix='.rb')"
+
+cat >"${hello_script}" <<EOF
+puts "hello, ruby"
+EOF
+
+ruby "${hello_script}" |
+    tee "${results_dir}/hello.log"
+
+# Collect the results
+tar czf "${results_tar}" -C "${results_dir}" .
+mv "${results_tar}" "${results_dir}/"


### PR DESCRIPTION
**Description of changes:**

Add simple workloads for ruby and dotnet.

**Testing done:**

**Bottlerocket 1.26.0 w/ process restriction**
```shell
NAME                                                TYPE                       STATE                                       PASSED                   FAILED                  SKIPPED   BUILD ID                  LAST UPDATE
 x86-64-aws-k8s-130-test                             Test                       error                                            1                        1                        0   85f0d68c                  2025-02-17T19:22:24Z
                                                                                                                                 0                        0                        0
```

**Bottlerocket 1.32.0**
```shell
 NAME                                                TYPE                       STATE                                       PASSED                   FAILED                  SKIPPED   BUILD ID                  LAST UPDATE
 x86-64-aws-k8s-132-test                             Test                       running                                          2                        0                        0   f818b28c                  2025-02-15T01:18:13Z
 x86-64-aws-k8s-132                                  Resource                   completed                                                                                              f818b28c                  2025-02-15T01:16:47Z
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
