### PR TITLE
update bottlerocket sample to use latest k8s version

### DIFF
--- a/bottlerocket/samples/Makefile.toml
+++ b/bottlerocket/samples/Makefile.toml
@@ -8,18 +8,18 @@ ARCH = { value = "x86_64", condition = { env_not_set = ["ARCH"] } }
 CLUSTER_TYPE = { value = "eks", condition = { env_not_set = ["CLUSTER_TYPE"] } }
 ASSUME_ROLE = { value = "~", condition = { env_not_set = ["ASSUME_ROLE"] } }
 AWS_REGION = { value = "us-west-2", condition = { env_not_set = ["AWS_REGION"] } }
-UPGRADE_VERSION = { value = "v1.20.4", condition = { env_not_set = ["UPGRADE_VERSION"] } }
+UPGRADE_VERSION = { value = "v1.36.0", condition = { env_not_set = ["UPGRADE_VERSION"] } }
 STARTING_VERSION = { script = ["""\
         aws ssm get-parameter \
             --region us-west-2 \
-            --name "/aws/service/bottlerocket/aws-k8s-1.24/arm64/latest/image_version" \
+            --name "/aws/service/bottlerocket/aws-k8s-1.32/arm64/latest/image_version" \
             --query Parameter.Value \
             --output text \
         | awk -F- '{printf "v%s", $1}' \
     """], condition = { env_not_set = ["STARTING_VERSION"] } }
 SONOBUOY_MODE = { value = "quick", condition = { env_not_set = ["SONOBUOY_MODE"] } }
 TARGETS_URL = { value = "https://updates.bottlerocket.aws/targets", condition = { env_not_set = ["TARGETS_URL"] } }
-K8S_VERSION = { value = "v1.24", condition = { env_not_set = ["K8S_VERSION"] } }
+K8S_VERSION = { value = "v1.32", condition = { env_not_set = ["K8S_VERSION"] } }
 SINGLE_IMAGE_REPO = { value = "false", condition = { env_not_set = ["SINGLE_IMAGE_REPO"] } }
 
 # The following variable needs a value only if `SINGLE_IMAGE_REPO` is "true". This value should be the name of the repository containing all agent images.
@@ -334,22 +334,22 @@ VARIANT = { value = "aws-ecs-1", condition = { env_not_set = ["VARIANT"] } }
 VARIANT = { value = "aws-ecs-1-nvidia", condition = { env_not_set = ["VARIANT"] } }
 
 [tasks.sonobuoy-migration-test.env]
-VARIANT = { value = "aws-k8s-1.24", condition = { env_not_set = ["VARIANT"] } }
+VARIANT = { value = "aws-k8s-1.32", condition = { env_not_set = ["VARIANT"] } }
 
 [tasks.sonobuoy-test.env]
-VARIANT = { value = "aws-k8s-1.24", condition = { env_not_set = ["VARIANT"] } }
+VARIANT = { value = "aws-k8s-1.32", condition = { env_not_set = ["VARIANT"] } }
 
 [tasks.sonobuoy-test-karpenter.env]
-VARIANT = { value = "aws-k8s-1.24", condition = { env_not_set = ["VARIANT"] } }
+VARIANT = { value = "aws-k8s-1.32", condition = { env_not_set = ["VARIANT"] } }
 
 [tasks.k8s-workload-test.env]
-VARIANT = { value = "aws-k8s-1.24-nvidia", condition = { env_not_set = ["VARIANT"] } }
+VARIANT = { value = "aws-k8s-1.32-nvidia", condition = { env_not_set = ["VARIANT"] } }
 
 [tasks.vmware-migration-test.env]
-VARIANT = { value = "vmware-k8s-1.24", condition = { env_not_set = ["VARIANT"] } }
+VARIANT = { value = "vmware-k8s-1.32", condition = { env_not_set = ["VARIANT"] } }
 
 [tasks.vmware-sonobuoy-test.env]
-VARIANT = { value = "vmware-k8s-1.24", condition = { env_not_set = ["VARIANT"] } }
+VARIANT = { value = "vmware-k8s-1.32", condition = { env_not_set = ["VARIANT"] } }
 
 [tasks.metal-sonobuoy-test.env]
-VARIANT = { value = "metal-k8s-1.24", condition = { env_not_set = ["VARIANT"] } }
+VARIANT = { value = "metal-k8s-1.32", condition = { env_not_set = ["VARIANT"] } }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Bottlerocket has deprecated k8s 1.24 variants, and this change updates bottlerocket sample to use the latest k8s version.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
