### PR TITLE
ec2-resource-agent: Remove ecr-credential-provider from userdata

### DIFF
--- a/bottlerocket/agents/src/bin/ec2-resource-agent/ec2_provider.rs
+++ b/bottlerocket/agents/src/bin/ec2-resource-agent/ec2_provider.rs
@@ -471,14 +471,6 @@ cluster-name = "{}"
 cluster-certificate = "{}"
 cluster-dns-ip = "{}"
 
-[settings.kubernetes.credential-providers.ecr-credential-provider]
-enabled = true
-cache-duration = "30m"
-image-patterns = [
-  "*.dkr.ecr.us-east-2.amazonaws.com",
-  "*.dkr.ecr.us-west-2.amazonaws.com"
-]
-
 [settings.network]
 no-proxy = ["localhost", "127.0.0.1"]"#,
         endpoint


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

**Description of changes:**
This setting is limited to regions outside us-west-2 where we run our Testsys clusters(cn-north-1 & us-gov). And this causes Credential Error Preventing Image Pulls from Amazon ECR in AWS China (cn-north-1). We should remove this setting.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
