### PR TITLE
Add kubernetes 1.33 support

### DIFF
--- a/bottlerocket/agents/src/bin/eks-resource-agent/eks_provider.rs
+++ b/bottlerocket/agents/src/bin/eks-resource-agent/eks_provider.rs
@@ -142,6 +142,11 @@ enum IPFamily {
     IPv4,
 }
 
+#[derive(Serialize, Debug, EnumString)]
+enum AmiFamily {
+    Bottlerocket,
+}
+
 /// Configuration for setting up an EKS cluster using eksctl yaml file.
 ///
 /// # Fields:
@@ -241,6 +246,8 @@ struct ManagedNodeGroup {
     max_size: i32,
     // The desired number of nodes in the managed node group.
     desired_capacity: i32,
+    // The desired OS of nodes in the managed node group.
+    ami_family: AmiFamily,
 }
 
 #[allow(clippy::unwrap_or_default)]
@@ -288,6 +295,7 @@ fn create_yaml(
             min_size: MNG_MIN_SIZE,
             max_size: MNG_MAX_SIZE,
             desired_capacity: MNG_DESIRED_CAPACITY,
+            ami_family: AmiFamily::Bottlerocket,
         }],
     };
 


### PR DESCRIPTION
**Description of changes:**

Sets the amiFamily in the initial managed node group to Bottlerocket, as AmazonLinux2 is not a valid amiFamily for k8s 1.33.


**Testing done:**

```bash
 x86-64-aws-k8s-133-quick                    Test                        passed                                             5                         0                       6730   97fcd255                   2025-06-05T00:46:20Z
 x86-64-aws-k8s-133                          Resource                    completed                                                                                                   97fcd255                   2025-06-05T00:44:04Z
```
(thanks, @zongzhidanielhu!)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
