### PR TITLE
Disable NuGet in hello-dotnet

### DIFF
--- a/bottlerocket/tests/workload/hello-dotnet/Dockerfile
+++ b/bottlerocket/tests/workload/hello-dotnet/Dockerfile
@@ -10,6 +10,11 @@ RUN dnf makecache && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
+# Disable NuGet network access
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+ENV NUGET_XMLDOC_MODE=skip
+
 # Copy the script that will run the application
 COPY --chmod=755 ./run.sh /
 ENTRYPOINT ["./run.sh"]

--- a/bottlerocket/tests/workload/hello-dotnet/run.sh
+++ b/bottlerocket/tests/workload/hello-dotnet/run.sh
@@ -31,7 +31,7 @@ EOF
 dotnet new console -o Hello
 mv "${hello_script}" Hello/Program.cs
 cd Hello
-dotnet run |
+dotnet run --no-restore |
    tee "../${results_dir}/hello.log"
 cd ..
 rm -rf Hello


### PR DESCRIPTION
**Description of changes:**

Avoid extraneous network calls triggered by .NET project restoration.

**Testing done:**

`env`
```shell
NUGET_XMLDOC_MODE=skip
HOSTNAME=XXXXXXXXXXXX
DOTNET_CLI_TELEMETRY_OPTOUT=1
DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
PWD=/
HOME=/root
TERM=xterm
SHLVL=2
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
_=/usr/bin/env
```

`./run.sh`
```shell

The template "Console App" was created successfully.

Processing post-creation actions...
Restoring /Hello/Hello.csproj:
Restore succeeded.


hello, dotnet
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
