### PR TITLE
feat: add single zone configuration

### DIFF
--- a/bottlerocket/types/src/agent_config.rs
+++ b/bottlerocket/types/src/agent_config.rs
@@ -296,6 +296,9 @@ pub struct Ec2Config {
     /// The device mappings used for EC2 resource provisioning
     #[serde(default)]
     pub device_mappings: Option<Vec<BlockDeviceMappingConfig>>,
+
+     /// The target availibity zones
+     pub input_availability_zones: Vec<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**


**Description of changes:**
Added feature allows configuring a specific zone in Test.toml, so that  EC2 instance(s) can be launched in this specific zone. Usually, two zones must specified, but this feature allows one specific single zone for EC2 instance to launch into.

**Testing done:**
5 rounds same testings have been launched to make sure us-west-2b is not randomly picked up: 
Input Test.toml: 
<img width="525" alt="Screenshot 2025-03-17 at 11 23 30 AM" src="https://github.com/user-attachments/assets/b758bb42-c13f-4f35-bfd3-44c82b766cf8" />

After EC2 instance launched: 
[ (eksctl-x86-64-aws-k8s-129-nvidia-cluster/SubnetPublicUSWEST2B)]

Invalid input tests: 
input: 
<img width="498" alt="Screenshot 2025-03-17 at 1 49 13 PM" src="https://github.com/user-attachments/assets/b253e947-b89d-4b0f-ba7f-dbbb7ba66691" />

output: 
<img width="1402" alt="Screenshot 2025-03-17 at 1 49 54 PM" src="https://github.com/user-attachments/assets/3f0592ba-fa71-4671-a07d-b428d8762b17" />



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
