### PR TITLE
eks-resource-agent: default ManagedNodeGroup desiredCapacity to 0

### DIFF
--- a/bottlerocket/agents/src/bin/eks-resource-agent/eks_provider.rs
+++ b/bottlerocket/agents/src/bin/eks-resource-agent/eks_provider.rs
@@ -31,9 +31,13 @@ use strum_macros::EnumString;
 /// The default region for the cluster.
 const DEFAULT_REGION: &str = "us-west-2";
 /// The default cluster version.
-const DEFAULT_VERSION: &str = "1.24";
+const DEFAULT_VERSION: &str = "1.32";
 const TEST_CLUSTER_CONFIG_PATH: &str = "/local/eksctl_config.yaml";
 const CLUSTER_CONFIG_PATH: &str = "/local/cluster_config.yaml";
+/// The default cluster managed node group values.
+const MNG_MIN_SIZE: i32 = 0;
+const MNG_MAX_SIZE: i32 = 2;
+const MNG_DESIRED_CAPACITY: i32 = 0;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -227,9 +231,16 @@ struct IAMConfig {
 /// # Fields:
 /// - `name`: The name of the managed node group.
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct ManagedNodeGroup {
     /// Name of the managed node group
     name: String,
+    /// The minimum number of nodes in the managed node group.
+    min_size: i32,
+    /// The maximum number of nodes in the managed node group.
+    max_size: i32,
+    // The desired number of nodes in the managed node group.
+    desired_capacity: i32,
 }
 
 #[allow(clippy::unwrap_or_default)]
@@ -274,6 +285,9 @@ fn create_yaml(
         iam: IAMConfig { withOIDC: true },
         managed_node_groups: vec![ManagedNodeGroup {
             name: "mng-1".to_string(),
+            min_size: MNG_MIN_SIZE,
+            max_size: MNG_MAX_SIZE,
+            desired_capacity: MNG_DESIRED_CAPACITY,
         }],
     };
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

**Description of changes:**
```
eks-resource-agent: default ManagedNodeGroup desiredCapacity to 0
```
During testing, we should avoid using AL nodes from ManagedNodeGroup. These nodes cause Karpenter tests to fail because Karpenter attempts to taint them without having the necessary permissions. This results in Karpenter resource creation hanging until it times out.

**Testing done:**

- [x] Deploy the EKS cluster using the modified resource agent image. Then verify that the ManagedNodeGroup's desired capacity is defaulting to 0
![Screenshot 2025-02-20 at 3 44 32 PM](https://github.com/user-attachments/assets/8dfedfa3-3cc5-41f7-8242-32b7bcf988c6)


- [x] Run Karpenter test

```
x86-64-aws-k8s-128-quick                          Test                    passed                                     5                     0                   7391   f818b28c               2025-02-20T23:32:08Z
 x86-64-aws-k8s-129-quick                          Test                    passed                                     5                     0                   7410   f818b28c               2025-02-20T23:37:22Z
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
