### PR TITLE
Fix NVIDIA workload test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,7 @@ dependencies = [
  "bottlerocket-types",
  "flate2",
  "hex",
+ "json-patch",
  "k8s-openapi",
  "kube",
  "log",

--- a/bottlerocket/agents/Cargo.toml
+++ b/bottlerocket/agents/Cargo.toml
@@ -21,6 +21,7 @@ aws-sdk-cloudformation = "1"
 base64 = "0.21"
 flate2 = "1.0"
 hex ="0.4"
+json-patch = "1"
 k8s-openapi = { version = "0.21", default-features = false, features = ["v1_24"] }
 kube = { version = "0.88", default-features = false, features = ["config", "derive", "client"] }
 log = "0.4"

--- a/bottlerocket/agents/src/error.rs
+++ b/bottlerocket/agents/src/error.rs
@@ -36,6 +36,15 @@ pub enum Error {
     #[snafu(display("{}", source))]
     DeserializeJson { source: serde_json::Error },
 
+    #[snafu(display("{}", source))]
+    SerializeJson { source: serde_json::Error },
+
+    #[snafu(display("{}", source))]
+    DeserializeYaml { source: serde_yaml::Error },
+
+    #[snafu(display("{}", source))]
+    SerializeYaml { source: serde_yaml::Error },
+
     #[snafu(display("Missing '{}' field from sonobuoy status", field))]
     MissingSonobuoyStatusField { field: String },
 

--- a/bottlerocket/agents/src/workload.rs
+++ b/bottlerocket/agents/src/workload.rs
@@ -4,6 +4,8 @@ use crate::sonobuoy::{
 };
 use bottlerocket_types::agent_config::{WorkloadConfig, SONOBUOY_RESULTS_FILENAME};
 use log::{info, trace};
+use serde::Serialize;
+use serde_yaml;
 use snafu::{ensure, ResultExt};
 use std::fs::File;
 use std::io::Write;
@@ -16,6 +18,51 @@ use testsys_model::{SecretName, TestResults};
 /// Timeout for sonobuoy status to become available (seconds)
 const SONOBUOY_STATUS_TIMEOUT: u64 = 900;
 const SONOBUOY_BIN_PATH: &str = "/usr/bin/sonobuoy";
+
+#[derive(Serialize)]
+struct PluginConfig {
+    spec: Spec,
+}
+
+#[derive(Serialize)]
+struct Spec {
+    resources: Resources,
+}
+
+#[derive(Serialize)]
+struct Resources {
+    limits: Limits,
+    requests: Requests,
+}
+
+#[derive(Default, Serialize)]
+struct Limits {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cpu: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    memory: Option<String>,
+}
+
+#[derive(Default, Serialize)]
+struct Requests {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cpu: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    memory: Option<String>,
+}
+
+impl PluginConfig {
+    fn new() -> Self {
+        PluginConfig {
+            spec: Spec {
+                resources: Resources {
+                    limits: Limits::default(),
+                    requests: Requests::default(),
+                },
+            },
+        }
+    }
+}
 
 /// Runs the workload conformance tests according to the provided configuration and returns a test
 /// result at the end.
@@ -49,19 +96,31 @@ where
             }
         );
 
+        // Generate additional configuration for specific workloads
+        let mut additional_configuration = PluginConfig::new();
+
+        // Merge additional configuration with the initialization output
+        let plugin_init_stdout = output.stdout;
+        let mut plugin_json: serde_json::Value =
+            serde_yaml::from_slice(&plugin_init_stdout).context(error::DeserializeYamlSnafu)?;
+        let additional_configuration_json =
+            serde_json::to_value(additional_configuration).context(error::SerializeJsonSnafu)?;
+        json_patch::merge(&mut plugin_json, &additional_configuration_json);
+        let plugin_yaml = serde_yaml::to_string(&plugin_json).context(error::SerializeYamlSnafu)?;
+
         // Write out the output to a file we can reference later
         let file_name = format!("{}-plugin.yaml", test.name);
-        let plugin_yaml = PathBuf::from(".").join(file_name);
-        let mut f = File::create(&plugin_yaml).context(error::FileWriteSnafu {
-            path: plugin_yaml.display().to_string(),
+        let file_path = PathBuf::from(".").join(file_name);
+        let mut f = File::create(&file_path).context(error::FileWriteSnafu {
+            path: file_path.display().to_string(),
         })?;
-        f.write_all(&output.stdout)
+        f.write_all(plugin_yaml.as_bytes())
             .context(error::WorkloadProcessSnafu)?;
 
         // Add plugin to the arguments to be passed to sonobuoy run
         plugin_test_args.append(&mut vec![
             "--plugin".to_string(),
-            plugin_yaml.display().to_string(),
+            file_path.display().to_string(),
         ]);
     }
     let sonobuoy_image_arg = match &workload_config.sonobuoy_image {

--- a/bottlerocket/agents/src/workload.rs
+++ b/bottlerocket/agents/src/workload.rs
@@ -41,6 +41,9 @@ struct Limits {
     cpu: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     memory: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "nvidia.com/gpu")]
+    nvidia_com_gpu: Option<u32>,
 }
 
 #[derive(Default, Serialize)]
@@ -49,6 +52,9 @@ struct Requests {
     cpu: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     memory: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "nvidia.com/gpu")]
+    nvidia_com_gpu: Option<u32>,
 }
 
 impl PluginConfig {
@@ -98,6 +104,20 @@ where
 
         // Generate additional configuration for specific workloads
         let mut additional_configuration = PluginConfig::new();
+
+        // Explicitly request GPUs for NVIDIA workloads
+        if test.gpu && test.name.contains("nvidia") {
+            additional_configuration
+                .spec
+                .resources
+                .limits
+                .nvidia_com_gpu = Some(1);
+            additional_configuration
+                .spec
+                .resources
+                .requests
+                .nvidia_com_gpu = Some(1);
+        };
 
         // Merge additional configuration with the initialization output
         let plugin_init_stdout = output.stdout;

--- a/bottlerocket/tests/workload/nvidia-smoke/Dockerfile
+++ b/bottlerocket/tests/workload/nvidia-smoke/Dockerfile
@@ -1,16 +1,17 @@
 # Builder for the CUDA Sample binaries. The image we run to perform the tests
 # doesn't need everything that is included in the "devel" image. So we build with
 # the larger image, then copy them to the lightweight image we use to run.
-FROM nvidia/cuda:11.4.3-devel-ubi8 as builder
+FROM nvidia/cuda:12.8.0-devel-ubi9 AS builder
 
-# Make sure we have git to clone the sample repo
 RUN dnf makecache \
-  && dnf -y install git-core \
+  && dnf -y install \
+    cmake \
+    git-core \
   && dnf clean all \
   && rm -fr /var/cache/dnf
 
 # Clone the samples, pinned to a version we know should work
-RUN git clone --branch v11.6 --depth 1 https://github.com/NVIDIA/cuda-samples.git
+RUN git clone --branch v12.8 --depth 1 https://github.com/NVIDIA/cuda-samples.git
 RUN mkdir -p /samples
 
 # There is a Makefile in the 'cuda-samples' project, but it will
@@ -18,21 +19,21 @@ RUN mkdir -p /samples
 # a 'FILTER_OUT' variable that can be set, but as the name suggests
 # it filters out what samples won't be build.
 # This only includes the samples that should run on both amd64 and arm64.
-RUN cd /cuda-samples/Samples/0_Introduction/vectorAdd/ && make && cp $(basename $(pwd)) /samples/
-RUN cd /cuda-samples/Samples/0_Introduction/simpleVoteIntrinsics/ && make && cp $(basename $(pwd)) /samples/
-RUN cd /cuda-samples/Samples/0_Introduction/simpleAtomicIntrinsics/ && make && cp $(basename $(pwd)) /samples/
-RUN cd /cuda-samples/Samples/0_Introduction/simpleAWBarrier/ && make && cp $(basename $(pwd)) /samples/
-RUN cd /cuda-samples/Samples/1_Utilities/deviceQuery/ && make && cp $(basename $(pwd)) /samples/
-RUN cd /cuda-samples/Samples/2_Concepts_and_Techniques/reductionMultiBlockCG/ && make && cp $(basename $(pwd)) /samples/
-RUN cd /cuda-samples/Samples/2_Concepts_and_Techniques/shfl_scan/ && make && cp $(basename $(pwd)) /samples/
-RUN cd /cuda-samples/Samples/3_CUDA_Features/immaTensorCoreGemm/ && make && cp $(basename $(pwd)) /samples/
-RUN cd /cuda-samples/Samples/3_CUDA_Features/warpAggregatedAtomicsCG/ && make && cp $(basename $(pwd)) /samples/
-RUN cd /cuda-samples/Samples/3_CUDA_Features/globalToShmemAsyncCopy/ && make && cp $(basename $(pwd)) /samples/
-RUN cd /cuda-samples/Samples/6_Performance/UnifiedMemoryPerf/ && make && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/0_Introduction/vectorAdd/ && cmake . && make -j$(nproc) && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/0_Introduction/simpleVoteIntrinsics/ && cmake . && make -j$(nproc) && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/0_Introduction/simpleAtomicIntrinsics/ && cmake . && make -j$(nproc) && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/0_Introduction/simpleAWBarrier/ && cmake . && make -j$(nproc) && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/1_Utilities/deviceQuery/ && cmake . && make -j$(nproc) && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/2_Concepts_and_Techniques/reductionMultiBlockCG/ && cmake . && make -j$(nproc) && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/2_Concepts_and_Techniques/shfl_scan/ && cmake . && make -j$(nproc) && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/3_CUDA_Features/immaTensorCoreGemm/ && cmake . && make -j$(nproc) && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/3_CUDA_Features/warpAggregatedAtomicsCG/ && cmake . && make -j$(nproc) && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/3_CUDA_Features/globalToShmemAsyncCopy/ && cmake . && make -j$(nproc) && cp $(basename $(pwd)) /samples/
+RUN cd /cuda-samples/Samples/6_Performance/UnifiedMemoryPerf/ && cmake . && make -j$(nproc) && cp $(basename $(pwd)) /samples/
 
 # We only need the base image to run the tests. It contains the necessary
 # drivers and runtime environment we need.
-FROM nvidia/cuda:11.4.3-base-ubi8
+FROM nvidia/cuda:12.8.0-base-ubi9
 COPY ./run.sh /
 COPY --from=builder /samples/* /samples/
 RUN chmod +x ./run.sh

--- a/bottlerocket/tests/workload/nvidia-smoke/Makefile
+++ b/bottlerocket/tests/workload/nvidia-smoke/Makefile
@@ -3,7 +3,7 @@
 #### Variables
 PUBLISH_IMAGES_REGISTRY ?=
 TAG ?= latest
-REPOSITORY ?= gpu-tests
+REPOSITORY ?= nvidia-smoke
 
 #### Format the registry portion of the image tag, if needed
 REGISTRY ?=
@@ -11,18 +11,49 @@ ifdef PUBLISH_IMAGES_REGISTRY
 REGISTRY = "$(PUBLISH_IMAGES_REGISTRY)/"
 endif
 
-#### Actual build targets
-build:
 ifndef REGISTRY
 $(error "The PUBLISH_IMAGES_REGISTRY value must be provided (e.g. PUBLISH_IMAGES_REGISTRY=861807767978.dkr.ecr.us-east-2.amazonaws.com make)")
 endif
-	docker buildx build --platform linux/arm64,linux/amd64 --tag $(REGISTRY)$(REPOSITORY):$(TAG) .
 
-publish:
-	docker buildx build --push --platform linux/arm64,linux/amd64 --tag $(REGISTRY)$(REPOSITORY):$(TAG) .
+define build-image
+	docker buildx build . -t $(REPOSITORY)-$1 --platform $2 --load
+endef
 
+define tag-image
+	docker tag $(REPOSITORY)-$1 $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+define push-image
+	docker push $(REGISTRY)$(REPOSITORY):$(TAG)-$1
+endef
+
+#### Actual build targets
+.PHONY: build
+build: x86_64 aarch64
+
+.PHONY: x86_64
 x86_64:
-	docker buildx build --platform linux/amd64 --tag $(REGISTRY)$(REPOSITORY):$(TAG)-x86_64 .
+	$(call build-image,$@,linux/amd64)
+	$(call tag-image,x86_64)
 
+.PHONY: aarch64
 aarch64:
-	docker buildx build --platform linux/arm64 --tag $(REGISTRY)$(REPOSITORY):$(TAG)-aarch64 .
+	$(call build-image,$@,linux/aarch64)
+	$(call tag-image,aarch64)
+
+.PHONY: push-platforms
+push-platforms: build
+	$(call push-image,x86_64)
+	$(call push-image,aarch64)
+
+.PHONY: create-manifest
+create-manifest: push-platforms
+	- docker manifest rm $(REGISTRY)$(REPOSITORY):$(TAG)
+	docker manifest create \
+		$(REGISTRY)$(REPOSITORY):$(TAG) \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-x86_64 \
+		$(REGISTRY)$(REPOSITORY):$(TAG)-aarch64 \
+
+.PHONY: publish
+publish: create-manifest
+	docker manifest push $(REGISTRY)$(REPOSITORY):$(TAG)

--- a/bottlerocket/tests/workload/nvidia-smoke/run.sh
+++ b/bottlerocket/tests/workload/nvidia-smoke/run.sh
@@ -5,16 +5,15 @@ set -o pipefail
 
 # Collect the test output where sonobuoy expects plugins to place them
 results_dir="${RESULTS_DIR:-/tmp/results}"
+results_tar="results.tar.gz"
 mkdir -p "${results_dir}"
 
-saveResults() {
-     cd "${results_dir}"
-     tar czf results.tar.gz ./*
-     echo "${results_dir}/results.tar.gz" > "${results_dir}/done"
+testDone() {
+    echo "${results_dir}/${results_tar}" >"${results_dir}/done"
 }
 
-# Make sure to always capture results in expected place and format
-trap saveResults EXIT
+# Make sure to always output done file in expected place and format
+trap testDone EXIT
 
 # Run the CUDA sample binaries to exercise various GPU functions
 cd /samples
@@ -26,3 +25,7 @@ for sample in *; do
     echo
     "./${sample}" 2>&1 | tee "${results_dir}/${sample}.log"
 done
+
+# Collect the results
+tar czf "${results_tar}" -C "${results_dir}" .
+mv "${results_tar}" "${results_dir}/"


### PR DESCRIPTION
**Description of changes:**

This PR, in conjunction with https://github.com/bottlerocket-os/twoliter/pull/480, makes several changes to how NVIDIA workload tests are executed for `aws-k8s-*-nvidia` variants:

- Rather than return a count of the logs, trigger FAIL in sonobuoy when a CUDA sample fails to execute.
- Refactor the Makefile to be consistent with newer workload tests.
- Update to the latest NVIDIA CUDA v12.8.0.
- Explicitly request GPU resources for NVIDIA workload tests _(and add support for future custom resource configurations)_.

**Testing done:**

- [x] FAIL `bottlerocket-aws-k8s-1.29-nvidia-aarch64-v1.33.0-cc306b6f`
- [x] PASS `bottlerocket-aws-k8s-1.29-nvidia-aarch64-v1.34.0-18d04e52`



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
