### PR TITLE
Update tough, aws-sdk*, and aws-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "agent-common",
  "aws-config",
  "aws-credential-types",
+ "aws-lc-rs",
  "aws-sdk-iam",
  "aws-sdk-ssm",
  "aws-sdk-sts",
@@ -220,6 +221,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,14 +234,12 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.17"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490aa7465ee685b2ced076bb87ef654a47724a7844e2c7d3af4e749ce5b875dd"
+checksum = "8c39646d1a6b51240a1a23bb57ea4eebede7e16fbc237fdc876980233dcecb4f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -245,14 +250,11 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "hex",
- "http 0.2.12",
- "ring",
+ "http 1.3.1",
  "time",
  "tokio",
  "tracing",
  "url",
- "zeroize",
 ]
 
 [[package]]
@@ -308,13 +310,14 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76dd04d39cc12844c0994f2c9c5a6f5184c22e9188ec1ff723de41910a21dcad"
+checksum = "0aff45ffe35196e593ea3b9dd65b320e51e2dda95aff4390bc459e461d09c6ad"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -333,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudformation"
-version = "1.67.0"
+version = "1.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890be976d70d787da24b48e04829f6da831f64b0309c5cfcab2e9237a1cd0d5e"
+checksum = "52b631dfb3e68c071e919772ad16f31859bd804f3d065c1cf0f188a9c684e323"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -357,13 +360,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudwatchlogs"
-version = "1.71.0"
+version = "1.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1925e6963baf1b83604d852247260262cf16e2dfb2653f6066c528b76801b075"
+checksum = "3b7a8df7f19f2ff90191c905fefb8cf0ff512ad7c2cc92c422240ff5b114750c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-json",
  "aws-smithy-runtime",
@@ -380,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ec2"
-version = "1.114.0"
+version = "1.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96d95163e855b22d8013ddfb219083b9a44d3e5e7ce8dcb14aec73a66dfb09e"
+checksum = "f6c3ef2470307bdeb6471d66d5c28aee1e1b10d7f752d0fd9da6cccc5791f9b3"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -404,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ecs"
-version = "1.68.0"
+version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b1c3d5bdf89f6ef96e8797603387491ac1b54b1eaa4cf16ce3551174318d6d"
+checksum = "54196e7685f46c8ece4d78be027de01458f133d32c94c5c148fcb51836a076b4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -427,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-eks"
-version = "1.76.0"
+version = "1.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d224e44ab25bd33ea3f9ff07d92df46bc736ca183f0fdfdfb9c4ac419d0f08a"
+checksum = "438965cf3c3ed87fbbe15180c8ba9f426163feec8e24f5ae4d76ccb3f715fc89"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -450,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-iam"
-version = "1.63.0"
+version = "1.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42be877ca573bc6345aae9535228aa204323af42d693d58b1b5dfc19005853e"
+checksum = "758e1427b5bcd07a20702262696f42594ca1ecd3cbd35c85ab308d3aa6f2a5c1"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -465,6 +469,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
+ "fastrand",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -473,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.64.0"
+version = "1.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d043d816535461c5d5289b53c03a4458aae3e9c4d47e3e901722590c8d6fcb"
+checksum = "5c18fb03c6aad6a5de2a36e44eebc83640eea9a025bf407579f503b5dc4cd0b0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -496,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssm"
-version = "1.66.0"
+version = "1.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479c4a6787dadce70f29d6f71c26ad5ba51ac8fcc3d615009c90c787ab66ce9c"
+checksum = "d07c58e00d2059c0080d11c40ffabb7a4802f7ddf35e04d181f0f090eaf20cab"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -518,54 +523,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-sso"
-version = "1.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60186fab60b24376d3e33b9ff0a43485f99efd470e3b75a9160c849741d63d56"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssooidc"
-version = "1.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7033130ce1ee13e6018905b7b976c915963755aef299c1521897679d6cd4f8ef"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
 name = "aws-sdk-sts"
-version = "1.61.0"
+version = "1.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c1cac7677179d622b4448b0d31bcb359185295dc6fca891920cfb17e2b5156"
+checksum = "96a78a8f50a1630db757b60f679c8226a8a70ee2ab5f5e6e51dc67f6c61c7cfd"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -578,6 +539,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
+ "fastrand",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -586,11 +548,12 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.9"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bfe75fad52793ce6dec0dc3d4b1f388f038b5eb866c8d4d7f3a8e21b5ea5051"
+checksum = "69d03c3c05ff80d54ff860fe38c726f6f494c639ae975203a101335f223386db"
 dependencies = [
  "aws-credential-types",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -619,22 +582,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http"
-version = "0.60.12"
+name = "aws-smithy-eventstream"
+version = "0.60.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
+checksum = "7c45d3dddac16c5c59d553ece225a88870cf81b7b813c9cc17b78cf4685eac7a"
 dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5949124d11e538ca21142d1fba61ab0a2a2c1bc3ed323cdb3e4b878bfb83166"
+dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
+ "http 1.3.1",
  "http-body 0.4.6",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aff1159006441d02e57204bf57a1b890ba68bedb6904ffd2873c1c4c11c546b"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.5",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.23.25",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
+ "tokio",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -645,6 +644,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92144e45819cae7dc62af23eac5a038a58aa544432d2102609654376a900bd07"
 dependencies = [
  "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445d065e76bc1ef54963db400319f1dd3ebb3e0a74af20f7f7630625b0cc7cc0"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "once_cell",
 ]
 
 [[package]]
@@ -659,27 +668,25 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.8"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d526a12d9ed61fadefda24abe2e682892ba288c2018bcb38b1b4c111d13f6d92"
+checksum = "0152749e17ce4d1b47c7747bdfec09dac1ccafdcbc741ebf9daa2a373356730f"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "fastrand",
- "h2",
  "http 0.2.12",
+ "http 1.3.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
- "httparse",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls 0.21.12",
  "tokio",
  "tracing",
 ]
@@ -886,6 +893,7 @@ dependencies = [
 name = "bottlerocket-types"
 version = "0.0.16"
 dependencies = [
+ "aws-lc-rs",
  "aws-sdk-ec2",
  "builder-derive",
  "configuration-derive",
@@ -1096,6 +1104,7 @@ version = "0.0.16"
 dependencies = [
  "anyhow",
  "aws-config",
+ "aws-lc-rs",
  "aws-sdk-cloudwatchlogs",
  "aws-types",
  "env_logger",
@@ -1125,6 +1134,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1511,16 +1530,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
- "http 0.2.12",
+ "http 1.3.1",
  "indexmap",
  "slab",
  "tokio",
@@ -1658,7 +1677,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1681,6 +1699,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -1702,7 +1721,7 @@ dependencies = [
  "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -1718,6 +1737,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "rustls 0.23.25",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -2096,7 +2116,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tower-http",
  "tracing",
 ]
@@ -2183,7 +2203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2926,7 +2946,19 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -3062,7 +3094,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3716,9 +3761,9 @@ checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tough"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe73519c5c485dc0b585088523ad861cda19836b2eb94896fac278db68bd5ab"
+checksum = "e88d0ee9525696569cc2af5d46f8a739028c0268895071e0386957195b0c9161"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -3764,6 +3809,16 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -4151,7 +4206,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/agent/utils/Cargo.toml
+++ b/agent/utils/Cargo.toml
@@ -6,13 +6,14 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+aws-lc-rs = { version = "1", features = ["bindgen"] }
 agent-common = { version = "0.0.16", path = "../../agent/agent-common" }
-aws-config = "1"
+aws-config = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
 aws-credential-types = "1"
 aws-types = "1"
-aws-sdk-iam = "1"
-aws-sdk-ssm = "1"
-aws-sdk-sts = "1"
+aws-sdk-iam = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-sdk-ssm = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-sdk-sts = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
 aws-smithy-types = "1"
 base64 = "0.21"
 env_logger = "0.11"

--- a/bottlerocket/agents/Cargo.toml
+++ b/bottlerocket/agents/Cargo.toml
@@ -12,14 +12,14 @@ bottlerocket-types = { version = "0.0.16", path = "../types" }
 aws-lc-rs = { version = "1", features = ["bindgen"] }
 async-trait = "0.1"
 aws-types = "1"
-aws-sdk-ec2 = "1"
-aws-sdk-ecs = "1"
-aws-sdk-eks = "1"
-aws-sdk-iam = "1"
-aws-sdk-ssm = "1"
-aws-sdk-sts = "1"
-aws-sdk-cloudformation = "1"
-aws-sdk-secretsmanager = "1"
+aws-sdk-ec2 = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-sdk-ecs = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-sdk-eks = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-sdk-iam = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-sdk-ssm = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-sdk-sts = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-sdk-cloudformation = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
+aws-sdk-secretsmanager = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
 base64 = "0.21"
 flate2 = "1.0"
 hex ="0.4"
@@ -41,7 +41,7 @@ tar = "0.4"
 test-agent = { version = "0.0.16", path = "../../agent/test-agent" }
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
 toml = "0.5"
-tough = { version = "0.20", features = ["http"] }
+tough = { version = "0.21", features = ["http"] }
 url = "2"
 uuid = { version = "1", default-features = false, features = ["serde", "v4"] }
 strum = { version = "0.26", features = ["derive"] }

--- a/bottlerocket/types/Cargo.toml
+++ b/bottlerocket/types/Cargo.toml
@@ -6,7 +6,8 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-aws-sdk-ec2 = "1"
+aws-lc-rs = { version = "1", features = ["bindgen"] }
+aws-sdk-ec2 = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
 configuration-derive = { version = "0.0.16", path = "../../agent/configuration-derive" }
 builder-derive = { version = "0.0.16", path = "../../agent/builder-derive" }
 testsys-model = { version = "0.0.16", path = "../../model" }

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -6,10 +6,11 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+aws-lc-rs = { version = "1", features = ["bindgen"] }
 anyhow = "1"
-aws-config = "1"
+aws-config = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
 aws-types = "1"
-aws-sdk-cloudwatchlogs = "1"
+aws-sdk-cloudwatchlogs = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
 env_logger = "0.11"
 futures = "0.3"
 http = "1"

--- a/deny.toml
+++ b/deny.toml
@@ -31,29 +31,13 @@ skip = [
     "http@0.2",
     "http-body@0.4",
 
-    # many crates still use syn v1
-    "syn@1",
-
-    # many crates still use base64 v0.21
-    "base64@0.21",
-
     # tabled uses an older version of heck
     "heck@0.4.1",
-
-    # aws-lc-rs uses an older version of untrusted
-    "untrusted@0.7",
-
-    # several crates use an older version of hyper/rustls
-    "hyper@0.14",
-    "hyper-rustls@0.24",
-    "rustls@0.21",
-    "rustls-pemfile@1",
-    "rustls-webpki@0.101",
-    "tokio-rustls@0.24",
 ]
 
 skip-tree = [
-    { crate = "windows-sys" },
+    "kube-client",
+    "windows-sys",
 ]
 
 # https://github.com/hsivonen/encoding_rs The non-test code that isn't generated from the WHATWG data in this crate is


### PR DESCRIPTION
**Description of changes:**

Updates Cargo.toml's `tough` from **0.20** to **0.21**, all the aws-sdk*, aws-confg, and deny.toml
This PR is Co-authored-with: Patrick J.P. Culp <jpculp@amazon.com>

**Testing done:**
1. Both cargo build and make images succeeded
2. Passed cargo deny
```bash
bans ok, licenses ok, sources ok
``` 
3. Migration Test: 
```bash
 x86-64-aws-k8s-132-1-initial                         Test                       passed                                           5                       0                     6621   78594e2e                  2025-05-02T23:52:48Z
 x86-64-aws-k8s-132-2-migrate                         Test                       passed                                           2                       0                        0   78594e2e                  2025-05-02T23:53:38Z
 x86-64-aws-k8s-132-3-migrated                        Test                       passed                                           5                       0                     6621   78594e2e                  2025-05-02T23:55:08Z
 x86-64-aws-k8s-132-4-migrate                         Test                       passed                                           2                       0                        0   78594e2e                  2025-05-02T23:55:38Z
 x86-64-aws-k8s-132-5-final                           Test                       passed                                           5                       0                     6621   78594e2e                  2025-05-02T23:57:08Z
 x86-64-aws-k8s-132-ipv6-1-initial                    Test                       passed                                           5                       0                     6621   78594e2e                  2025-05-02T23:53:13Z
 x86-64-aws-k8s-132-ipv6-2-migrate                    Test                       passed                                           2                       0                        0   78594e2e                  2025-05-02T23:54:01Z
 x86-64-aws-k8s-132-ipv6-3-migrated                   Test                       passed                                           5                       0                     6621   78594e2e                  2025-05-02T23:55:02Z
 x86-64-aws-k8s-132-ipv6-4-migrate                    Test                       passed                                           2                       0                        0   78594e2e                  2025-05-02T23:55:33Z
 x86-64-aws-k8s-132-ipv6-5-final                      Test                       passed                                           5                       0                     6621   78594e2e                  2025-05-02T23:56:32Z
```

Thanks, @gthao313 for testing support. 
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
